### PR TITLE
docs: point to published SDLC

### DIFF
--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -308,3 +308,8 @@ The threat model for presidio-hardened-x402 addresses the following adversaries:
 - **Zero-trust metadata**: All payment metadata is treated as untrusted until scanned.
 - **Fail-safe**: Security control errors default to blocking the payment, not allowing it.
 - **Observable**: Every security decision is audited; no silent suppression.
+
+## SDLC
+
+These requirements are delivered under the family-wide Presidio SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/README.md
+++ b/README.md
@@ -326,3 +326,10 @@ See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 ## License
 
 MIT
+
+---
+
+## SDLC
+
+This repository is developed under the Presidio hardened-family SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,3 +68,9 @@ See `PRESIDIO-REQ.md` for the full threat model and security design rationale.
   only (emails, SSNs, credit cards, phone numbers) and may miss free-text PII
 - The in-memory replay guard does not persist across process restarts; use the Redis
   backend for production deployments requiring cross-process deduplication
+
+## Software Development Lifecycle
+
+This repository is developed under the Presidio hardened-family SDLC. The public report
+— scope, standards mapping, threat-model gates, and supply-chain controls — is at
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.


### PR DESCRIPTION
## Summary

- Add pointers to the published family SDLC in README.md, SECURITY.md, and PRESIDIO-REQ.md.
- SECURITY.md Reporting section already matches the family pattern; no change there.
- SDLC: https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md

## Test plan

- [x] Diff scoped to docs files; no source or workflow changes
- [x] Links render on GitHub