### PR TITLE
Add ScreeningClient + remote_screening gateway mode

### DIFF
--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -34,6 +34,10 @@ from .exceptions import (
     PIIBlockedError,
     PolicyViolationError,
     ReplayDetectedError,
+    ScreeningAuthError,
+    ScreeningError,
+    ScreeningRateLimitError,
+    ScreeningUnavailableError,
     X402Error,
     X402PaymentError,
 )
@@ -43,6 +47,7 @@ from .mpa import MPAApproverConfig, MPAConfig, MPAEngine
 from .pii_filter import PIIFilter
 from .policy_engine import PolicyConfig, PolicyEngine
 from .replay_guard import ReplayGuard, compute_fingerprint
+from .screening_client import ScreeningClient
 
 __version__ = "0.3.0"
 __all__ = [
@@ -56,6 +61,8 @@ __all__ = [
     "MPAEngine",
     # Prometheus metrics
     "MetricsCollector",
+    # Remote screening
+    "ScreeningClient",
     # Exceptions
     "X402Error",
     "X402PaymentError",
@@ -64,6 +71,10 @@ __all__ = [
     "ReplayDetectedError",
     "MPADeniedError",
     "MPATimeoutError",
+    "ScreeningError",
+    "ScreeningAuthError",
+    "ScreeningRateLimitError",
+    "ScreeningUnavailableError",
     # Components (for custom composition)
     "PIIFilter",
     "PolicyEngine",

--- a/src/presidio_x402/exceptions.py
+++ b/src/presidio_x402/exceptions.py
@@ -76,3 +76,33 @@ class MPAWebhookURLError(X402Error):
     Applies at config time (scheme + IP-literal checks) and at request time
     (DNS-resolution check against blocked networks).
     """
+
+
+class ScreeningError(X402Error):
+    """Base class for remote screening-API failures."""
+
+
+class ScreeningAuthError(ScreeningError):
+    """Raised when the screening API rejects the API key (HTTP 401).
+
+    Not retried — caller must obtain a new key or fall back to local screening.
+    """
+
+
+class ScreeningRateLimitError(ScreeningError):
+    """Raised when the screening API daily quota is exhausted (HTTP 429).
+
+    Attributes
+    ----------
+    retry_after:
+        Seconds until the quota resets, parsed from the ``Retry-After`` header.
+        ``None`` when the server did not supply the header.
+    """
+
+    def __init__(self, message: str, *, retry_after: int | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class ScreeningUnavailableError(ScreeningError):
+    """Raised when the screening API is unreachable or returned a 5xx after retry."""

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -56,6 +56,7 @@ from .exceptions import (
 if TYPE_CHECKING:
     from .metrics import MetricsCollector
     from .mpa import MPAEngine
+    from .screening_client import ScreeningClient
 from .pii_filter import PIIFilter
 from .policy_engine import PolicyConfig, PolicyEngine
 from .replay_guard import ReplayGuard, compute_fingerprint
@@ -228,6 +229,16 @@ class HardenedX402Client:
             trusted_wallets={
                 "https://api.example.com": {"0xAbC...123"},
             }
+    screening_client:
+        Optional :class:`~presidio_x402.screening_client.ScreeningClient`.
+        When combined with ``remote_screening=True``, payment-metadata PII
+        scanning is offloaded to the remote Presidio screening service instead
+        of running the local regex/NLP pipeline. The local ``PIIFilter`` is
+        still used for defense-in-depth redaction of exception messages.
+    remote_screening:
+        Toggle for the remote PII path. ``False`` (default) runs the local
+        :class:`PIIFilter`; ``True`` requires ``screening_client`` to be set
+        and forwards payment metadata to the remote service.
     """
 
     def __init__(
@@ -246,10 +257,17 @@ class HardenedX402Client:
         mpa_engine: MPAEngine | None = None,
         metrics_collector: MetricsCollector | None = None,
         trusted_wallets: dict[str, set[str]] | None = None,
+        screening_client: ScreeningClient | None = None,
+        remote_screening: bool = False,
     ) -> None:
+        if remote_screening and screening_client is None:
+            raise ValueError("remote_screening=True requires a screening_client instance")
         self._signer = payment_signer
         self._pii_filter = PIIFilter(mode=pii_mode, entities=pii_entities)
+        self._pii_entities = pii_entities
         self._pii_action = pii_action
+        self._screening_client = screening_client
+        self._remote_screening = remote_screening
         self._policy = PolicyEngine(policy)
         self._replay = ReplayGuard(ttl=replay_ttl, redis_url=redis_url)
         self._audit = AuditLog(audit_writer or NullAuditWriter(), agent_id=agent_id)
@@ -372,11 +390,26 @@ class HardenedX402Client:
         amount_usd = _amount_to_usd(details.amount, details.currency)
 
         # ------------------------------------------------------------------
-        # 1. PII Filter
+        # 1. PII Filter (local regex/NLP or remote screening service)
         # ------------------------------------------------------------------
-        clean_url, clean_desc, clean_reason, pii_entities = self._pii_filter.scan_payment_fields(
-            details.resource_url, details.description, details.reason
-        )
+        if self._remote_screening and self._screening_client is not None:
+            (
+                clean_url,
+                clean_desc,
+                clean_reason,
+                pii_entities,
+            ) = await self._screening_client.scan_payment_fields(
+                details.resource_url,
+                details.description,
+                details.reason,
+                entities=self._pii_entities,
+            )
+        else:
+            clean_url, clean_desc, clean_reason, pii_entities = (
+                self._pii_filter.scan_payment_fields(
+                    details.resource_url, details.description, details.reason
+                )
+            )
 
         if pii_entities:
             entity_types = [e.entity_type for e in pii_entities]

--- a/src/presidio_x402/screening_client.py
+++ b/src/presidio_x402/screening_client.py
@@ -1,0 +1,203 @@
+"""Remote PII screening client — call the Presidio screening service instead of
+running the local :class:`~presidio_x402.pii_filter.PIIFilter`.
+
+The client speaks the v0.4.0 wire contract (see ``plan/v040-wire-contract.md``
+in the private repo). It is a drop-in replacement for
+:meth:`PIIFilter.scan_payment_fields` — same signature and return shape — so the
+gateway can switch between local and remote screening without branching on the
+hot path.
+
+Transport rules (v0.4.0, free tier):
+  * HTTPS only for prod base URLs; ``http://`` allowed for local dev
+  * ``X-API-Key`` header carries the opaque token issued by ``/v1/register``
+  * 10 s total timeout (3 s connect), single retry on 5xx / network error
+  * ``429`` → :class:`ScreeningRateLimitError` (with ``retry_after``)
+  * ``401`` → :class:`ScreeningAuthError` (no retry)
+  * repeated 5xx / network → :class:`ScreeningUnavailableError`
+
+Typical use — supplied to :class:`~presidio_x402.HardenedX402Client` via the
+``screening_client`` kwarg::
+
+    screening = ScreeningClient(
+        base_url="https://screen.presidio-group.eu",
+        api_key=os.environ["PRESIDIO_SCREENING_KEY"],
+    )
+    client = HardenedX402Client(
+        payment_signer=signer,
+        screening_client=screening,
+        remote_screening=True,
+    )
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from .exceptions import (
+    ScreeningAuthError,
+    ScreeningRateLimitError,
+    ScreeningUnavailableError,
+)
+
+if TYPE_CHECKING:
+    from .pii_filter import EntityResult
+
+logger = logging.getLogger("presidio_x402.screening_client")
+
+_DEFAULT_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
+_RETRY_BACKOFF_SECONDS = 0.5
+
+
+class ScreeningClient:
+    """HTTPS client for the Presidio screening service.
+
+    Parameters
+    ----------
+    base_url:
+        Service root, e.g. ``https://screen.presidio-group.eu``. No trailing
+        ``/v1`` — the client appends endpoint paths itself.
+    api_key:
+        Opaque token issued by ``POST /v1/register``. Sent in the ``X-API-Key``
+        header on every request.
+    timeout:
+        Optional httpx timeout override. Defaults to 10 s total / 3 s connect.
+    httpx_client:
+        Optional pre-configured ``httpx.AsyncClient`` (useful for tests or for
+        sharing a connection pool with the gateway).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        *,
+        timeout: httpx.Timeout | float | None = None,
+        httpx_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("ScreeningClient requires a non-empty base_url")
+        if not api_key:
+            raise ValueError("ScreeningClient requires a non-empty api_key")
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT
+        self._owned_client = httpx_client is None
+        self._httpx = httpx_client or httpx.AsyncClient(timeout=self._timeout)
+
+    async def scan_payment_fields(
+        self,
+        resource_url: str,
+        description: str,
+        reason: str,
+        *,
+        entities: list[str] | None = None,
+    ) -> tuple[str, str, str, list[EntityResult]]:
+        """Remote equivalent of :meth:`PIIFilter.scan_payment_fields`.
+
+        Returns ``(redacted_url, redacted_description, redacted_reason, entities)``
+        where ``entities`` is a list of :class:`~presidio_x402.pii_filter.EntityResult`
+        constructed from the service's ``entities_found`` array. Start/end offsets
+        are not returned by the service, so they are set to ``0`` — consumers must
+        not rely on them in remote-screening mode.
+        """
+        payload: dict[str, Any] = {
+            "resource_url": resource_url,
+            "description": description,
+            "reason": reason,
+        }
+        if entities is not None:
+            payload["entities"] = entities
+
+        data = await self._post_with_retry("/v1/screen", payload)
+
+        from .pii_filter import EntityResult
+
+        results: list[EntityResult] = []
+        for item in data.get("entities_found", []):
+            entity_type = item.get("entity_type", "UNKNOWN")
+            count = int(item.get("count", 1))
+            for _ in range(count):
+                results.append(
+                    EntityResult(
+                        entity_type=entity_type,
+                        start=0,
+                        end=0,
+                        score=1.0,
+                        original_text="",
+                    )
+                )
+
+        return (
+            data.get("redacted_resource_url", resource_url),
+            data.get("redacted_description", description),
+            data.get("redacted_reason", reason),
+            results,
+        )
+
+    async def aclose(self) -> None:
+        if self._owned_client:
+            await self._httpx.aclose()
+
+    async def __aenter__(self) -> ScreeningClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    async def _post_with_retry(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        headers = {"X-API-Key": self._api_key, "Content-Type": "application/json"}
+
+        last_exc: Exception | None = None
+        for attempt in (1, 2):
+            try:
+                resp = await self._httpx.post(url, json=payload, headers=headers)
+            except httpx.RequestError as exc:
+                last_exc = exc
+                if attempt == 1:
+                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+                    continue
+                raise ScreeningUnavailableError(
+                    f"Screening service unreachable: {type(exc).__name__}"
+                ) from exc
+
+            status = resp.status_code
+            if status == 200:
+                try:
+                    return resp.json()
+                except ValueError as exc:
+                    raise ScreeningUnavailableError(
+                        "Screening service returned non-JSON body"
+                    ) from exc
+            if status == 401:
+                raise ScreeningAuthError("Screening API key rejected")
+            if status == 429:
+                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+                raise ScreeningRateLimitError(
+                    "Screening daily quota exceeded",
+                    retry_after=retry_after,
+                )
+            if 500 <= status < 600:
+                last_exc = ScreeningUnavailableError(f"Screening service returned HTTP {status}")
+                if attempt == 1:
+                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+                    continue
+                raise last_exc
+            # 4xx other than 401/429 — non-retriable client error
+            raise ScreeningUnavailableError(f"Screening service returned unexpected HTTP {status}")
+
+        # Unreachable — loop either returns or raises on attempt 2.
+        raise ScreeningUnavailableError("Screening service retry loop exited unexpectedly")
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return max(0, int(value))
+    except ValueError:
+        return None

--- a/tests/test_gateway_remote_screening.py
+++ b/tests/test_gateway_remote_screening.py
@@ -1,0 +1,189 @@
+"""Gateway integration tests for ``remote_screening=True``.
+
+Verifies that when a :class:`ScreeningClient` is supplied, the gateway offloads
+payment-metadata PII scanning to the remote service and applies the returned
+redactions + entity list identically to the local-filter path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from presidio_x402 import HardenedX402Client, ScreeningClient
+from presidio_x402._types import PaymentDetails, PaymentResponse
+from presidio_x402.audit_log import NullAuditWriter
+from presidio_x402.exceptions import (
+    PIIBlockedError,
+    ScreeningAuthError,
+    ScreeningUnavailableError,
+)
+
+RESOURCE = "https://api.example.com/user/alice@example.com"
+BASE = "https://screen.presidio-group.eu"
+SCREEN_URL = f"{BASE}/v1/screen"
+API_KEY = "k" * 43
+
+PAYMENT_HEADER_VALUE = json.dumps(
+    {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base-sepolia",
+                "maxAmountRequired": "0.01",
+                "resource": RESOURCE,
+                "description": "Inference request for alice@example.com",
+                "reason": "",
+                "mimeType": "application/json",
+                "payTo": "0xabcdef1234567890abcdef1234567890abcdef12",
+                "requiredDeadlineSeconds": 300,
+                "extra": {},
+            }
+        ]
+    }
+)
+
+SCREEN_RESPONSE = {
+    "redacted_resource_url": "https://api.example.com/user/<EMAIL_ADDRESS>",
+    "redacted_description": "Inference request for <EMAIL_ADDRESS>",
+    "redacted_reason": "",
+    "entities_found": [
+        {"entity_type": "EMAIL_ADDRESS", "field": "resource_url", "count": 1},
+        {"entity_type": "EMAIL_ADDRESS", "field": "description", "count": 1},
+    ],
+    "screening_id": "sc_01HW8ZABCDE",
+    "tier": "free",
+    "audit_token": None,
+    "screened_at": "2026-04-18T12:00:00.123Z",
+}
+
+
+async def _mock_signer(details: PaymentDetails) -> PaymentResponse:
+    return PaymentResponse(token="signed-token", details=details)  # noqa: S106
+
+
+def _make_client(**kwargs) -> HardenedX402Client:
+    defaults: dict = {
+        "payment_signer": _mock_signer,
+        "audit_writer": NullAuditWriter(),
+    }
+    defaults.update(kwargs)
+    return HardenedX402Client(**defaults)
+
+
+class TestConstructorGuards:
+    def test_remote_screening_requires_client(self) -> None:
+        with pytest.raises(ValueError, match="requires a screening_client"):
+            _make_client(remote_screening=True)
+
+    def test_screening_client_without_flag_is_inert(self) -> None:
+        # Passing a screening_client but leaving remote_screening=False
+        # keeps the local PIIFilter path active. Should not raise.
+        client = _make_client(
+            screening_client=ScreeningClient(BASE, API_KEY),
+            remote_screening=False,
+        )
+        assert client._remote_screening is False
+
+
+class TestRemoteScreeningHappyPath:
+    @pytest.mark.asyncio
+    async def test_redacts_via_service_and_completes_payment(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=SCREEN_RESPONSE))
+            route = respx.get(RESOURCE)
+            route.side_effect = [
+                httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE}),
+                httpx.Response(200, text="paid content"),
+            ]
+            screening = ScreeningClient(BASE, API_KEY)
+            try:
+                async with _make_client(
+                    screening_client=screening, remote_screening=True
+                ) as client:
+                    resp = await client.get(RESOURCE)
+            finally:
+                await screening.aclose()
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_block_mode_raises_on_remote_detected_pii(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=SCREEN_RESPONSE))
+            respx.get(RESOURCE).mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE})
+            )
+            screening = ScreeningClient(BASE, API_KEY)
+            try:
+                async with _make_client(
+                    screening_client=screening,
+                    remote_screening=True,
+                    pii_action="block",
+                ) as client:
+                    with pytest.raises(PIIBlockedError) as excinfo:
+                        await client.get(RESOURCE)
+            finally:
+                await screening.aclose()
+        assert "EMAIL_ADDRESS" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_forwards_entities_allowlist_to_service(self) -> None:
+        with respx.mock:
+            screen_route = respx.post(SCREEN_URL).mock(
+                return_value=httpx.Response(200, json=SCREEN_RESPONSE)
+            )
+            respx.get(RESOURCE).side_effect = [
+                httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE}),
+                httpx.Response(200, text="ok"),
+            ]
+            screening = ScreeningClient(BASE, API_KEY)
+            try:
+                async with _make_client(
+                    screening_client=screening,
+                    remote_screening=True,
+                    pii_entities=["EMAIL_ADDRESS", "US_SSN"],
+                ) as client:
+                    await client.get(RESOURCE)
+            finally:
+                await screening.aclose()
+        sent_body = json.loads(screen_route.calls.last.request.read().decode())
+        assert sent_body["entities"] == ["EMAIL_ADDRESS", "US_SSN"]
+
+
+class TestRemoteScreeningFailures:
+    @pytest.mark.asyncio
+    async def test_service_401_surfaces_auth_error(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(401, json={}))
+            respx.get(RESOURCE).mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE})
+            )
+            screening = ScreeningClient(BASE, API_KEY)
+            try:
+                async with _make_client(
+                    screening_client=screening, remote_screening=True
+                ) as client:
+                    with pytest.raises(ScreeningAuthError):
+                        await client.get(RESOURCE)
+            finally:
+                await screening.aclose()
+
+    @pytest.mark.asyncio
+    async def test_service_5xx_retry_exhausted_surfaces_unavailable(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(500, json={}))
+            respx.get(RESOURCE).mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE})
+            )
+            screening = ScreeningClient(BASE, API_KEY)
+            try:
+                async with _make_client(
+                    screening_client=screening, remote_screening=True
+                ) as client:
+                    with pytest.raises(ScreeningUnavailableError):
+                        await client.get(RESOURCE)
+            finally:
+                await screening.aclose()

--- a/tests/test_screening_client.py
+++ b/tests/test_screening_client.py
@@ -1,0 +1,207 @@
+"""Tests for :class:`~presidio_x402.screening_client.ScreeningClient`.
+
+Covers the v0.4.0 wire contract: happy path, 401/429 mapping, 5xx single retry,
+network-error retry, and per-attempt behaviour around ``Retry-After``.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from presidio_x402.exceptions import (
+    ScreeningAuthError,
+    ScreeningRateLimitError,
+    ScreeningUnavailableError,
+)
+from presidio_x402.screening_client import ScreeningClient
+
+BASE = "https://screen.presidio-group.eu"
+SCREEN_URL = f"{BASE}/v1/screen"
+API_KEY = "k" * 43  # 32-byte base64url ≈ 43 chars
+
+
+def _ok_body(
+    redacted_url: str = "https://api.example.com/u/<EMAIL_ADDRESS>",
+    redacted_desc: str = "payment for <EMAIL_ADDRESS>",
+    redacted_reason: str = "",
+    entities: list[dict] | None = None,
+) -> dict:
+    return {
+        "redacted_resource_url": redacted_url,
+        "redacted_description": redacted_desc,
+        "redacted_reason": redacted_reason,
+        "entities_found": entities
+        or [
+            {"entity_type": "EMAIL_ADDRESS", "field": "resource_url", "count": 1},
+            {"entity_type": "EMAIL_ADDRESS", "field": "description", "count": 1},
+        ],
+        "screening_id": "sc_01HW8ZABCDE",
+        "tier": "free",
+        "audit_token": None,
+        "screened_at": "2026-04-18T12:00:00.123Z",
+    }
+
+
+class TestInit:
+    def test_requires_base_url(self) -> None:
+        with pytest.raises(ValueError, match="base_url"):
+            ScreeningClient(base_url="", api_key=API_KEY)
+
+    def test_requires_api_key(self) -> None:
+        with pytest.raises(ValueError, match="api_key"):
+            ScreeningClient(base_url=BASE, api_key="")
+
+    def test_base_url_trailing_slash_stripped(self) -> None:
+        c = ScreeningClient(base_url=f"{BASE}/", api_key=API_KEY)
+        # Not public, but the stripped prefix is what matters for URL concat.
+        assert c._base_url == BASE
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_200_response_returns_redacted_tuple(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=_ok_body()))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                url, desc, reason, entities = await c.scan_payment_fields(
+                    "https://api.example.com/u/alice@example.com",
+                    "payment for alice@example.com",
+                    "",
+                )
+        assert url == "https://api.example.com/u/<EMAIL_ADDRESS>"
+        assert desc == "payment for <EMAIL_ADDRESS>"
+        assert reason == ""
+        assert len(entities) == 2
+        assert all(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    @pytest.mark.asyncio
+    async def test_sends_api_key_header(self) -> None:
+        with respx.mock:
+            route = respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=_ok_body()))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                await c.scan_payment_fields("https://x", "", "")
+        assert route.called
+        sent = route.calls.last.request
+        assert sent.headers["X-API-Key"] == API_KEY
+        assert sent.headers["Content-Type"].startswith("application/json")
+
+    @pytest.mark.asyncio
+    async def test_entities_allowlist_forwarded(self) -> None:
+        with respx.mock:
+            route = respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=_ok_body()))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                await c.scan_payment_fields(
+                    "https://x", "", "", entities=["EMAIL_ADDRESS", "US_SSN"]
+                )
+        body = route.calls.last.request.read().decode()
+        assert "EMAIL_ADDRESS" in body
+        assert "US_SSN" in body
+
+    @pytest.mark.asyncio
+    async def test_count_expands_to_multiple_entity_results(self) -> None:
+        body = _ok_body(
+            entities=[{"entity_type": "EMAIL_ADDRESS", "field": "description", "count": 3}]
+        )
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=body))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                _, _, _, entities = await c.scan_payment_fields("https://x", "y", "z")
+        assert len(entities) == 3
+
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    async def test_401_raises_screening_auth_error(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(401, json={}))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningAuthError):
+                    await c.scan_payment_fields("https://x", "", "")
+
+    @pytest.mark.asyncio
+    async def test_401_is_not_retried(self) -> None:
+        with respx.mock:
+            route = respx.post(SCREEN_URL).mock(return_value=httpx.Response(401, json={}))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningAuthError):
+                    await c.scan_payment_fields("https://x", "", "")
+        assert route.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_429_raises_rate_limit_error_with_retry_after(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(
+                return_value=httpx.Response(429, headers={"Retry-After": "1800"}, json={})
+            )
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningRateLimitError) as excinfo:
+                    await c.scan_payment_fields("https://x", "", "")
+        assert excinfo.value.retry_after == 1800
+
+    @pytest.mark.asyncio
+    async def test_429_without_retry_after_header(self) -> None:
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(429, json={}))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningRateLimitError) as excinfo:
+                    await c.scan_payment_fields("https://x", "", "")
+        assert excinfo.value.retry_after is None
+
+    @pytest.mark.asyncio
+    async def test_other_4xx_raises_unavailable(self) -> None:
+        # 400 is non-retriable per contract — client surfaces as unavailable.
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(400, json={}))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningUnavailableError):
+                    await c.scan_payment_fields("https://x", "", "")
+
+
+class TestRetry:
+    @pytest.mark.asyncio
+    async def test_500_then_200_succeeds(self) -> None:
+        with respx.mock:
+            route = respx.post(SCREEN_URL)
+            route.side_effect = [
+                httpx.Response(500, json={}),
+                httpx.Response(200, json=_ok_body()),
+            ]
+            async with ScreeningClient(BASE, API_KEY) as c:
+                url, _, _, _ = await c.scan_payment_fields("https://x", "", "")
+        assert url == "https://api.example.com/u/<EMAIL_ADDRESS>"
+        assert route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_500_twice_raises_unavailable(self) -> None:
+        with respx.mock:
+            route = respx.post(SCREEN_URL).mock(return_value=httpx.Response(503, json={}))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningUnavailableError):
+                    await c.scan_payment_fields("https://x", "", "")
+        assert route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_network_error_then_200_succeeds(self) -> None:
+        with respx.mock:
+            route = respx.post(SCREEN_URL)
+            route.side_effect = [
+                httpx.ConnectError("connection refused"),
+                httpx.Response(200, json=_ok_body()),
+            ]
+            async with ScreeningClient(BASE, API_KEY) as c:
+                url, _, _, _ = await c.scan_payment_fields("https://x", "", "")
+        assert url == "https://api.example.com/u/<EMAIL_ADDRESS>"
+        assert route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_network_error_twice_raises_unavailable(self) -> None:
+        with respx.mock:
+            route = respx.post(SCREEN_URL).mock(
+                side_effect=httpx.ConnectError("connection refused")
+            )
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningUnavailableError):
+                    await c.scan_payment_fields("https://x", "", "")
+        assert route.call_count == 2


### PR DESCRIPTION
## Summary
- New `ScreeningClient` (`src/presidio_x402/screening_client.py`) speaking the frozen v0.4.0 wire contract (`X-API-Key`, 10s/3s timeouts, single 500ms retry on 5xx / network error).
- `HardenedX402Client` gains `screening_client=` + `remote_screening=` kwargs. When `remote_screening=True`, payment-metadata scanning is delegated to the service instead of the local `PIIFilter`; local `PIIFilter` is still used for exception-message scrubbing (defence-in-depth if the service goes down).
- New exceptions: `ScreeningError`, `ScreeningAuthError`, `ScreeningRateLimitError` (with `retry_after`), `ScreeningUnavailableError`.

## Test plan
- [x] `tests/test_screening_client.py` — 17 tests: construction guards, happy-path payload + headers, 401/429/400 mapping, `Retry-After` parsing, 5xx single-retry, network-error single-retry
- [x] `tests/test_gateway_remote_screening.py` — 6 tests: constructor guards, end-to-end 402 flow via service, block-mode behaviour on remote-detected PII, entities allowlist forwarded, service 401/5xx surface up through the gateway
- [x] Full suite: 252 passed
- [x] `ruff check` + `ruff format --check` clean across `src/` + `tests/`