### PR TITLE
security: bump langsmith 0.7.32 → 0.8.4 (CVE-2026-45134)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1743,7 +1743,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.32"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1756,9 +1756,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/e9/4ceeba766bae47de1a6ecdaa4024d10eff63eed936796b77005742399e8d/langsmith-0.8.4.tar.gz", hash = "sha256:989b387f6ff92ec5f9d14c0edb333e2579590cad5a1ca07042d924b0ec43cd10", size = 4460243, upload-time = "2026-05-13T21:00:59.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
+    { url = "https://files.pythonhosted.org/packages/db/94/8b872959ea529ecfbbe2c3f91d9ebf98cb8dbd9e3f7487bc134740d3d235/langsmith-0.8.4-py3-none-any.whl", hash = "sha256:4e334ab223d10129c9943c461d95fa9089523638ea29cd048045a7f99b973f50", size = 398701, upload-time = "2026-05-13T21:00:57.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Closes Dependabot High-severity alert for **CVE-2026-45134** (GHSA-3644-q5cj-c5c7) — *LangSmith SDK: public prompt pull deserializes untrusted manifests without trust boundary warning*.
- Bumps `langsmith` `0.7.32 → 0.8.4` in `uv.lock` (first patched version is `0.8.0`).
- Lockfile-only change; `langchain` / `langchain-classic` (also named in the CVE) are not in this lockfile, so no other packages are affected.

## Test plan
- [x] `ruff check src/ tests/` — passed
- [x] `ruff format --check src/ tests/` — 32 files clean
- [x] `pytest tests/` — all pass (2 skipped); `test_adapters.py` langchain stub exercised against 0.8.4
- [x] `uv lock --locked` — no lockfile drift