### PR TITLE
deps: bump langchain-core 1.3.0 -> 1.3.3 (CVE-2026-44843)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,11 @@ redis = [
     "redis>=5.0.0",
 ]
 langchain = [
-    "langchain-core>=0.1.0",
+    # >=1.3.3 closes CVE-2026-44843 (GHSA-pjwx-r37v-7724) — unsafe broad-allowlist
+    # deserialization in older runtime paths (RunnableWithMessageHistory,
+    # astream_log, astream_events(version="v1")). The 0.3.x line gets the same
+    # fix at 0.3.85.
+    "langchain-core>=1.3.3",
 ]
 crewai = [
     "crewai>=0.28.0",

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -100,6 +100,11 @@ _KNOWN_VULNERABLE: dict[str, str] = {
     "presidio-analyzer": "2.2.362",
     "presidio-anonymizer": "2.2.362",
     "cryptography": "46.0.6",
+    # CVE-2026-44843 / GHSA-pjwx-r37v-7724 — unsafe deserialization in
+    # RunnableWithMessageHistory, astream_log, astream_events(version="v1").
+    # 1.3.3 (1.x line) and 0.3.85 (0.3.x line) carry the fix; pinning the
+    # 1.3.3 floor here is correct for our optional [langchain] extra.
+    "langchain-core": "1.3.3",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1711,10 +1711,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1723,9 +1724,21 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3034,7 +3034,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.21.0" },
     { name = "jsonschema", marker = "extra == 'schema'", specifier = ">=4.21.0" },
-    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.1.0" },
+    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3" },
     { name = "presidio-analyzer", specifier = ">=2.2.0" },
     { name = "presidio-anonymizer", specifier = ">=2.2.0" },
     { name = "prometheus-client", marker = "extra == 'dev'", specifier = ">=0.20.0" },


### PR DESCRIPTION
## Summary
- Bumps `langchain-core` from 1.3.0 to 1.3.3 to close Dependabot alert #3 (GHSA-pjwx-r37v-7724, CVE-2026-44843, HIGH / CVSS 8.2 — unsafe deserialization of attacker-controlled objects via overly broad `load()` allowlists in older LangChain runtime paths).
- Tightens the `[langchain]` optional extra from `>=0.1.0` to `>=1.3.3` so downstream `pip install presidio-hardened-x402[langchain]` cannot resolve a vulnerable version.
- Adds `langchain-core: 1.3.3` to `_KNOWN_VULNERABLE` so the on-import audit warns if a deployment drifts back below the fix line.

## Code exposure
None. The only langchain reference in this repo is `src/presidio_x402/adapters/langchain.py`, which subclasses `langchain_core.tools.BaseTool` and forwards `_arun` to `HardenedX402Client._request`. It does not call any of the vulnerable APIs (`RunnableWithMessageHistory`, `astream_log`, `astream_events(version=\"v1\")`, `load`, `loads`, `dumps`, `dumpd`). The bump exists to clear the lock and prevent downstream installs from picking up a vulnerable resolution.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `pytest tests/` — 271 passed
- [x] `python -c "import presidio_x402"` — on-import audit reports `langchain-core is not installed` (correct; optional extra not in dev venv)
- [ ] CI green on this PR
- [ ] Dependabot alert #3 auto-closes after merge