### PR TITLE
security: close audit findings F-C, F-D, F-E (2026-05-10)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,5 +29,4 @@ jobs:
           bandit -r src/ \
             --severity-level medium \
             --confidence-level medium \
-            -f txt \
-            --exit-zero
+            -f txt

--- a/src/presidio_x402/replay_guard.py
+++ b/src/presidio_x402/replay_guard.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
 import logging
 import os
 import secrets
@@ -93,8 +94,12 @@ def compute_fingerprint(
         Payment deadline (seconds). Payments with different deadlines are
         considered distinct to avoid false positives on retried expired payments.
     """
-    canonical = "|".join([resource_url, pay_to, amount, currency, str(deadline_seconds)])
-    return hmac.new(_FINGERPRINT_KEY, canonical.encode(), hashlib.sha256).hexdigest()
+    canonical = json.dumps(
+        [resource_url, pay_to, amount, currency, deadline_seconds],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hmac.new(_FINGERPRINT_KEY, canonical, hashlib.sha256).hexdigest()
 
 
 class _MemoryStore:
@@ -179,7 +184,11 @@ class ReplayGuard:
         fingerprint and returns normally.
         """
         if not self._store.check_and_set(fingerprint, self.ttl):
-            logger.warning("Replay detected: fingerprint %s...", fingerprint[:16])
+            logger.error(
+                "Replay detected: fingerprint %s...",
+                fingerprint[:16],
+                extra={"event": "REPLAY_DETECTED", "fingerprint": fingerprint[:16]},
+            )
             raise ReplayDetectedError(
                 f"Duplicate payment detected (fingerprint: {fingerprint[:16]}…)",
                 fingerprint=fingerprint,

--- a/tests/test_replay_guard.py
+++ b/tests/test_replay_guard.py
@@ -42,6 +42,17 @@ class TestComputeFingerprint:
         assert len(fp) == 64  # SHA-256 hex is 64 chars
         int(fp, 16)  # should not raise
 
+    def test_pipe_in_resource_url_does_not_collide_with_other_tuples(self):
+        # F-D regression: prior `"|".join(...)` canonicalisation was ambiguous
+        # under server-controlled `resource_url`. JSON-array canonicalisation
+        # must produce distinct fingerprints for these structurally distinct
+        # tuples even though the legacy pipe-joined forms were identical.
+        fp_attacker = compute_fingerprint(
+            "https://a.com/x|0xLegit|1.00|USDC", "300", "0.00", "USDC", 0
+        )
+        fp_legit = compute_fingerprint("https://a.com/x", "0xLegit", "1.00", "USDC", 300)
+        assert fp_attacker != fp_legit
+
 
 class TestReplayGuardMemory:
     def setup_method(self):


### PR DESCRIPTION
## Summary
- **F-C (HIGH, CWE-693)**: remove `--exit-zero` from Bandit step in `.github/workflows/codeql.yml` so MEDIUM+ findings now fail CI (subsumes stale backlog F045).
- **F-D (LOW, CWE-20)**: replace `|`-joined canonical fingerprint in `replay_guard.compute_fingerprint` with `json.dumps([...])` to remove delimiter-injection ambiguity via server-controlled `resource_url`.
- **F-E (LOW, CWE-778)**: elevate replay-detection log from WARNING to ERROR with structured `extra={event, fingerprint}` so SIEMs alerting at ERROR+ no longer drop active-attack signals.

Closes Felix's 2026-05-10 audit findings; risk level MEDIUM → LOW. Disposition + action plan at `security-audit/audit-response-2026-05-10.md` in the outer repo.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `pytest tests/` — 272 passed (was 271; +1 for `test_pipe_in_resource_url_does_not_collide_with_other_tuples`)
- [ ] CI: Bandit job runs without `--exit-zero` and reports zero MEDIUM+ findings
- [ ] CI: full matrix green on PR