### PR TITLE
Verify webhook response HMAC before counting MPA approval

### DIFF
--- a/src/presidio_x402/mpa.py
+++ b/src/presidio_x402/mpa.py
@@ -90,7 +90,17 @@ class MPAApproverConfig:
     webhook_url:
         Approval webhook endpoint (required for ``mode="webhook"``).
     shared_secret:
-        HMAC-SHA256 shared secret in bytes (required for ``mode="crypto"``).
+        HMAC-SHA256 shared secret in bytes.
+
+        - For ``mode="crypto"``: required — used to verify pre-collected
+          countersignatures.
+        - For ``mode="webhook"``: optional but strongly recommended for
+          production deployments. When set, the approver's HTTP response
+          **must** include an ``X-MPA-HMAC`` header containing the
+          HMAC-SHA256 hex digest of the raw response body, keyed with this
+          secret. Responses that omit or fail the header check are treated
+          as denied. Without a secret, responses are accepted on structural
+          validity alone (suitable for internal trusted networks only).
     """
 
     approver_id: str
@@ -373,6 +383,28 @@ class MPAEngine:
                 json=payload,
             )
             resp.raise_for_status()
+
+            # Verify response HMAC if the approver has a shared secret configured.
+            # The approver must include X-MPA-HMAC: <hex(HMAC-SHA256(secret, body))>.
+            if approver.shared_secret is not None:
+                header_hmac = resp.headers.get("X-MPA-HMAC", "")
+                expected_hmac = hmac.new(
+                    approver.shared_secret, resp.content, hashlib.sha256
+                ).hexdigest()
+                if not header_hmac or not hmac.compare_digest(expected_hmac, header_hmac.lower()):
+                    logger.warning(
+                        "MPA webhook response HMAC invalid for approver %s "
+                        "(header %s, expected %s…); treating as denied",
+                        approver.approver_id,
+                        repr(header_hmac[:8] + "…") if header_hmac else "missing",
+                        expected_hmac[:8],
+                    )
+                    return ApprovalResponse(
+                        approver_id=approver.approver_id,
+                        approved=False,
+                        reason="response HMAC verification failed",
+                    )
+
             data: dict[str, Any] = resp.json()
             return ApprovalResponse(
                 approver_id=approver.approver_id,

--- a/tests/test_mpa.py
+++ b/tests/test_mpa.py
@@ -330,6 +330,137 @@ class TestMPAWebhookMode:
 
 
 # ---------------------------------------------------------------------------
+# Webhook mode — HMAC response verification
+# ---------------------------------------------------------------------------
+
+WEBHOOK_SECRET = b"webhook-hmac-secret"
+
+
+def _make_hmac_header(secret: bytes, body: bytes) -> str:
+    """Compute the X-MPA-HMAC header value for a given response body."""
+    return hmac.new(secret, body, hashlib.sha256).hexdigest()
+
+
+class TestMPAWebhookHMAC:
+    """Tests for X-MPA-HMAC response authentication (CWE-295 fix)."""
+
+    def setup_method(self):
+        self.details = _make_details(amount="2.00")
+        self.amount_usd = 2.00
+
+    @pytest.mark.asyncio
+    async def test_valid_hmac_header_counts_as_approval(self):
+        """Webhook approver with shared_secret + correct X-MPA-HMAC → approved."""
+        engine = MPAEngine(
+            MPAConfig(
+                threshold=1,
+                approvers=[
+                    MPAApproverConfig(
+                        "alice",
+                        mode="webhook",
+                        webhook_url="https://approvals.internal/alice",
+                        shared_secret=WEBHOOK_SECRET,
+                    ),
+                ],
+            )
+        )
+        body = json.dumps({"approved": True, "approver_id": "alice"}).encode()
+        header = _make_hmac_header(WEBHOOK_SECRET, body)
+        with respx.mock:
+            respx.post("https://approvals.internal/alice").mock(
+                return_value=httpx.Response(
+                    200,
+                    content=body,
+                    headers={"Content-Type": "application/json", "X-MPA-HMAC": header},
+                )
+            )
+            # Should not raise — one approval meets threshold 1
+            await engine.request_approval(self.details, self.amount_usd)
+
+    @pytest.mark.asyncio
+    async def test_missing_hmac_header_treated_as_denied(self):
+        """Webhook approver with shared_secret but no X-MPA-HMAC header → denied."""
+        engine = MPAEngine(
+            MPAConfig(
+                threshold=1,
+                approvers=[
+                    MPAApproverConfig(
+                        "alice",
+                        mode="webhook",
+                        webhook_url="https://approvals.internal/alice",
+                        shared_secret=WEBHOOK_SECRET,
+                    ),
+                ],
+            )
+        )
+        with respx.mock:
+            respx.post("https://approvals.internal/alice").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"approved": True, "approver_id": "alice"},
+                    # No X-MPA-HMAC header
+                )
+            )
+            with pytest.raises(MPADeniedError, match="0 of 1 required approvals"):
+                await engine.request_approval(self.details, self.amount_usd)
+
+    @pytest.mark.asyncio
+    async def test_wrong_hmac_header_treated_as_denied(self):
+        """Webhook approver with shared_secret + tampered X-MPA-HMAC header → denied."""
+        engine = MPAEngine(
+            MPAConfig(
+                threshold=1,
+                approvers=[
+                    MPAApproverConfig(
+                        "alice",
+                        mode="webhook",
+                        webhook_url="https://approvals.internal/alice",
+                        shared_secret=WEBHOOK_SECRET,
+                    ),
+                ],
+            )
+        )
+        body = json.dumps({"approved": True, "approver_id": "alice"}).encode()
+        wrong_header = "deadbeef" * 8  # 64 hex chars, wrong value
+        with respx.mock:
+            respx.post("https://approvals.internal/alice").mock(
+                return_value=httpx.Response(
+                    200,
+                    content=body,
+                    headers={"Content-Type": "application/json", "X-MPA-HMAC": wrong_header},
+                )
+            )
+            with pytest.raises(MPADeniedError, match="0 of 1 required approvals"):
+                await engine.request_approval(self.details, self.amount_usd)
+
+    @pytest.mark.asyncio
+    async def test_no_shared_secret_skips_hmac_check(self):
+        """Webhook approver without shared_secret accepts response without X-MPA-HMAC."""
+        engine = MPAEngine(
+            MPAConfig(
+                threshold=1,
+                approvers=[
+                    MPAApproverConfig(
+                        "alice",
+                        mode="webhook",
+                        webhook_url="https://approvals.internal/alice",
+                        # No shared_secret — backwards-compatible path
+                    ),
+                ],
+            )
+        )
+        with respx.mock:
+            respx.post("https://approvals.internal/alice").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"approved": True, "approver_id": "alice"},
+                    # No X-MPA-HMAC header — should still pass
+                )
+            )
+            await engine.request_approval(self.details, self.amount_usd)
+
+
+# ---------------------------------------------------------------------------
 # Mixed mode (crypto + webhook)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `X-MPA-HMAC` response header verification in `_request_single_approval`: when `shared_secret` is configured on a webhook approver, the response body HMAC must match before the approval is counted
- Missing or invalid header is treated as denied (fail-safe, not fail-open)
- Approvers without a `shared_secret` retain the existing no-check behaviour (backwards compatible)

## Test plan

- [ ] `test_valid_hmac_header_counts_as_approval` — correct header → approval counted
- [ ] `test_missing_hmac_header_treated_as_denied` — no header with secret set → denied
- [ ] `test_wrong_hmac_header_treated_as_denied` — tampered header → denied
- [ ] `test_no_shared_secret_skips_hmac_check` — no secret → header not required
- [ ] `ruff check src/ tests/` clean
- [ ] All 25 `test_mpa.py` tests pass

Fixes audit finding 2026-04-14 (CWE-295).