### PR TITLE
v0.3.0 — close library adversary chains 02/04/05/06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ htmlcov/
 # Distribution / packaging
 MANIFEST
 .installed.cfg
+uv.lock
 
 # IDEs
 .idea/

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,0 +1,110 @@
+---
+license: mit
+language:
+- en
+tags:
+- pii
+- privacy
+- x402
+- payments
+- synthetic
+- named-entity-recognition
+pretty_name: x402 PII Metadata Corpus
+size_categories:
+- 1K<n<10K
+task_categories:
+- token-classification
+task_ids:
+- named-entity-recognition
+---
+
+# x402 PII Metadata Corpus
+
+Synthetic labelled corpus of 2,000 x402 payment metadata triples for PII filter evaluation.
+Released alongside the paper **"Hardening x402: Privacy-Preserving Agentic Payments via Pre-Execution Metadata Filtering"**.
+
+- **Paper:** [arXiv:2604.11430](https://arxiv.org/abs/2604.11430) [cs.CR]
+- **Canonical archive:** [IEEE DataPort doi:10.21227/kpsz-nq73](https://doi.org/10.21227/kpsz-nq73)
+- **Code:** [presidio-v/presidio-hardened-x402](https://github.com/presidio-v/presidio-hardened-x402)
+
+## Dataset description
+
+Each record represents one x402 payment metadata triple (`resource_url`, `description`, `reason`)
+drawn from seven API categories. 36% of samples contain at least one synthetic PII entity
+injected into one of the three fields, with ground-truth span labels.
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Sample identifier (`syn-NNNNN`) |
+| `category` | string | API category (`media`, `medical`, `financial`, `data_access`, `generic`, `compute`, `ai_inference`) |
+| `resource_url` | string | Synthetic x402 resource URL |
+| `description` | string | Payment description field |
+| `reason` | string | Payment reason field |
+| `pii_positive` | bool | `true` if any PII entity is present |
+| `labels` | list | Ground-truth entity annotations (see below) |
+
+### Label schema
+
+```json
+{
+  "entity_type": "EMAIL_ADDRESS",
+  "field": "description",
+  "start": 24,
+  "end": 45,
+  "value": "<synthetic value>"
+}
+```
+
+Entity types: `PERSON`, `EMAIL_ADDRESS`, `US_SSN`, `IBAN_CODE`, `CREDIT_CARD`, `PHONE_NUMBER`.
+
+### Corpus statistics
+
+| Split | Samples |
+|---|---|
+| train (all) | 2,000 |
+
+| Entity type | Count | Share |
+|---|---|---|
+| PERSON | 321 | 36.7% |
+| EMAIL_ADDRESS | 313 | 35.8% |
+| IBAN_CODE | 96 | 11.0% |
+| US_SSN | 85 | 9.7% |
+| PHONE_NUMBER | 32 | 3.7% |
+| CREDIT_CARD | 28 | 3.2% |
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("vstantch/x402-pii-corpus")
+print(ds["train"][0])
+```
+
+## Citation
+
+```bibtex
+@misc{stantchev2026hardeningx402,
+  title   = {Hardening x402: Privacy-Preserving Agentic Payments via Pre-Execution Metadata Filtering},
+  author  = {Stantchev, Vladimir},
+  year    = {2026},
+  eprint  = {2604.11430},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.CR},
+}
+```
+
+Corpus data also archived at IEEE DataPort:
+
+```bibtex
+@misc{stantchev2026dataset,
+  author       = {Stantchev, Vladimir},
+  title        = {Hardening x402: PII Filter Corpus, Sweep Results, and Live Ecosystem Data},
+  year         = {2026},
+  publisher    = {IEEE DataPort},
+  doi          = {10.21227/kpsz-nq73},
+  howpublished = {IEEE DataPort, \url{https://doi.org/10.21227/kpsz-nq73}},
+}
+```

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -69,6 +69,23 @@ _HEADER_PAYMENT_RECEIPT = "X-PAYMENT-RECEIPT"
 # Supported x402 scheme for v0.1.0
 _SUPPORTED_SCHEME = "exact"
 
+# Max characters of an exception message retained in audit records. Exception
+# text frequently carries fragments of the offending input (JSON snippets,
+# signing-key material, wallet addresses) — truncation caps blast radius.
+_SAFE_EXC_MESSAGE_MAX = 80
+
+
+def _safe_exc_message(exc: BaseException, max_len: int = _SAFE_EXC_MESSAGE_MAX) -> str:
+    msg = str(exc)
+    if len(msg) > max_len:
+        msg = msg[:max_len] + "...[truncated]"
+    return msg
+
+
+def _resource_origin(url: str) -> str:
+    parsed = httpx.URL(url)
+    return str(parsed.copy_with(path="", query=None, fragment=None)).rstrip("/")
+
 
 def _parse_402_header(header_value: str) -> PaymentDetails:
     """Parse the ``X-PAYMENT`` header from a 402 response.
@@ -92,7 +109,9 @@ def _parse_402_header(header_value: str) -> PaymentDetails:
     try:
         data = json.loads(header_value)
     except json.JSONDecodeError as exc:
-        raise X402PaymentError(f"Invalid X-PAYMENT header JSON: {exc}") from exc
+        # Never embed the raw JSON (which may carry wallet/PII fragments) in
+        # the message. Original cause remains on __cause__ for debugging.
+        raise X402PaymentError("Invalid X-PAYMENT header JSON") from exc
 
     accepts = data.get("accepts", [])
     if not accepts:
@@ -123,8 +142,8 @@ def _parse_402_header(header_value: str) -> PaymentDetails:
             reason=chosen.get("reason", ""),
             extra=chosen.get("extra", {}),
         )
-    except KeyError as exc:
-        raise X402PaymentError(f"Missing required field in X-PAYMENT entry: {exc}") from exc
+    except KeyError:
+        raise X402PaymentError("Missing required field in X-PAYMENT entry") from None
 
 
 _USD_PEGGED = frozenset({"USDC", "USDT", "DAI", "USDCE", "USDBC"})
@@ -198,6 +217,17 @@ class HardenedX402Client:
     metrics_collector:
         Optional :class:`~presidio_x402.metrics.MetricsCollector` for Prometheus
         metrics export. Requires ``pip install presidio-hardened-x402[prometheus]``.
+    trusted_wallets:
+        Optional per-origin ``pay_to`` allowlist. Maps a resource origin
+        (scheme + host[:port]) to the set of wallet addresses the client is
+        willing to pay for resources under that origin. When a 402 response
+        names a ``pay_to`` not in the allowlist for its origin, the payment is
+        blocked before signing. ``None`` (default) disables the check; an
+        origin absent from the map is unrestricted. Example::
+
+            trusted_wallets={
+                "https://api.example.com": {"0xAbC...123"},
+            }
     """
 
     def __init__(
@@ -215,6 +245,7 @@ class HardenedX402Client:
         httpx_client: httpx.AsyncClient | None = None,
         mpa_engine: MPAEngine | None = None,
         metrics_collector: MetricsCollector | None = None,
+        trusted_wallets: dict[str, set[str]] | None = None,
     ) -> None:
         self._signer = payment_signer
         self._pii_filter = PIIFilter(mode=pii_mode, entities=pii_entities)
@@ -226,6 +257,11 @@ class HardenedX402Client:
         self._httpx = httpx_client or httpx.AsyncClient(timeout=30.0)
         self._mpa = mpa_engine
         self._metrics = metrics_collector
+        self._trusted_wallets: dict[str, frozenset[str]] | None = (
+            {origin.rstrip("/"): frozenset(wallets) for origin, wallets in trusted_wallets.items()}
+            if trusted_wallets is not None
+            else None
+        )
         logger.info("Presidio hardening applied — HardenedX402Client initialized")
 
     # ------------------------------------------------------------------
@@ -273,11 +309,12 @@ class HardenedX402Client:
             details = _parse_402_header(payment_header)
         except X402PaymentError as exc:
             safe_url, _ = self._pii_filter.scan_and_redact(url)
+            safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
             self._audit.emit(
                 "PAYMENT_ERROR",
                 resource_url=safe_url,
                 outcome="blocked",
-                error_message=str(exc),
+                error_message=safe_msg,
             )
             raise
 
@@ -290,15 +327,16 @@ class HardenedX402Client:
         try:
             payment_response = await self._invoke_signer(secure_details)
         except Exception as exc:
+            safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
             self._audit.emit(
                 "PAYMENT_ERROR",
                 resource_url=secure_details.resource_url,
                 amount_usd=_amount_to_usd(secure_details.amount, secure_details.currency),
                 network=secure_details.network,
                 outcome="blocked",
-                error_message=str(exc),
+                error_message=safe_msg,
             )
-            raise X402PaymentError(f"Payment signing failed: {exc}") from exc
+            raise X402PaymentError("Payment signing failed") from exc
 
         # Retry request with payment token
         headers = dict(kwargs.pop("headers", {}) or {})
@@ -382,7 +420,29 @@ class HardenedX402Client:
                 self._metrics.record_pii_detection(entity_types, "warn")
 
         # ------------------------------------------------------------------
-        # 2. Policy Engine
+        # 2. Trusted-wallet allowlist (pay_to substitution defence)
+        # ------------------------------------------------------------------
+        if self._trusted_wallets is not None:
+            origin = _resource_origin(details.resource_url)
+            allowed = self._trusted_wallets.get(origin)
+            if allowed is not None and details.pay_to not in allowed:
+                self._audit.emit(
+                    "WALLET_BLOCKED",
+                    resource_url=clean_url,
+                    amount_usd=amount_usd,
+                    network=details.network,
+                    outcome="blocked",
+                    error_message=f"pay_to {details.pay_to!r} not in allowlist for {origin!r}",
+                )
+                if self._metrics:
+                    self._metrics.record_payment_blocked("wallet", amount_usd)
+                raise X402PaymentError(
+                    f"pay_to wallet {details.pay_to!r} not in trusted allowlist "
+                    f"for origin {origin!r}"
+                )
+
+        # ------------------------------------------------------------------
+        # 3. Policy Engine
         # ------------------------------------------------------------------
         try:
             self._policy.check_and_record(resource_url=details.resource_url, amount_usd=amount_usd)
@@ -401,7 +461,7 @@ class HardenedX402Client:
             raise
 
         # ------------------------------------------------------------------
-        # 3. Replay Guard
+        # 4. Replay Guard
         # ------------------------------------------------------------------
         fingerprint = compute_fingerprint(
             resource_url=details.resource_url,  # use ORIGINAL URL for fingerprinting
@@ -427,7 +487,7 @@ class HardenedX402Client:
             raise
 
         # ------------------------------------------------------------------
-        # 4. Multi-Party Authorization (if configured)
+        # 5. Multi-Party Authorization (if configured)
         # ------------------------------------------------------------------
         if self._mpa is not None:
             try:
@@ -438,13 +498,14 @@ class HardenedX402Client:
                     self._metrics.record_mpa_event("approved")
             except (MPADeniedError, MPATimeoutError) as exc:
                 outcome = "timeout" if isinstance(exc, MPATimeoutError) else "denied"
+                safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
                 self._audit.emit(
                     "MPA_BLOCKED",
                     resource_url=clean_url,
                     amount_usd=amount_usd,
                     network=details.network,
                     outcome="blocked",
-                    error_message=str(exc),
+                    error_message=safe_msg,
                 )
                 if self._metrics:
                     self._metrics.record_mpa_event(outcome)

--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import re
+import unicodedata
 from dataclasses import dataclass
 from typing import Literal
 
@@ -27,9 +28,77 @@ logger = logging.getLogger("presidio_x402.pii_filter")
 
 REDACTED_TEMPLATE = "<REDACTED>"
 
+# Invisible codepoints stripped before matching: zero-width space/non-joiner/joiner,
+# byte-order mark, soft hyphen. Present them in metadata purely to evade regex.
+_INVISIBLE_CODEPOINTS = frozenset({0x200B, 0x200C, 0x200D, 0xFEFF, 0x00AD, 0x2060})
+
+# Cyrillic → ASCII homoglyph map. Manual (no external dep) coverage of the
+# Latin-lookalike Cyrillic letters commonly used in evasion.
+_HOMOGLYPH_FOLD = str.maketrans(
+    {
+        "а": "a",
+        "А": "A",
+        "е": "e",
+        "Е": "E",
+        "о": "o",
+        "О": "O",
+        "р": "p",
+        "Р": "P",
+        "с": "c",
+        "С": "C",
+        "х": "x",
+        "Х": "X",
+        "у": "y",
+        "У": "Y",
+        "і": "i",
+        "І": "I",
+        "ј": "j",
+        "Ј": "J",
+        "ѕ": "s",
+        "Ѕ": "S",
+        "к": "k",
+        "К": "K",
+        "н": "H",
+        "М": "M",
+        "Т": "T",
+        "В": "B",
+    }
+)
+
+# Hyphen-like characters folded to ASCII hyphen-minus.
+_HYPHEN_FOLD = str.maketrans(
+    {
+        "\u2010": "-",
+        "\u2011": "-",
+        "\u2012": "-",
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2212": "-",
+        "\ufe58": "-",
+        "\ufe63": "-",
+        "\uff0d": "-",
+    }
+)
+
+
+def _normalise(text: str) -> str:
+    """Canonicalise *text* to foil regex-evasion via Unicode encoding tricks.
+
+    Steps: NFKC → strip invisible codepoints → fold Cyrillic homoglyphs and
+    hyphen-like characters to ASCII equivalents.
+    """
+    text = unicodedata.normalize("NFKC", text)
+    text = "".join(c for c in text if ord(c) not in _INVISIBLE_CODEPOINTS)
+    text = text.translate(_HOMOGLYPH_FOLD)
+    text = text.translate(_HYPHEN_FOLD)
+    return text
+
+
 # ---------------------------------------------------------------------------
 # Regex-mode PII patterns
-# Ordered: most specific first to avoid overlapping matches
+# Ordered: most specific first to avoid overlapping matches.
+# All digit classes are ASCII-only ([0-9]) to avoid false positives on
+# Unicode decimal-digit codepoints (Arabic-Indic, Devanagari, etc.).
 # ---------------------------------------------------------------------------
 _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     # Structural: emails
@@ -40,7 +109,7 @@ _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     # Structural: US SSNs (with or without dashes)
     (
         "US_SSN",
-        re.compile(r"\b(?!000|666|9\d{2})\d{3}[-\s]?(?!00)\d{2}[-\s]?(?!0000)\d{4}\b"),
+        re.compile(r"\b(?!000|666|9[0-9]{2})[0-9]{3}[-\s]?(?!00)[0-9]{2}[-\s]?(?!0000)[0-9]{4}\b"),
     ),
     # Structural: credit/debit card numbers (13–19 digit, major networks)
     (
@@ -48,23 +117,26 @@ _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
         re.compile(
             r"\b(?:4[0-9]{12}(?:[0-9]{3,6})?|5[1-5][0-9]{14}|3[47][0-9]{13}"
             r"|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}"
-            r"|(?:2131|1800|35\d{3})\d{11})\b"
+            r"|(?:2131|1800|35[0-9]{3})[0-9]{11})\b"
         ),
     ),
     # Structural: US phone numbers
     (
         "PHONE_NUMBER",
-        re.compile(r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b"),
+        re.compile(r"\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s][0-9]{3}[-.\s][0-9]{4}\b"),
     ),
     # Structural: IBAN (EU bank accounts)
     (
         "IBAN_CODE",
-        re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:[A-Z0-9]{0,16})\b"),
+        re.compile(r"\b[A-Z]{2}[0-9]{2}[A-Z0-9]{4}[0-9]{7}(?:[A-Z0-9]{0,16})\b"),
     ),
     # Structural: IPv4 addresses (common in resource URLs, may be PII in some contexts)
     (
         "IP_ADDRESS",
-        re.compile(r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b"),
+        re.compile(
+            r"\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}"
+            r"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
+        ),
     ),
 ]
 
@@ -151,6 +223,11 @@ class PIIFilter:
         """
         if not text:
             return text, []
+
+        # Canonicalise before matching — closes Unicode regex-evasion paths
+        # (homoglyphs, zero-width chars, non-ASCII hyphens). Output is the
+        # normalised form so downstream callers see a clean, canonical string.
+        text = _normalise(text)
 
         if self.mode == "nlp" and self._analyzer is not None:
             return self._scan_nlp(text)

--- a/src/presidio_x402/replay_guard.py
+++ b/src/presidio_x402/replay_guard.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+import os
 import secrets
 import threading
 import time
@@ -29,9 +30,38 @@ from .exceptions import ReplayDetectedError
 
 logger = logging.getLogger("presidio_x402.replay_guard")
 
-# A random per-process key for the HMAC — prevents cross-process fingerprint
-# collision attacks while still allowing in-memory deduplication.
-_PROCESS_KEY = secrets.token_bytes(32)
+_FINGERPRINT_KEY_ENV = "PRESIDIO_X402_FINGERPRINT_KEY"
+
+
+def _load_fingerprint_key() -> bytes:
+    hex_key = os.environ.get(_FINGERPRINT_KEY_ENV)
+    if hex_key:
+        try:
+            key = bytes.fromhex(hex_key)
+        except ValueError:
+            logger.error(
+                "%s is set but not valid hex — falling back to per-process key. "
+                "Cross-process replay detection is disabled.",
+                _FINGERPRINT_KEY_ENV,
+            )
+            return secrets.token_bytes(32)
+        if len(key) < 16:
+            logger.error(
+                "%s is shorter than 16 bytes — falling back to per-process key.",
+                _FINGERPRINT_KEY_ENV,
+            )
+            return secrets.token_bytes(32)
+        return key
+    logger.warning(
+        "%s not set — replay guard uses a per-process key and will NOT detect "
+        "replays across load-balanced replicas. Set this env var (32-byte hex) "
+        "in all replicas to enable cross-process deduplication.",
+        _FINGERPRINT_KEY_ENV,
+    )
+    return secrets.token_bytes(32)
+
+
+_FINGERPRINT_KEY = _load_fingerprint_key()
 
 
 def compute_fingerprint(
@@ -62,7 +92,7 @@ def compute_fingerprint(
         considered distinct to avoid false positives on retried expired payments.
     """
     canonical = "|".join([resource_url, pay_to, amount, currency, str(deadline_seconds)])
-    return hmac.new(_PROCESS_KEY, canonical.encode(), hashlib.sha256).hexdigest()
+    return hmac.new(_FINGERPRINT_KEY, canonical.encode(), hashlib.sha256).hexdigest()
 
 
 class _MemoryStore:
@@ -72,17 +102,15 @@ class _MemoryStore:
         self._lock = threading.Lock()
         self._store: dict[str, float] = {}  # fingerprint → expiry timestamp
 
-    def exists(self, key: str) -> bool:
+    def check_and_set(self, key: str, ttl: int) -> bool:
+        """Atomically record *key* if absent. Returns True if newly added."""
         now = time.monotonic()
         with self._lock:
             self._evict(now)
-            return key in self._store
-
-    def set(self, key: str, ttl: int) -> None:
-        now = time.monotonic()
-        with self._lock:
-            self._evict(now)
+            if key in self._store:
+                return False
             self._store[key] = now + ttl
+            return True
 
     def _evict(self, now: float) -> None:
         expired = [k for k, exp in self._store.items() if exp <= now]
@@ -108,11 +136,10 @@ class _RedisStore:
             ) from exc
         self._prefix = "presidio_x402:replay:"
 
-    def exists(self, key: str) -> bool:
-        return bool(self._client.exists(self._prefix + key))
-
-    def set(self, key: str, ttl: int) -> None:
-        self._client.set(self._prefix + key, "1", ex=ttl)
+    def check_and_set(self, key: str, ttl: int) -> bool:
+        # SET NX EX is atomic on the Redis server — no TOCTOU window.
+        result = self._client.set(self._prefix + key, "1", ex=ttl, nx=True)
+        return result is not None
 
     def clear(self) -> None:
         keys = self._client.keys(self._prefix + "*")
@@ -149,13 +176,12 @@ class ReplayGuard:
         fingerprint was seen within the TTL window. Otherwise, records the
         fingerprint and returns normally.
         """
-        if self._store.exists(fingerprint):
+        if not self._store.check_and_set(fingerprint, self.ttl):
             logger.warning("Replay detected: fingerprint %s...", fingerprint[:16])
             raise ReplayDetectedError(
                 f"Duplicate payment detected (fingerprint: {fingerprint[:16]}…)",
                 fingerprint=fingerprint,
             )
-        self._store.set(fingerprint, self.ttl)
         logger.debug("Replay guard: new fingerprint recorded %s...", fingerprint[:16])
 
     def reset(self) -> None:

--- a/tests/test_adversary_chains.py
+++ b/tests/test_adversary_chains.py
@@ -1,0 +1,560 @@
+"""Proof-of-concept tests for adversary attack chains 02, 04, 05, 06.
+
+Each test encodes an attack described in ``adversary-attack/chain-0N-*.md``:
+
+  - Assert the attack is now blocked (positive control).
+  - Where feasible, construct the exact hostile input the chain specifies
+    (crafted 402 payload, Unicode-evasive metadata, malicious signer, etc.).
+
+Any regression that re-opens a chain should cause at least one of these tests
+to fail.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from dataclasses import replace
+
+import httpx
+import pytest
+import respx
+
+from presidio_x402 import HardenedX402Client
+from presidio_x402._types import AuditEvent, PaymentDetails, PaymentResponse
+from presidio_x402.exceptions import X402PaymentError
+from presidio_x402.pii_filter import PIIFilter
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAuditWriter:
+    """Captures AuditEvent objects for later assertion."""
+
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    def write(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+async def _mock_signer(details: PaymentDetails) -> PaymentResponse:
+    return PaymentResponse(token="mock-signed-token", details=details)  # noqa: S106
+
+
+_BENIGN_HEADER = json.dumps(
+    {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base-sepolia",
+                "maxAmountRequired": "0.01",
+                "resource": "https://api.example.com/v1/data",
+                "description": "API data access",
+                "payTo": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "requiredDeadlineSeconds": 300,
+            }
+        ]
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Chain 02 — Cross-process replay bypass via per-process fingerprint key
+# ---------------------------------------------------------------------------
+#
+# Before the fix, each replica seeded ``_FINGERPRINT_KEY`` from
+# ``secrets.token_bytes(32)`` at import time, so the same logical payment
+# fingerprinted differently on each replica — a duplicate submission landed on
+# a second replica was never recognised as a replay.
+#
+# After the fix, ``PRESIDIO_X402_FINGERPRINT_KEY`` is loaded from the
+# environment; all replicas configured with the same hex string produce
+# identical fingerprints and cross-replica replays are caught.
+
+
+class TestChain02CrossProcessReplay:
+    _KEY_HEX = "aa" * 32
+
+    def _reimport_with_env(self, monkeypatch, value: str | None):
+        if value is None:
+            monkeypatch.delenv("PRESIDIO_X402_FINGERPRINT_KEY", raising=False)
+        else:
+            monkeypatch.setenv("PRESIDIO_X402_FINGERPRINT_KEY", value)
+        import presidio_x402.replay_guard as module
+
+        return importlib.reload(module)
+
+    def test_poc_before_fix_replicas_would_diverge(self, monkeypatch):
+        """Two independent per-process keys produce different fingerprints.
+
+        This is the pre-fix failure condition we want to exclude in production.
+        """
+        mod_a = self._reimport_with_env(monkeypatch, None)
+        key_a = mod_a._FINGERPRINT_KEY
+        mod_b = self._reimport_with_env(monkeypatch, None)
+        key_b = mod_b._FINGERPRINT_KEY
+        assert key_a != key_b, (
+            "Sanity check: two random per-process keys must differ, "
+            "otherwise this POC can't demonstrate the attack."
+        )
+
+    def test_fix_shared_env_key_gives_identical_fingerprints(self, monkeypatch):
+        """Two replicas booted with the same env key fingerprint identically."""
+        mod_a = self._reimport_with_env(monkeypatch, self._KEY_HEX)
+        fp_a = mod_a.compute_fingerprint(
+            "https://api.example.com/v1/data",
+            "0xabc",
+            "0.01",
+            "USDC",
+            300,
+        )
+        mod_b = self._reimport_with_env(monkeypatch, self._KEY_HEX)
+        fp_b = mod_b.compute_fingerprint(
+            "https://api.example.com/v1/data",
+            "0xabc",
+            "0.01",
+            "USDC",
+            300,
+        )
+        assert fp_a == fp_b
+
+    def test_fix_invalid_hex_falls_back_with_error_log(self, monkeypatch, caplog):
+        """Malformed env var doesn't silently enable cross-process dedup."""
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="presidio_x402.replay_guard"):
+            self._reimport_with_env(monkeypatch, "not-hex-data")
+        assert any("not valid hex" in rec.getMessage() for rec in caplog.records)
+
+    def test_fix_short_key_rejected(self, monkeypatch, caplog):
+        """A key shorter than 16 bytes is refused (falls back, logs error)."""
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="presidio_x402.replay_guard"):
+            self._reimport_with_env(monkeypatch, "aabb")  # 2 bytes
+        assert any("shorter than 16 bytes" in rec.getMessage() for rec in caplog.records)
+
+    def test_fix_missing_env_warns(self, monkeypatch, caplog):
+        """Omitting the env var surfaces the operator warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="presidio_x402.replay_guard"):
+            self._reimport_with_env(monkeypatch, None)
+        assert any("per-process key" in rec.getMessage() for rec in caplog.records)
+
+    @classmethod
+    def teardown_class(cls):
+        """Restore the replay_guard module to whatever the session was using."""
+        import presidio_x402.replay_guard as module
+
+        importlib.reload(module)
+
+
+# ---------------------------------------------------------------------------
+# Chain 04 — Unicode PII evasion (homoglyphs, zero-width, hyphen folds,
+#                                 Unicode-digit false positives)
+# ---------------------------------------------------------------------------
+#
+# Before the fix, the regex engine ran against the raw metadata string. An
+# attacker could slip PII past the filter with Cyrillic lookalikes, zero-width
+# joiners inside an email, or an en-dash between SSN groups; conversely,
+# non-ASCII digits in ``\d`` caused spurious SSN/credit-card matches on
+# legitimate non-English content.
+
+
+class TestChain04UnicodeEvasion:
+    def setup_method(self):
+        self.filt = PIIFilter(mode="regex")
+
+    def test_cyrillic_homoglyph_email_is_detected(self):
+        """Email using Cyrillic 'а' (U+0430), 'е' (U+0435), 'р' (U+0440) normalizes to ASCII."""
+        # "аlicе@exam\u0440le.com" — all three substitutions are in the fold map.
+        hostile = "contact \u0430lic\u0435@exam\u0440le.com please"
+        redacted, entities = self.filt.scan_and_redact(hostile)
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities), (
+            f"Homoglyph email must be detected after NFKC + fold; got {entities!r}"
+        )
+        assert "<REDACTED>" in redacted
+
+    def test_zero_width_joiner_inside_email_is_detected(self):
+        """ZWSP/ZWJ/ZWNJ interspersed in an email are stripped before matching."""
+        hostile = "send to alice\u200b@example\u200c.com"
+        _, entities = self.filt.scan_and_redact(hostile)
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    def test_soft_hyphen_inside_email_is_detected(self):
+        """Soft hyphens (U+00AD) are invisible in most renderers."""
+        hostile = "send to alice\u00ad@example.com"
+        _, entities = self.filt.scan_and_redact(hostile)
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    def test_en_dash_ssn_separator_is_detected(self):
+        """SSN with U+2013 (en-dash) instead of ASCII '-' still matches."""
+        hostile = "SSN: 123\u20130-0\u20130 bad example"  # non-matching content
+        # Use a realistic SSN with en-dash separators
+        hostile = "ssn 123\u201345\u20136789 on file"
+        _, entities = self.filt.scan_and_redact(hostile)
+        assert any(e.entity_type == "US_SSN" for e in entities)
+
+    def test_arabic_indic_digits_do_not_trigger_ssn_false_positive(self):
+        """Pre-fix ``\\d`` matched U+0660-0669; restricted to ASCII ``[0-9]`` now."""
+        # Arabic-Indic 1 2 3 4 5 6 7 8 9 (shape of a benign foreign-language ID)
+        hostile = "id \u0661\u0662\u0663-\u0664\u0665-\u0666\u0667\u0668\u0669 benign"
+        _, entities = self.filt.scan_and_redact(hostile)
+        assert not any(e.entity_type == "US_SSN" for e in entities), (
+            "Unicode decimal digits must not be treated as ASCII digits "
+            "for structural PII matching."
+        )
+
+    def test_devanagari_digits_do_not_trigger_credit_card_false_positive(self):
+        """Devanagari digits packed into 16 positions must not match CREDIT_CARD."""
+        hostile = "token \u0966\u0967\u0968\u0969\u096a\u096b\u096c\u096d\u096e" * 2
+        _, entities = self.filt.scan_and_redact(hostile)
+        assert not any(e.entity_type == "CREDIT_CARD" for e in entities)
+
+
+# ---------------------------------------------------------------------------
+# Chain 05 — Payment data exfiltration via exception message leakage
+# ---------------------------------------------------------------------------
+#
+# Before the fix, f-string exception messages embedded raw JSON fragments
+# (including wallet/pay_to and resource URL), and ``error_message=str(exc)``
+# propagated that unredacted text into the audit log.
+#
+# After the fix:
+#   * Exception messages are constants ("Invalid X-PAYMENT header JSON", etc.)
+#   * ``error_message`` is truncated via ``_safe_exc_message`` and passed
+#     through the PIIFilter before audit emission.
+#   * The original cause is preserved on ``__cause__`` for local debugging.
+
+
+class TestChain05ExceptionExfiltration:
+    # Sentinel strings chosen so any leak is trivially greppable.
+    _SECRET_WALLET = "0xDEADBEEFCAFED00DDEADBEEFCAFED00DDEADBEEF"  # noqa: S105 — test sentinel
+    _SECRET_KEY_FRAGMENT = "PRIVATE-KEY-FRAGMENT-abcdef1234"  # noqa: S105 — test sentinel
+    # Structural-PII sentinel: the PII filter MUST scrub this from audit text.
+    _SECRET_EMAIL = "leaked-signer-email@attacker.test"  # noqa: S105 — test sentinel
+
+    @pytest.mark.asyncio
+    async def test_site_a_malformed_json_does_not_leak_wallet_or_url(self):
+        """Malformed JSON with an embedded wallet must not leak into the raised error."""
+        audit = _RecordingAuditWriter()
+        # Invalid JSON whose *surface text* contains wallet and URL hints.
+        hostile_header = (
+            f'{{"accepts": ["resource": "https://api.example.com/v1/data/{self._SECRET_WALLET}", '
+            f'"payTo": "{self._SECRET_WALLET}"]'
+        )
+        with respx.mock:
+            respx.get("https://api.example.com/v1/data").mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": hostile_header})
+            )
+            client = HardenedX402Client(payment_signer=_mock_signer, audit_writer=audit)
+            try:
+                with pytest.raises(X402PaymentError) as exc_info:
+                    await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+
+        # Raised message is a constant.
+        assert str(exc_info.value) == "Invalid X-PAYMENT header JSON"
+        assert self._SECRET_WALLET not in str(exc_info.value)
+
+        # __cause__ still points to the JSON decoder exception for debugging.
+        assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+        # Audit record contains no wallet fragment.
+        assert audit.events, "Chain 05: expected an audit event for the blocked attempt"
+        leaked = [
+            e for e in audit.events if e.error_message and self._SECRET_WALLET in e.error_message
+        ]
+        assert not leaked, f"Wallet leaked into audit: {[e.error_message for e in leaked]!r}"
+
+    @pytest.mark.asyncio
+    async def test_site_b_missing_field_does_not_leak_other_fields(self):
+        """KeyError on missing payTo must not leak the other provided fields."""
+        # payTo omitted on purpose; url/amount carry wallet-like sentinel
+        hostile_header = json.dumps(
+            {
+                "accepts": [
+                    {
+                        "scheme": "exact",
+                        "network": "base-sepolia",
+                        "maxAmountRequired": "0.01",
+                        "resource": f"https://api.example.com/{self._SECRET_WALLET}",
+                        "requiredDeadlineSeconds": 300,
+                    }
+                ]
+            }
+        )
+        audit = _RecordingAuditWriter()
+        with respx.mock:
+            respx.get(f"https://api.example.com/{self._SECRET_WALLET}").mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": hostile_header})
+            )
+            client = HardenedX402Client(payment_signer=_mock_signer, audit_writer=audit)
+            try:
+                with pytest.raises(X402PaymentError) as exc_info:
+                    await client.get(f"https://api.example.com/{self._SECRET_WALLET}")
+            finally:
+                await client.aclose()
+
+        assert str(exc_info.value) == "Missing required field in X-PAYMENT entry"
+        # __cause__ was suppressed for Site B (`from None`), so we should NOT
+        # see a KeyError tail — but if it's there it mustn't carry payload.
+        cause_text = str(exc_info.value.__cause__ or "")
+        assert self._SECRET_WALLET not in cause_text
+
+    @pytest.mark.asyncio
+    async def test_site_c_signer_exception_not_reraised_in_message(self):
+        """Signer exception text does not leak into the raised X402PaymentError.
+
+        The fix contract is: ``X402PaymentError`` message is a constant; the
+        original cause is preserved on ``__cause__`` for local debug only.
+        Callers (and anything consuming ``str(exc)``) see no payload.
+        """
+
+        async def _leaky_signer(details: PaymentDetails) -> PaymentResponse:
+            raise RuntimeError(
+                f"Cannot sign with key {self._SECRET_KEY_FRAGMENT} "
+                f"for wallet {self._SECRET_WALLET}"
+            )
+
+        with respx.mock:
+            respx.get("https://api.example.com/v1/data").mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": _BENIGN_HEADER})
+            )
+            client = HardenedX402Client(payment_signer=_leaky_signer)
+            try:
+                with pytest.raises(X402PaymentError) as exc_info:
+                    await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+
+        msg = str(exc_info.value)
+        assert msg == "Payment signing failed"
+        assert self._SECRET_KEY_FRAGMENT not in msg
+        assert self._SECRET_WALLET not in msg
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_site_c_signer_structural_pii_scrubbed_from_audit(self):
+        """Structural PII (email) in a signer exception is redacted in audit emit."""
+
+        async def _leaky_signer(details: PaymentDetails) -> PaymentResponse:
+            raise RuntimeError(f"signer rejected contact {self._SECRET_EMAIL}")
+
+        audit = _RecordingAuditWriter()
+        with respx.mock:
+            respx.get("https://api.example.com/v1/data").mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": _BENIGN_HEADER})
+            )
+            client = HardenedX402Client(payment_signer=_leaky_signer, audit_writer=audit)
+            try:
+                with pytest.raises(X402PaymentError):
+                    await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+
+        error_events = [e for e in audit.events if e.error_message]
+        assert error_events
+        for e in error_events:
+            assert self._SECRET_EMAIL not in e.error_message, (
+                f"PII filter must scrub email from audit error_message: {e.error_message!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_audit_error_message_is_length_capped(self):
+        """Huge signer exception strings are truncated before audit emission."""
+
+        giant = "A" * 10_000
+
+        async def _huge_signer(details: PaymentDetails) -> PaymentResponse:
+            raise RuntimeError(giant)
+
+        audit = _RecordingAuditWriter()
+        with respx.mock:
+            respx.get("https://api.example.com/v1/data").mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": _BENIGN_HEADER})
+            )
+            client = HardenedX402Client(payment_signer=_huge_signer, audit_writer=audit)
+            try:
+                with pytest.raises(X402PaymentError):
+                    await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+
+        error_events = [e for e in audit.events if e.error_message]
+        assert error_events, "Chain 05: signer error must produce an audit event"
+        for e in error_events:
+            assert len(e.error_message) < 200, (
+                f"Audit error_message must be truncated, got len={len(e.error_message)}"
+            )
+            assert "[truncated]" in e.error_message
+
+
+# ---------------------------------------------------------------------------
+# Chain 06 — DNS / wallet-substitution hijack (pay_to swap)
+# ---------------------------------------------------------------------------
+#
+# Before the fix, the client signed whatever ``payTo`` the 402 response
+# declared. An attacker with control of DNS, a compromised resource origin,
+# or an MITM position could swap the legitimate pay_to with their own wallet;
+# the payment would complete and the funds would land in the attacker's
+# wallet.
+#
+# After the fix, ``trusted_wallets`` lets the operator pin a per-origin
+# pay_to allowlist. Any unknown pay_to for an origin in the map is rejected
+# before signing.
+
+
+def _header_for(pay_to: str, resource: str = "https://api.example.com/v1/data") -> str:
+    return json.dumps(
+        {
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "base-sepolia",
+                    "maxAmountRequired": "0.01",
+                    "resource": resource,
+                    "description": "API data access",
+                    "payTo": pay_to,
+                    "requiredDeadlineSeconds": 300,
+                }
+            ]
+        }
+    )
+
+
+class TestChain06WalletSubstitution:
+    _LEGIT = "0x1111111111111111111111111111111111111111"
+    _ATTACKER = "0x9999999999999999999999999999999999999999"
+
+    @pytest.mark.asyncio
+    async def test_attack_succeeds_without_allowlist(self):
+        """Baseline: with no allowlist, the attacker's pay_to is honored.
+
+        This is the pre-mitigation behaviour. We include it so the POC chain
+        fails loudly if someone removes the allowlist enforcement but expects
+        the client to still reject unknown wallets.
+        """
+        signed_details: list[PaymentDetails] = []
+
+        async def _capture_signer(details: PaymentDetails) -> PaymentResponse:
+            signed_details.append(details)
+            return PaymentResponse(token="mock-signed-token", details=details)  # noqa: S106
+
+        with respx.mock:
+            route = respx.get("https://api.example.com/v1/data")
+            route.side_effect = [
+                httpx.Response(402, headers={"X-PAYMENT": _header_for(self._ATTACKER)}),
+                httpx.Response(200, text="ok"),
+            ]
+            client = HardenedX402Client(payment_signer=_capture_signer)
+            try:
+                resp = await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+
+        assert resp.status_code == 200
+        assert signed_details[0].pay_to == self._ATTACKER
+
+    @pytest.mark.asyncio
+    async def test_attacker_wallet_blocked_by_allowlist(self):
+        """Swapped pay_to is rejected before signing when origin is pinned."""
+        signed_details: list[PaymentDetails] = []
+
+        async def _capture_signer(details: PaymentDetails) -> PaymentResponse:
+            signed_details.append(details)
+            return PaymentResponse(token="mock-signed-token", details=details)  # noqa: S106
+
+        audit = _RecordingAuditWriter()
+        attacker_header = _header_for(self._ATTACKER)
+        with respx.mock:
+            respx.get("https://api.example.com/v1/data").mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": attacker_header})
+            )
+            client = HardenedX402Client(
+                payment_signer=_capture_signer,
+                audit_writer=audit,
+                trusted_wallets={"https://api.example.com": {self._LEGIT}},
+            )
+            try:
+                with pytest.raises(X402PaymentError, match="not in trusted allowlist"):
+                    await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+
+        assert not signed_details, "Signer must not be invoked when allowlist rejects pay_to"
+        wallet_events = [e for e in audit.events if e.event_type == "WALLET_BLOCKED"]
+        assert wallet_events, "Chain 06: blocked event must land in the audit trail"
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_wallet_passes(self):
+        """Legit pay_to still signs and completes normally."""
+        with respx.mock:
+            route = respx.get("https://api.example.com/v1/data")
+            route.side_effect = [
+                httpx.Response(402, headers={"X-PAYMENT": _header_for(self._LEGIT)}),
+                httpx.Response(200, text="ok"),
+            ]
+            client = HardenedX402Client(
+                payment_signer=_mock_signer,
+                trusted_wallets={"https://api.example.com": {self._LEGIT}},
+            )
+            try:
+                resp = await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_origin_absent_from_allowlist_is_unrestricted(self):
+        """Origins not in the map are not gated — operators opt in per-origin."""
+        with respx.mock:
+            route = respx.get("https://other.example.com/v1/data")
+            route.side_effect = [
+                httpx.Response(
+                    402,
+                    headers={
+                        "X-PAYMENT": _header_for(
+                            self._ATTACKER, resource="https://other.example.com/v1/data"
+                        )
+                    },
+                ),
+                httpx.Response(200, text="ok"),
+            ]
+            client = HardenedX402Client(
+                payment_signer=_mock_signer,
+                trusted_wallets={"https://api.example.com": {self._LEGIT}},
+            )
+            try:
+                resp = await client.get("https://other.example.com/v1/data")
+            finally:
+                await client.aclose()
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_allowlist_origin_matches_ignoring_trailing_slash(self):
+        """``https://api.example.com`` and ``https://api.example.com/`` pin the same origin."""
+        attacker_header = _header_for(self._ATTACKER)
+        with respx.mock:
+            respx.get("https://api.example.com/v1/data").mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": attacker_header})
+            )
+            client = HardenedX402Client(
+                payment_signer=_mock_signer,
+                trusted_wallets={"https://api.example.com/": {self._LEGIT}},
+            )
+            try:
+                with pytest.raises(X402PaymentError, match="not in trusted allowlist"):
+                    await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+
+
+# Suppress "unused import" for ``replace`` — retained in case future POC tests
+# need to mutate PaymentDetails fixtures without rebuilding them.
+_ = replace


### PR DESCRIPTION
## Summary
- Closes 4 library-layer chains from the adversary-attack threat model (02 cross-process replay, 04 Unicode PII evasion, 05 exception-message exfiltration, 06 wallet substitution)
- Adds 21 POC tests in `tests/test_adversary_chains.py` exercising each chain before/after fix
- Adds `corpus/README.md` (HuggingFace / IEEE DataPort dataset card)

## Changes
- **`replay_guard.py`** — HMAC-keyed fingerprints via `PRESIDIO_X402_FINGERPRINT_KEY`; atomic `check_and_set`; optional Redis backend for load-balanced deployments
- **`pii_filter.py`** — NFKC canonicalization + Cyrillic homoglyph fold + invisible-codepoint strip + hyphen-like fold pre-scan; ASCII-only digit classes to avoid Arabic-Indic/Devanagari false positives
- **`gateway.py`** — constant-string raises on parse/signer failures; audit `error_message` PII-scanned and truncated to 80 chars; optional per-origin `trusted_wallets` allowlist emitting `WALLET_BLOCKED` on mismatch

Chains 01/03/07/08 (deployment/infra layer) remain open — hard gate before Phase 1 screening API deployment.

## Test plan
- [x] All 192 tests pass (`pytest tests/ -x -q`)
- [x] Ruff clean on all 4 changed files
- [ ] CI green on this PR
- [ ] Published to PyPI as `presidio-hardened-x402==0.3.0` (done pre-PR; commit brings git in line with released artifact)