### PR TITLE
Close adversary chains 03 (audit OOM) and 07 (MPA webhook SSRF)

### DIFF
--- a/src/presidio_x402/audit_log.py
+++ b/src/presidio_x402/audit_log.py
@@ -39,6 +39,7 @@ Usage::
 
 from __future__ import annotations
 
+import atexit
 import hashlib
 import hmac
 import json
@@ -47,6 +48,7 @@ import os
 import secrets
 import sys
 import threading
+import weakref
 from datetime import datetime, timezone
 from typing import IO
 
@@ -99,6 +101,9 @@ class NullAuditWriter:
     def write(self, event: AuditEvent) -> None:
         pass
 
+    def flush(self) -> None:
+        return
+
 
 class StreamAuditWriter:
     """Writes JSON-L audit events to a file-like stream (e.g., ``sys.stdout``)."""
@@ -113,18 +118,50 @@ class StreamAuditWriter:
             self._stream.write(line + "\n")
             self._stream.flush()
 
+    def flush(self) -> None:
+        """Flush the underlying stream — matches the writer-uniform interface."""
+        with self._lock:
+            try:
+                self._stream.flush()
+            except Exception:
+                logger.exception("StreamAuditWriter flush failed")
+
 
 class FileAuditWriter:
-    """Appends JSON-L audit events to a file path."""
+    """Appends JSON-L audit events to a file path.
 
-    def __init__(self, path: str) -> None:
+    Parameters
+    ----------
+    path:
+        Filesystem path to append audit records to.
+    fsync:
+        When ``True`` (default), issues ``os.fsync`` after every write so the
+        entry survives a kernel-level process death (OOM-kill, SIGKILL,
+        container restart). Pay the syscall-per-write cost in exchange for
+        durability — the security posture audit logs exist for.
+        When ``False``, relies on OS buffer flushing — **not safe** for
+        compliance use but acceptable for short-lived test fixtures.
+    """
+
+    def __init__(self, path: str, *, fsync: bool = True) -> None:
         self._path = path
+        self._fsync = fsync
         self._lock = threading.Lock()
 
     def write(self, event: AuditEvent) -> None:
         line = json.dumps(_event_to_dict(event), default=str)
         with self._lock, open(self._path, "a", encoding="utf-8") as fh:
             fh.write(line + "\n")
+            if self._fsync:
+                fh.flush()
+                os.fsync(fh.fileno())
+
+    def flush(self) -> None:
+        """No-op for the file writer — each ``write`` already fsyncs when enabled.
+
+        Provided so :class:`AuditLog.flush` has a uniform interface across writers.
+        """
+        return
 
 
 class AuditLog:
@@ -149,11 +186,18 @@ class AuditLog:
         writer: AuditWriter | None = None,
         *,
         agent_id: str | None = None,
+        flush_on_exit: bool = True,
     ) -> None:
         self._writer = writer or NullAuditWriter()
         self._agent_id = agent_id
         self._prev_hmac: str | None = None
         self._lock = threading.Lock()
+        if flush_on_exit:
+            # Register a best-effort flush on clean interpreter shutdown.
+            # For OOM-kill / SIGKILL paths the writer's per-write fsync is the
+            # actual durability guarantee; atexit only helps the graceful case.
+            self_ref = weakref.ref(self)
+            atexit.register(_atexit_flush, self_ref)
 
     def emit(
         self,
@@ -197,3 +241,23 @@ class AuditLog:
             self._prev_hmac = _hmac_entry(entry_json)
 
         return event
+
+    def flush(self) -> None:
+        """Force the underlying writer to flush any buffered state.
+
+        Call from signal handlers (e.g., ``SIGTERM``) or shutdown hooks to
+        ensure the last emitted events are on stable storage before the
+        process exits. Safe to call multiple times.
+        """
+        try:
+            flush = getattr(self._writer, "flush", None)
+            if callable(flush):
+                flush()
+        except Exception:
+            logger.exception("AuditLog flush failed")
+
+
+def _atexit_flush(self_ref: weakref.ref[AuditLog]) -> None:
+    log = self_ref()
+    if log is not None:
+        log.flush()

--- a/src/presidio_x402/exceptions.py
+++ b/src/presidio_x402/exceptions.py
@@ -68,3 +68,11 @@ class MPATimeoutError(X402Error):
         super().__init__(message)
         self.approvals_received = approvals_received
         self.threshold = threshold
+
+
+class MPAWebhookURLError(X402Error):
+    """Raised when an MPA webhook URL fails SSRF safety validation.
+
+    Applies at config time (scheme + IP-literal checks) and at request time
+    (DNS-resolution check against blocked networks).
+    """

--- a/src/presidio_x402/mpa.py
+++ b/src/presidio_x402/mpa.py
@@ -60,20 +60,86 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
+import socket
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlparse
 
 import httpx
 
-from .exceptions import MPADeniedError, MPATimeoutError
+from .exceptions import MPADeniedError, MPATimeoutError, MPAWebhookURLError
 from .replay_guard import compute_fingerprint
 
 if TYPE_CHECKING:
     from ._types import PaymentDetails
 
 logger = logging.getLogger("presidio_x402.mpa")
+
+# Networks that must never be reachable by an MPA webhook — SSRF defense.
+# Covers loopback, RFC1918 private ranges, link-local (incl. IMDS 169.254.169.254),
+# CGNAT, and IPv6 equivalents. A webhook URL resolving into any of these is refused
+# both at config time (IP literals) and at request time (post-DNS).
+_BLOCKED_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+    ipaddress.ip_network("::/128"),
+)
+
+
+def _ip_is_blocked(addr_str: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(addr_str)
+    except ValueError:
+        return False
+    return any(addr in net for net in _BLOCKED_NETWORKS)
+
+
+def _validate_webhook_url(url: str) -> None:
+    """Static validation of an MPA webhook URL (called at config time).
+
+    Enforces HTTPS-only and rejects IP-literal hosts that fall in blocked ranges.
+    Hostname-based URLs are not resolved here — DNS-rebinding defense runs at
+    request time in :meth:`MPAEngine._request_single_approval`.
+    """
+    if not url:
+        raise MPAWebhookURLError("MPA webhook URL must be a non-empty string")
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise MPAWebhookURLError(
+            f"MPA webhook URL must use https:// (got scheme {parsed.scheme!r})"
+        )
+    host = parsed.hostname
+    if not host:
+        raise MPAWebhookURLError("MPA webhook URL must include a hostname")
+    if _ip_is_blocked(host):
+        raise MPAWebhookURLError(f"MPA webhook URL host {host!r} is in a blocked network range")
+
+
+def _resolve_and_check_host(host: str) -> None:
+    """Resolve *host* and raise if any A/AAAA record falls in a blocked range.
+
+    Defeats DNS-rebinding attacks where a public hostname briefly resolves to
+    an internal IP between config time and request time.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise MPAWebhookURLError(f"DNS resolution failed for {host!r}") from exc
+    for info in infos:
+        addr = info[4][0]
+        if _ip_is_blocked(addr):
+            raise MPAWebhookURLError(f"Host {host!r} resolves to blocked address {addr!r}")
 
 
 @dataclass(frozen=True)
@@ -108,6 +174,14 @@ class MPAApproverConfig:
     webhook_url: str | None = None
     shared_secret: bytes | None = None
 
+    def __post_init__(self) -> None:
+        if self.mode == "webhook":
+            if not self.webhook_url:
+                raise MPAWebhookURLError(
+                    f"MPA approver {self.approver_id!r} in webhook mode requires webhook_url"
+                )
+            _validate_webhook_url(self.webhook_url)
+
 
 @dataclass
 class MPAConfig:
@@ -125,12 +199,19 @@ class MPAConfig:
         meaning all payments require MPA if any approvers are configured).
     timeout_seconds:
         Maximum wait time for webhook approvals (default: ``30.0`` seconds).
+    dns_rebinding_protection:
+        Before every webhook request, resolve the hostname and verify no
+        resolved address falls in a blocked network (RFC1918, link-local,
+        loopback, IMDS, etc.). Default ``True``. Set ``False`` only in test
+        fixtures that mock the HTTP transport and do not own real DNS for
+        the configured approver hostnames.
     """
 
     threshold: int
     approvers: list[MPAApproverConfig] = field(default_factory=list)
     min_amount_usd: float = 0.0
     timeout_seconds: float = 30.0
+    dns_rebinding_protection: bool = True
 
     def __post_init__(self) -> None:
         if self.threshold < 1:
@@ -378,6 +459,16 @@ class MPAEngine:
             "amount_usd": request_data.amount_usd,
         }
         try:
+            # DNS-rebinding defense: if the URL host is a DNS name (not an IP
+            # literal), re-resolve it right before sending and refuse any
+            # resolved address that falls in a blocked network.
+            if self.config.dns_rebinding_protection:
+                host = urlparse(approver.webhook_url or "").hostname or ""
+                try:
+                    ipaddress.ip_address(host)
+                except ValueError:
+                    if host:
+                        _resolve_and_check_host(host)
             resp = await self._httpx.post(
                 approver.webhook_url,  # type: ignore[arg-type]
                 json=payload,

--- a/tests/test_chain_03_audit_durability.py
+++ b/tests/test_chain_03_audit_durability.py
@@ -1,0 +1,184 @@
+"""Chain 03 (audit-log OOM erasure) — POC tests for the durability fix.
+
+Attack model: attacker triggers an OOM-kill (or any hard SIGKILL) while the
+``FileAuditWriter`` has buffered audit entries. The OS discards unflushed
+buffers, the last events (including the attack itself) are lost, and the chain
+rolls forward on the next container start with a fresh key — severing
+tamper-evidence across the event.
+
+Fix: ``FileAuditWriter`` issues ``os.fsync`` after every write by default;
+``AuditLog.flush()`` forces the writer to drain on demand; an ``atexit`` hook
+flushes on clean shutdown.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from presidio_x402.audit_log import AuditLog, FileAuditWriter, StreamAuditWriter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestFileWriterFsyncDurability:
+    """Per-write fsync is the actual OOM-kill defence."""
+
+    def test_fsync_called_per_write_by_default(self, tmp_path: Path) -> None:
+        audit_path = tmp_path / "audit.jsonl"
+        writer = FileAuditWriter(str(audit_path))
+        log = AuditLog(writer=writer, flush_on_exit=False)
+
+        with patch("os.fsync") as mock_fsync:
+            log.emit(
+                "PAYMENT_ALLOWED",
+                resource_url="https://api.example.com/x",
+                amount_usd=0.10,
+                network="base",
+                outcome="allowed",
+            )
+        assert mock_fsync.call_count == 1, "fsync must be called once per emit"
+
+    def test_fsync_disabled_when_opt_out(self, tmp_path: Path) -> None:
+        audit_path = tmp_path / "audit.jsonl"
+        writer = FileAuditWriter(str(audit_path), fsync=False)
+        log = AuditLog(writer=writer, flush_on_exit=False)
+
+        with patch("os.fsync") as mock_fsync:
+            log.emit(
+                "PAYMENT_ALLOWED",
+                resource_url="https://api.example.com/x",
+                amount_usd=0.10,
+                network="base",
+                outcome="allowed",
+            )
+        assert mock_fsync.call_count == 0
+
+    def test_entries_readable_immediately_after_write(self, tmp_path: Path) -> None:
+        # fsync makes entries durable even if the process dies immediately.
+        audit_path = tmp_path / "audit.jsonl"
+        log = AuditLog(writer=FileAuditWriter(str(audit_path)), flush_on_exit=False)
+
+        log.emit(
+            "PAYMENT_ALLOWED",
+            resource_url="https://api.example.com/x",
+            amount_usd=0.10,
+            network="base",
+            outcome="allowed",
+        )
+        content = audit_path.read_text(encoding="utf-8")
+        line = content.strip().split("\n")[-1]
+        entry = json.loads(line)
+        assert entry["event_type"] == "PAYMENT_ALLOWED"
+        assert entry["outcome"] == "allowed"
+
+    def test_many_writes_all_durable(self, tmp_path: Path) -> None:
+        audit_path = tmp_path / "audit.jsonl"
+        log = AuditLog(writer=FileAuditWriter(str(audit_path)), flush_on_exit=False)
+        for i in range(25):
+            log.emit(
+                "PAYMENT_ALLOWED",
+                resource_url=f"https://api.example.com/{i}",
+                amount_usd=0.01 * i,
+                network="base",
+                outcome="allowed",
+            )
+        lines = audit_path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 25
+        # Entries preserve chain order
+        entries = [json.loads(line_) for line_ in lines]
+        for _prev, curr in zip(entries[:-1], entries[1:], strict=True):
+            assert curr["prev_entry_hmac"] is not None
+
+
+class TestAuditLogFlushAPI:
+    """``AuditLog.flush`` delegates to the writer — used by shutdown handlers."""
+
+    def test_flush_delegates_to_writer_flush(self) -> None:
+        class RecordingWriter:
+            def __init__(self) -> None:
+                self.flushed = 0
+
+            def write(self, event) -> None:  # noqa: ARG002
+                pass
+
+            def flush(self) -> None:
+                self.flushed += 1
+
+        w = RecordingWriter()
+        log = AuditLog(writer=w, flush_on_exit=False)
+        log.flush()
+        log.flush()
+        assert w.flushed == 2
+
+    def test_flush_tolerates_writer_without_flush(self) -> None:
+        # Users can pass bare writers lacking a flush method — no attribute error.
+        class BareWriter:
+            def write(self, event) -> None:  # noqa: ARG002
+                pass
+
+        log = AuditLog(writer=BareWriter(), flush_on_exit=False)
+        log.flush()  # should not raise
+
+    def test_flush_swallows_writer_exceptions(self) -> None:
+        class FailingWriter:
+            def write(self, event) -> None:  # noqa: ARG002
+                pass
+
+            def flush(self) -> None:
+                raise RuntimeError("disk full")
+
+        log = AuditLog(writer=FailingWriter(), flush_on_exit=False)
+        log.flush()  # must not propagate — shutdown paths can't recover anyway
+
+    def test_stream_writer_flush_calls_stream_flush(self) -> None:
+        class RecordingStream:
+            def __init__(self) -> None:
+                self.writes: list[str] = []
+                self.flushes = 0
+
+            def write(self, s: str) -> None:
+                self.writes.append(s)
+
+            def flush(self) -> None:
+                self.flushes += 1
+
+        stream = RecordingStream()
+        writer = StreamAuditWriter(stream=stream)
+        writer.flush()
+        assert stream.flushes == 1
+
+
+class TestOOMKillSurvival:
+    """Simulate the OOM-kill scenario: write then immediately re-read.
+
+    Without fsync, a SIGKILL would drop buffered data. With fsync, the data
+    is already on disk and the next reader sees every emitted event.
+    """
+
+    def test_entries_survive_process_death_simulation(self) -> None:
+        # Use the unflushed-close path as a process-death proxy: the test
+        # writes, and a *separate* reader (simulating a new process)
+        # immediately opens the file to verify the event is there.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as tmp:
+            audit_path = tmp.name
+        try:
+            log = AuditLog(writer=FileAuditWriter(audit_path), flush_on_exit=False)
+            log.emit(
+                "ATTACK_DETECTED",
+                resource_url="https://victim.example.com/",
+                amount_usd=0.0,
+                network="base",
+                outcome="blocked",
+                error_message="oom-kill triggered",
+            )
+            # Re-open in a fresh handle — simulates post-crash reader.
+            with open(audit_path, encoding="utf-8") as fh:
+                entries = [json.loads(line_) for line_ in fh if line_.strip()]
+            assert any(e["event_type"] == "ATTACK_DETECTED" for e in entries)
+        finally:
+            os.unlink(audit_path)

--- a/tests/test_chain_07_webhook_ssrf.py
+++ b/tests/test_chain_07_webhook_ssrf.py
@@ -1,0 +1,110 @@
+"""Chain 07 (MPA webhook SSRF) — POC tests demonstrating the fix blocks the attack.
+
+Attack model: attacker injects a webhook URL pointing at an internal service
+(cloud metadata, Redis, K8s API) via config manipulation. The MPA engine would
+then POST the payment payload into that internal service, leaking data and/or
+coercing side effects.
+
+Fix: ``MPAApproverConfig.__post_init__`` validates scheme + IP-literal hosts
+against a blocked-network allowlist. ``MPAEngine._request_single_approval``
+re-resolves DNS names immediately before each request to defeat rebinding.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from presidio_x402.exceptions import MPAWebhookURLError
+from presidio_x402.mpa import MPAApproverConfig, _ip_is_blocked, _validate_webhook_url
+
+
+class TestConfigTimeValidation:
+    """``_validate_webhook_url`` catches the common SSRF config shapes upfront."""
+
+    def test_http_scheme_refused(self) -> None:
+        with pytest.raises(MPAWebhookURLError, match="must use https"):
+            _validate_webhook_url("http://approvals.example.com/cb")
+
+    def test_file_scheme_refused(self) -> None:
+        with pytest.raises(MPAWebhookURLError, match="must use https"):
+            _validate_webhook_url("file:///etc/passwd")
+
+    def test_empty_url_refused(self) -> None:
+        with pytest.raises(MPAWebhookURLError, match="non-empty"):
+            _validate_webhook_url("")
+
+    def test_missing_hostname_refused(self) -> None:
+        with pytest.raises(MPAWebhookURLError, match="hostname"):
+            _validate_webhook_url("https:///path-only")
+
+    @pytest.mark.parametrize(
+        "blocked_ip",
+        [
+            "127.0.0.1",
+            "10.0.0.5",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",  # AWS/GCP IMDS
+            "100.64.0.1",  # CGNAT
+            "0.0.0.0",  # noqa: S104 — literal used as blocklist test input, not a bind address
+            "::1",
+            "fc00::1",
+            "fe80::1",
+        ],
+    )
+    def test_ip_literal_in_blocked_range_refused(self, blocked_ip: str) -> None:
+        url = f"https://[{blocked_ip}]/cb" if ":" in blocked_ip else f"https://{blocked_ip}/cb"
+        with pytest.raises(MPAWebhookURLError, match="blocked"):
+            _validate_webhook_url(url)
+
+    def test_public_ip_literal_accepted(self) -> None:
+        _validate_webhook_url("https://8.8.8.8/cb")
+        _validate_webhook_url("https://1.1.1.1/cb")
+
+    def test_public_hostname_accepted(self) -> None:
+        _validate_webhook_url("https://approvals.example.com/cb")
+
+
+class TestApproverConfigEnforcement:
+    """``MPAApproverConfig.__post_init__`` runs the validator for webhook mode."""
+
+    def test_webhook_mode_without_url_refused(self) -> None:
+        with pytest.raises(MPAWebhookURLError, match="requires webhook_url"):
+            MPAApproverConfig("alice", mode="webhook")
+
+    def test_webhook_mode_with_blocked_ip_refused(self) -> None:
+        with pytest.raises(MPAWebhookURLError, match="blocked"):
+            MPAApproverConfig(
+                "alice",
+                mode="webhook",
+                webhook_url="https://169.254.169.254/latest/meta-data/",
+            )
+
+    def test_webhook_mode_with_http_refused(self) -> None:
+        with pytest.raises(MPAWebhookURLError, match="https"):
+            MPAApproverConfig(
+                "alice",
+                mode="webhook",
+                webhook_url="http://approvals.example.com/cb",
+            )
+
+    def test_crypto_mode_unaffected(self) -> None:
+        # Crypto mode has no webhook_url — validator must not run.
+        MPAApproverConfig("alice", mode="crypto", shared_secret=b"s")
+
+
+class TestBlockedNetworkHelper:
+    """``_ip_is_blocked`` covers the defence matrix."""
+
+    @pytest.mark.parametrize("ip", ["127.0.0.1", "10.1.2.3", "169.254.169.254", "::1"])
+    def test_blocked(self, ip: str) -> None:
+        assert _ip_is_blocked(ip) is True
+
+    @pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"])
+    def test_public(self, ip: str) -> None:
+        assert _ip_is_blocked(ip) is False
+
+    def test_non_ip_string_returns_false(self) -> None:
+        # Hostnames passed here are not blocked by this helper directly — they
+        # go through the DNS-resolution check at request time instead.
+        assert _ip_is_blocked("approvals.example.com") is False

--- a/tests/test_mpa.py
+++ b/tests/test_mpa.py
@@ -57,6 +57,7 @@ CHARLIE_SECRET = b"charlie-shared-secret"
 class TestMPAConfigValidation:
     def test_valid_config(self):
         cfg = MPAConfig(
+            dns_rebinding_protection=False,
             threshold=2,
             approvers=[
                 MPAApproverConfig("alice", mode="webhook", webhook_url="https://a.internal"),
@@ -70,6 +71,7 @@ class TestMPAConfigValidation:
     def test_threshold_zero_raises(self):
         with pytest.raises(ValueError, match="threshold must be >= 1"):
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=0,
                 approvers=[
                     MPAApproverConfig("alice", mode="webhook", webhook_url="https://a.internal"),
@@ -79,6 +81,7 @@ class TestMPAConfigValidation:
     def test_threshold_exceeds_approvers_raises(self):
         with pytest.raises(ValueError, match="cannot exceed number of approvers"):
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=3,
                 approvers=[
                     MPAApproverConfig("alice", mode="webhook", webhook_url="https://a.internal"),
@@ -89,7 +92,7 @@ class TestMPAConfigValidation:
     def test_empty_approvers_raises(self):
         # threshold 1 > 0 approvers → should raise
         with pytest.raises(ValueError, match="cannot exceed number of approvers"):
-            MPAConfig(threshold=1, approvers=[])
+            MPAConfig(dns_rebinding_protection=False, threshold=1, approvers=[])
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +104,7 @@ class TestMPAAmountThreshold:
     def setup_method(self):
         self.engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 min_amount_usd=5.00,
                 approvers=[
@@ -140,6 +144,7 @@ class TestMPACryptoMode:
     async def test_single_valid_signature_meets_threshold(self):
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET)],
             )
@@ -154,6 +159,7 @@ class TestMPACryptoMode:
     async def test_two_of_three_valid_signatures(self):
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=2,
                 approvers=[
                     MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET),
@@ -172,6 +178,7 @@ class TestMPACryptoMode:
     async def test_wrong_signature_is_rejected(self):
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET)],
             )
@@ -189,6 +196,7 @@ class TestMPACryptoMode:
     async def test_missing_signature_is_denied(self):
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET)],
             )
@@ -200,6 +208,7 @@ class TestMPACryptoMode:
     async def test_below_threshold_signatures_denied(self):
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=2,
                 approvers=[
                     MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET),
@@ -226,6 +235,7 @@ class TestMPAWebhookMode:
         self.amount_usd = 3.00
         self.engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=2,
                 timeout_seconds=5.0,
                 approvers=[
@@ -313,6 +323,7 @@ class TestMPAWebhookMode:
     async def test_approved_error_message_is_informative(self):
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[
                     MPAApproverConfig(
@@ -353,6 +364,7 @@ class TestMPAWebhookHMAC:
         """Webhook approver with shared_secret + correct X-MPA-HMAC → approved."""
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[
                     MPAApproverConfig(
@@ -382,6 +394,7 @@ class TestMPAWebhookHMAC:
         """Webhook approver with shared_secret but no X-MPA-HMAC header → denied."""
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[
                     MPAApproverConfig(
@@ -409,6 +422,7 @@ class TestMPAWebhookHMAC:
         """Webhook approver with shared_secret + tampered X-MPA-HMAC header → denied."""
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[
                     MPAApproverConfig(
@@ -438,6 +452,7 @@ class TestMPAWebhookHMAC:
         """Webhook approver without shared_secret accepts response without X-MPA-HMAC."""
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=1,
                 approvers=[
                     MPAApproverConfig(
@@ -475,6 +490,7 @@ class TestMPAMixedMode:
         """Alice provides crypto sig; Bob approves via webhook; threshold 2 → approved."""
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=2,
                 approvers=[
                     MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET),
@@ -498,6 +514,7 @@ class TestMPAMixedMode:
         """Alice provides valid crypto sig; Bob denies; threshold 2 → MPADeniedError."""
         engine = MPAEngine(
             MPAConfig(
+                dns_rebinding_protection=False,
                 threshold=2,
                 approvers=[
                     MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET),


### PR DESCRIPTION
## Summary
- **Chain 07 (MPA webhook SSRF):** `MPAApproverConfig` validates webhook URLs at config time (HTTPS-only, hostname required, IP literals screened against RFC1918 + IMDS 169.254.169.254 + CGNAT 100.64/10 + link-local + loopback). `MPAEngine._request_single_approval` re-resolves DNS names immediately before each POST to defeat rebinding. Opt-out via `MPAConfig.dns_rebinding_protection=False` for tests that mock transport.
- **Chain 03 (audit log OOM erasure):** `FileAuditWriter` issues `os.fsync` per write by default so the last entries survive OOM-kill / SIGKILL. `AuditLog.flush()` exposes a writer-drain API for signal handlers; `atexit` hook flushes on clean shutdown. `NullAuditWriter` / `StreamAuditWriter` grow matching `flush()` methods for writer-interface uniformity.
- New `MPAWebhookURLError` exception for chain 07 validation failures.

## Test plan
- [x] `tests/test_chain_07_webhook_ssrf.py` — 28 tests: scheme/host/IP validation, blocked-network matrix, DNS helper, config-time enforcement
- [x] `tests/test_chain_03_audit_durability.py` — 9 tests: per-write fsync, opt-out, immediate durability, 25-write chain-order preservation, flush API, OOM-kill survival
- [x] Full suite green: 229 passed
- [x] `ruff check` + `ruff format --check` clean across `src/` + `tests/`