### PR TITLE
security: close audit findings F1-F5 + cryptography CVE chain

### DIFF
--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -106,7 +106,7 @@ explicitly deferred.*
 
 ### Publication
 
-- arXiv cs.CR preprint by 2026-11-01
+- arXiv cs.CR preprint — **delivered**: [arXiv:2604.11430](https://arxiv.org/abs/2604.11430)
 - Conference paper submission (USENIX Security 2027 or IEEE S&P 2027) after live
   data replication in v0.2.1
 
@@ -195,6 +195,13 @@ on controlled data with known ground truth, then confirm the threat model on liv
 
 - `docs/soc2-reference-architecture.md`: SOC 2 TSC mapping, three deployment patterns,
   audit log retention, GDPR obligations, secret management guidance, evidence collection table
+
+### Anchor project within PRESIDIO SDLC — delivered
+
+- `presidio-hardened-x402` serves as the canonical reference implementation for the
+  PRESIDIO SDLC: the `sdlc/` documentation set (14 docs + 6 ADRs + JSON inventory)
+  lives in the outer repo and is kept aligned with the codebase via the
+  data-inventory drift test that blocks PR merge.
 
 ### New exceptions
 

--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ All exceptions are importable from `presidio_x402`.
 | Version | Milestone |
 |---------|-----------|
 | v0.1.0 | PII redaction + spending policy + replay detection |
-| v0.2.0 | Synthetic corpus + 42-configuration precision/recall sweep, LangChain/CrewAI adapters, compliance report · [arXiv preprint (pending)](https://arxiv.org/abs/2504.xxxxx) |
-| v0.2.1 | Live ecosystem characterisation via Dune Analytics (20 projects, 96 wallets, 11 chains, ≥79M transactions); IEEE S&P magazine article submitted; IEEE TIFS paper under review |
+| v0.2.0 | Synthetic corpus + 42-configuration precision/recall sweep, LangChain/CrewAI adapters, compliance report · [arXiv:2604.11430](https://arxiv.org/abs/2604.11430) |
+| v0.2.1 | Live ecosystem characterisation via Dune Analytics (20 projects, 96 wallets, 11 chains, ≥79M transactions); IEEE S&P magazine article submitted; IEEE TIFS paper under review · Corpus: [`v0.2.1/dataport/`](v0.2.1/dataport/), [Hugging Face](https://huggingface.co/datasets/vstantch/x402-pii-corpus), [IEEE DataPort (doi:10.21227/kpsz-nq73)](https://doi.org/10.21227/kpsz-nq73) |
 | **v0.3.0** | **Multi-party authorization** (`mpa.py`: n-of-m, webhook + crypto modes) · **Policy-as-code** JSON Schema (IETF draft candidate) · **Prometheus metrics** exporter · Kubernetes Helm chart + Docker image · SOC2 reference architecture — **current** |
 | v0.4.0 | Production hardening: security audit, OpenTelemetry spans, policy hot-reload, operator runbook |
 | v0.5.0 | **SLO payment broker** — x402 micropayments as runtime infrastructure bids; `presidio-hardened-arch-translucency` integration |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
     "httpx>=0.27.0",
     "presidio-analyzer>=2.2.0",
     "presidio-anonymizer>=2.2.0",
+    # Transitive of presidio-analyzer; pin minimum to evict 6 CVEs in 41.x
+    # (CVE-2024-0727, CVE-2023-50782, GHSA-h4gh-qq45-vh27, PYSEC-2024-225,
+    # CVE-2026-26007, CVE-2026-34073). Audit 2026-04-26.
+    "cryptography>=46.0.6",
 ]
 
 [project.optional-dependencies]

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -91,10 +91,15 @@ logger = logging.getLogger("presidio_x402")
 # ---------------------------------------------------------------------------
 # On-import security audit
 # ---------------------------------------------------------------------------
-_KNOWN_VULNERABLE: dict[str, dict[str, str]] = {
-    "httpx": {},
-    "presidio-analyzer": {},
-    "presidio-anonymizer": {},
+# Minimum-safe versions per PRESIDIO-REQ.md REQ-6. Bumped when a CVE / security
+# advisory lands or when the upstream project marks a version as vulnerable.
+# Keys are PyPI distribution names; values are the lowest version known not to
+# carry an unfixed advisory at the time of this release.
+_KNOWN_VULNERABLE: dict[str, str] = {
+    "httpx": "0.27.0",
+    "presidio-analyzer": "2.2.362",
+    "presidio-anonymizer": "2.2.362",
+    "cryptography": "46.0.6",
 }
 
 
@@ -102,19 +107,39 @@ def _on_import_audit() -> None:
     try:
         from importlib.metadata import PackageNotFoundError, version
 
+        try:
+            from packaging.version import InvalidVersion as _InvalidVersion
+            from packaging.version import Version as _Version
+        except ImportError:  # pragma: no cover - packaging ships with pip
+            _Version = None  # noqa: N806 - aliasing imported class symbol
+            _InvalidVersion = Exception  # noqa: N806 - aliasing imported class symbol
+
         issues: list[str] = []
-        for pkg in _KNOWN_VULNERABLE:
+        for pkg, min_safe in _KNOWN_VULNERABLE.items():
             try:
                 ver = version(pkg)
-                logger.debug("Dependency OK: %s==%s", pkg, ver)
             except PackageNotFoundError:
                 issues.append(f"{pkg} is not installed")
+                continue
+            if _Version is None:
+                logger.debug("Dependency present (version compare unavailable): %s==%s", pkg, ver)
+                continue
+            try:
+                if _Version(ver) < _Version(min_safe):
+                    issues.append(
+                        f"{pkg}=={ver} is below minimum-safe version {min_safe} "
+                        "(see PRESIDIO-REQ §REQ-6)"
+                    )
+                else:
+                    logger.debug("Dependency OK: %s==%s (>= %s)", pkg, ver, min_safe)
+            except _InvalidVersion:
+                logger.debug("Dependency version unparseable: %s==%s", pkg, ver)
 
         if issues:
             for issue in issues:
                 logger.warning("[PRESIDIO AUDIT] %s", issue)
         else:
-            logger.info("[PRESIDIO AUDIT] All x402 dependencies present")
+            logger.info("[PRESIDIO AUDIT] All x402 dependencies present at minimum-safe versions")
 
     except Exception:
         logger.debug("Dependency audit skipped")

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -162,6 +163,12 @@ def _amount_to_usd(amount: str, currency: str) -> float:
         value = float(amount)
     except ValueError as exc:
         raise X402PaymentError(f"Invalid payment amount {amount!r}: not a numeric value") from exc
+    if not math.isfinite(value) or value < 0:
+        raise X402PaymentError(
+            f"Invalid payment amount {amount!r}: must be a finite non-negative number. "
+            "Non-finite values (nan, inf, -inf) bypass IEEE 754 comparison-based limit checks "
+            "and are rejected to preserve policy enforcement integrity."
+        )
     if currency.upper() not in _USD_PEGGED:
         raise X402PaymentError(
             f"Unsupported currency {currency!r} for policy enforcement. "
@@ -389,6 +396,15 @@ class HardenedX402Client:
         """
         amount_usd = _amount_to_usd(details.amount, details.currency)
 
+        # Preserve the original resource_url for replay-guard fingerprinting.
+        # In pii_action="redact" mode the URL gets rewritten with PII tokens
+        # masked; using the redacted URL for fingerprinting would collide
+        # distinct user-specific URLs (e.g. /user/alice@.../pay vs
+        # /user/bob@.../pay both reduce to /user/<EMAIL_ADDRESS>/pay) and
+        # produce false-positive ReplayDetectedError. Original URL is never
+        # passed downstream to signer / MPA — only used for the local HMAC.
+        original_resource_url = details.resource_url
+
         # ------------------------------------------------------------------
         # 1. PII Filter (local regex/NLP or remote screening service)
         # ------------------------------------------------------------------
@@ -440,13 +456,16 @@ class HardenedX402Client:
                 )
                 if self._metrics:
                     self._metrics.record_pii_detection(entity_types, "redact")
-                # Replace metadata fields with redacted versions
+                # Replace metadata fields with redacted versions.
+                # resource_url is replaced AFTER replay-fingerprint computation
+                # earlier in this function so the original URL still drives
+                # deduplication; from this point on every downstream consumer
+                # (signer, MPA webhooks, audit log post-event) sees clean_url.
                 details = replace(
                     details,
+                    resource_url=clean_url,
                     description=clean_desc,
                     reason=clean_reason,
-                    # Note: resource_url is used for fingerprinting with ORIGINAL value
-                    # but we pass clean_url to the signer to avoid PII in the chain
                 )
             elif self._metrics:
                 # pii_action == "warn": log already happened in PIIFilter
@@ -497,7 +516,7 @@ class HardenedX402Client:
         # 4. Replay Guard
         # ------------------------------------------------------------------
         fingerprint = compute_fingerprint(
-            resource_url=details.resource_url,  # use ORIGINAL URL for fingerprinting
+            resource_url=original_resource_url,  # ORIGINAL URL — see top of method
             pay_to=details.pay_to,
             amount=details.amount,
             currency=details.currency,

--- a/src/presidio_x402/replay_guard.py
+++ b/src/presidio_x402/replay_guard.py
@@ -52,10 +52,12 @@ def _load_fingerprint_key() -> bytes:
             )
             return secrets.token_bytes(32)
         return key
-    logger.warning(
+    logger.error(
         "%s not set — replay guard uses a per-process key and will NOT detect "
         "replays across load-balanced replicas. Set this env var (32-byte hex) "
-        "in all replicas to enable cross-process deduplication.",
+        "in all replicas to enable cross-process deduplication. This message is "
+        "ERROR-level rather than WARNING because the default is silently insecure "
+        "in any horizontally-scaled deployment; treat as a deployment-time defect.",
         _FINGERPRINT_KEY_ENV,
     )
     return secrets.token_bytes(32)

--- a/src/presidio_x402/screening_client.py
+++ b/src/presidio_x402/screening_client.py
@@ -68,6 +68,12 @@ class ScreeningClient:
     httpx_client:
         Optional pre-configured ``httpx.AsyncClient`` (useful for tests or for
         sharing a connection pool with the gateway).
+    allow_insecure:
+        Allow ``http://`` base URLs for local development. Defaults to ``False``.
+        With the default, an ``http://`` ``base_url`` raises :class:`ValueError` at
+        construction time so a typo cannot silently transmit the ``X-API-Key`` header
+        in cleartext to a production hostname. Set to ``True`` only for ``localhost`` /
+        ``127.0.0.1`` development testing.
     """
 
     def __init__(
@@ -77,11 +83,29 @@ class ScreeningClient:
         *,
         timeout: httpx.Timeout | float | None = None,
         httpx_client: httpx.AsyncClient | None = None,
+        allow_insecure: bool = False,
     ) -> None:
         if not base_url:
             raise ValueError("ScreeningClient requires a non-empty base_url")
         if not api_key:
             raise ValueError("ScreeningClient requires a non-empty api_key")
+        scheme = base_url.split("://", 1)[0].lower() if "://" in base_url else ""
+        if scheme == "http" and not allow_insecure:
+            raise ValueError(
+                f"ScreeningClient base_url uses http:// ({base_url!r}); the X-API-Key "
+                "header would be transmitted in cleartext. Use https:// for production, "
+                "or pass allow_insecure=True to opt into plaintext for local development."
+            )
+        if scheme == "http" and allow_insecure:
+            logger.warning(
+                "ScreeningClient configured with http:// base_url %r and allow_insecure=True. "
+                "X-API-Key is sent in cleartext. Use only for local development.",
+                base_url,
+            )
+        elif scheme not in {"https", "http"}:
+            raise ValueError(
+                f"ScreeningClient base_url must start with https:// or http://; got {base_url!r}"
+            )
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -324,3 +324,93 @@ async def test_post_method_works():
         async with _make_client() as client:
             resp = await client.post("https://api.example.com/v1/data")
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Amount validation — F1 regression (audit 2026-04-26)
+# ---------------------------------------------------------------------------
+
+
+def _amount_header(amount: str) -> str:
+    return json.dumps(
+        {
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "base-sepolia",
+                    "maxAmountRequired": amount,
+                    "resource": "https://api.example.com/v1/data",
+                    "description": "API data access",
+                    "payTo": "0xabcdef1234567890abcdef1234567890abcdef12",
+                    "requiredDeadlineSeconds": 300,
+                }
+            ]
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_amount", ["nan", "NaN", "inf", "-inf", "Infinity", "-1.0"])
+async def test_non_finite_or_negative_amount_rejected(bad_amount):
+    """Non-finite / negative amounts must not silently bypass policy limits.
+
+    `float("nan") > limit` is False under IEEE 754, which previously let NaN /
+    inf payments pass per-call, daily, and per-endpoint comparison checks.
+    Audit 2026-04-26 finding F1.
+    """
+    with respx.mock:
+        respx.get("https://api.example.com/v1/data").mock(
+            return_value=httpx.Response(402, headers={"X-PAYMENT": _amount_header(bad_amount)})
+        )
+        async with _make_client(policy={"max_per_call_usd": 0.01}) as client:
+            with pytest.raises(X402PaymentError, match="finite non-negative"):
+                await client.get("https://api.example.com/v1/data")
+
+
+# ---------------------------------------------------------------------------
+# resource_url redaction — F2 regression (audit 2026-04-26)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redact_strips_pii_from_resource_url_before_signer():
+    """In pii_action='redact' mode, the signer must receive the redacted URL,
+    not the original PII-bearing one. Audit 2026-04-26 finding F2.
+    """
+    captured: dict[str, PaymentDetails] = {}
+
+    async def capturing_signer(details: PaymentDetails) -> PaymentResponse:
+        captured["details"] = details
+        return PaymentResponse(token="signed", details=details)  # noqa: S106
+
+    pii_url = "https://api.example.com/user/alice@example.com/pay"
+    pii_header = json.dumps(
+        {
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "base-sepolia",
+                    "maxAmountRequired": "0.01",
+                    "resource": pii_url,
+                    "description": "user alice@example.com",
+                    "payTo": "0xabcdef1234567890abcdef1234567890abcdef12",
+                    "requiredDeadlineSeconds": 300,
+                }
+            ]
+        }
+    )
+    with respx.mock:
+        route = respx.get(pii_url)
+        route.side_effect = [
+            httpx.Response(402, headers={"X-PAYMENT": pii_header}),
+            httpx.Response(200, text="ok"),
+        ]
+        async with _make_client(payment_signer=capturing_signer, pii_action="redact") as client:
+            await client.get(pii_url)
+
+    assert "details" in captured, "signer was not invoked"
+    signed_url = captured["details"].resource_url
+    assert "alice@example.com" not in signed_url, signed_url
+    # Some redaction marker must be present — exact token depends on PIIFilter
+    # config (e.g. "<REDACTED>" for resource_url path, "<EMAIL_ADDRESS>" elsewhere).
+    assert "<" in signed_url and ">" in signed_url, signed_url

--- a/tests/test_screening_client.py
+++ b/tests/test_screening_client.py
@@ -58,6 +58,26 @@ class TestInit:
         # Not public, but the stripped prefix is what matters for URL concat.
         assert c._base_url == BASE
 
+    def test_http_base_url_rejected_by_default(self) -> None:
+        """Audit 2026-04-26 finding F4: a typo'd http:// base_url must not
+        silently transmit the X-API-Key header in cleartext.
+        """
+        with pytest.raises(ValueError, match="cleartext|allow_insecure"):
+            ScreeningClient(base_url="http://screen.presidio-group.eu", api_key=API_KEY)
+
+    def test_http_base_url_allowed_with_allow_insecure(self) -> None:
+        """allow_insecure=True opt-in is honoured for local development."""
+        c = ScreeningClient(
+            base_url="http://localhost:8080",
+            api_key=API_KEY,
+            allow_insecure=True,
+        )
+        assert c._base_url == "http://localhost:8080"
+
+    def test_unknown_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="https://"):
+            ScreeningClient(base_url="ftp://example.com", api_key=API_KEY)
+
 
 class TestHappyPath:
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1011,7 +1011,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2977,6 +2977,7 @@ name = "presidio-hardened-x402"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "httpx" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
@@ -3015,6 +3016,7 @@ schema = [
 [package.metadata]
 requires-dist = [
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.28.0" },
+    { name = "cryptography", specifier = ">=46.0.6" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.23" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.21.0" },


### PR DESCRIPTION
## Summary

Close all five findings from the 2026-04-26 Felix audit (CRITICAL → LOW) and evict the transitive `cryptography` 41.x CVE chain.

- **F1 (CRITICAL CWE-20):** reject non-finite / negative payment amounts in `_amount_to_usd`. `float("nan")` previously bypassed every comparison-based policy limit and corrupted `_SpendLedger` totals via IEEE 754 propagation.
- **F2 (MEDIUM CWE-200):** redact `resource_url` before signer + MPA webhook payloads. Capture the original URL once at the top of `_apply_security_controls` so replay-guard fingerprinting still uses the unique pre-redaction URL while every downstream consumer sees the redacted form.
- **F3 (MEDIUM CWE-693):** elevate the `PRESIDIO_X402_FINGERPRINT_KEY`-unset fallback log from WARNING to ERROR. Hard startup-gate tracked for v0.5.0.
- **F4 (MEDIUM CWE-319):** reject `http://` in `ScreeningClient.base_url` by default; opt-in `allow_insecure` for local dev.
- **F5 (LOW REQ-6):** populate `_KNOWN_VULNERABLE` with minimum-safe versions and compare via `packaging.version.Version` on import.
- Pin `cryptography>=46.0.6` directly to evict CVE-2026-34073 (CRITICAL) and 5 other CVEs in 41.x.

Audit response: `security-audit/audit-response-2026-04-26.md` (in the outer repo).

## Test plan

- [x] `ruff check src/presidio_x402/ tests/` — clean
- [x] `ruff format --check src/presidio_x402/ tests/` — clean
- [x] `pytest tests/` — 262 passing (was 252; +10 regression cases for F1, F2, F4)
- [ ] CI green on this branch