### PR TITLE
security: close audit findings F1, F2, F3 (2026-05-17)

### DIFF
--- a/src/presidio_x402/audit_log.py
+++ b/src/presidio_x402/audit_log.py
@@ -71,6 +71,13 @@ if _chain_key_hex:
         )
     logger.debug("AuditLog: loaded persistent chain key from PRESIDIO_X402_CHAIN_KEY")
 else:
+    logger.error(
+        "PRESIDIO_X402_CHAIN_KEY not set — audit HMAC chain is process-scoped "
+        "and cross-session tamper detection is disabled. Set this env var "
+        "(32-byte hex) in production. This message is ERROR-level rather than "
+        "WARNING because the default is silently insecure in any deployment "
+        "that survives a process restart; treat as a deployment-time defect."
+    )
     _CHAIN_KEY = secrets.token_bytes(32)
 
 

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -75,6 +75,12 @@ _SUPPORTED_SCHEME = "exact"
 # signing-key material, wallet addresses) — truncation caps blast radius.
 _SAFE_EXC_MESSAGE_MAX = 80
 
+# Max byte length of the raw X-PAYMENT header before JSON parsing. A malicious
+# 402 server could otherwise force the client to allocate arbitrary memory in
+# json.loads before any security control fires. 64 KiB is multiple orders of
+# magnitude above any legitimate x402 accepts payload.
+_PAYMENT_HEADER_MAX_BYTES = 65_536
+
 
 def _safe_exc_message(exc: BaseException, max_len: int = _SAFE_EXC_MESSAGE_MAX) -> str:
     msg = str(exc)
@@ -107,6 +113,10 @@ def _parse_402_header(header_value: str) -> PaymentDetails:
           }]
         }
     """
+    if len(header_value.encode("utf-8")) > _PAYMENT_HEADER_MAX_BYTES:
+        raise X402PaymentError(
+            f"X-PAYMENT header exceeds maximum length of {_PAYMENT_HEADER_MAX_BYTES} bytes"
+        )
     try:
         data = json.loads(header_value)
     except json.JSONDecodeError as exc:

--- a/src/presidio_x402/replay_guard.py
+++ b/src/presidio_x402/replay_guard.py
@@ -94,8 +94,13 @@ def compute_fingerprint(
         Payment deadline (seconds). Payments with different deadlines are
         considered distinct to avoid false positives on retried expired payments.
     """
+    # Canonicalise case-insensitive fields before serialisation. EVM addresses
+    # are case-insensitive (EIP-55 checksum is optional); a server that returns
+    # the same `pay_to` in mixed case across retries would otherwise produce
+    # distinct fingerprints and bypass replay detection. Currency tickers are
+    # conventionally uppercase but not enforced by the 402 spec.
     canonical = json.dumps(
-        [resource_url, pay_to, amount, currency, deadline_seconds],
+        [resource_url, pay_to.lower(), amount, currency.upper(), deadline_seconds],
         separators=(",", ":"),
         ensure_ascii=False,
     ).encode("utf-8")

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -233,6 +233,23 @@ class TestChainKeyFromEnv:
         with pytest.raises(ValueError, match="exactly 32 bytes"):
             importlib.reload(al_mod)
 
+    def test_missing_env_key_logs_error(self, monkeypatch, caplog):
+        # F2 regression (2026-05-17): when PRESIDIO_X402_CHAIN_KEY is unset,
+        # the silent fallback to a per-process key must emit an ERROR-level
+        # log so operators get the same deployment-defect signal that
+        # replay_guard.py emits for its equivalent env var.
+        import logging
+
+        monkeypatch.delenv("PRESIDIO_X402_CHAIN_KEY", raising=False)
+        import presidio_x402.audit_log as al_mod
+
+        with caplog.at_level(logging.ERROR, logger="presidio_x402.audit_log"):
+            importlib.reload(al_mod)
+        assert any(
+            "PRESIDIO_X402_CHAIN_KEY" in rec.message and rec.levelno == logging.ERROR
+            for rec in caplog.records
+        )
+
     def teardown_method(self, method):
         # Reload without env var so other tests get a fresh ephemeral key
         os.environ.pop("PRESIDIO_X402_CHAIN_KEY", None)

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -213,14 +213,14 @@ class TestChainKeyFromEnv:
 
         key_hex = secrets.token_bytes(32).hex()
         monkeypatch.setenv("PRESIDIO_X402_CHAIN_KEY", key_hex)
-        import presidio_x402.audit_log as al_mod
+        from presidio_x402 import audit_log as al_mod
 
         importlib.reload(al_mod)
         assert bytes.fromhex(key_hex) == al_mod._CHAIN_KEY
 
     def test_invalid_hex_env_key_raises(self, monkeypatch):
         monkeypatch.setenv("PRESIDIO_X402_CHAIN_KEY", "not-valid-hex!!")
-        import presidio_x402.audit_log as al_mod
+        from presidio_x402 import audit_log as al_mod
 
         with pytest.raises(ValueError, match="64-character hex string"):
             importlib.reload(al_mod)
@@ -228,7 +228,7 @@ class TestChainKeyFromEnv:
     def test_wrong_length_env_key_raises(self, monkeypatch):
         # Valid hex but only 16 bytes (32 hex chars) — too short
         monkeypatch.setenv("PRESIDIO_X402_CHAIN_KEY", "aa" * 16)
-        import presidio_x402.audit_log as al_mod
+        from presidio_x402 import audit_log as al_mod
 
         with pytest.raises(ValueError, match="exactly 32 bytes"):
             importlib.reload(al_mod)
@@ -241,7 +241,7 @@ class TestChainKeyFromEnv:
         import logging
 
         monkeypatch.delenv("PRESIDIO_X402_CHAIN_KEY", raising=False)
-        import presidio_x402.audit_log as al_mod
+        from presidio_x402 import audit_log as al_mod
 
         with caplog.at_level(logging.ERROR, logger="presidio_x402.audit_log"):
             importlib.reload(al_mod)
@@ -253,6 +253,6 @@ class TestChainKeyFromEnv:
     def teardown_method(self, method):
         # Reload without env var so other tests get a fresh ephemeral key
         os.environ.pop("PRESIDIO_X402_CHAIN_KEY", None)
-        import presidio_x402.audit_log as al_mod
+        from presidio_x402 import audit_log as al_mod
 
         importlib.reload(al_mod)

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -137,6 +137,22 @@ async def test_malformed_x_payment_header_raises_x402_error():
 
 
 @pytest.mark.asyncio
+async def test_oversized_x_payment_header_raises_before_json_parse():
+    # F3 regression (2026-05-17): a hostile 402 server could return a
+    # multi-megabyte X-PAYMENT header and force json.loads to allocate memory
+    # before any security control fires. The header length must be checked
+    # before parsing.
+    oversized = "x" * 70_000  # > 65 KiB limit
+    with respx.mock:
+        respx.get("https://api.example.com/v1/data").mock(
+            return_value=httpx.Response(402, headers={"X-PAYMENT": oversized})
+        )
+        async with _make_client() as client:
+            with pytest.raises(X402PaymentError, match="exceeds maximum length"):
+                await client.get("https://api.example.com/v1/data")
+
+
+@pytest.mark.asyncio
 async def test_unsupported_scheme_raises_x402_error():
     header = json.dumps({"accepts": [{"scheme": "unknown-scheme", "network": "base-sepolia"}]})
     with respx.mock:

--- a/tests/test_replay_guard.py
+++ b/tests/test_replay_guard.py
@@ -42,6 +42,27 @@ class TestComputeFingerprint:
         assert len(fp) == 64  # SHA-256 hex is 64 chars
         int(fp, 16)  # should not raise
 
+    def test_pay_to_case_variants_produce_same_fingerprint(self):
+        # F1 regression (2026-05-17): EVM addresses are case-insensitive at the
+        # protocol level. A malicious 402 server retrying with `pay_to` toggled
+        # between checksummed and lower-case would otherwise bypass replay
+        # detection. Canonicalisation must lowercase `pay_to` before hashing.
+        fp_upper = compute_fingerprint(
+            "https://api.example.com", "0xAbCdEf0123456789", "0.01", "USDC", 300
+        )
+        fp_lower = compute_fingerprint(
+            "https://api.example.com", "0xabcdef0123456789", "0.01", "USDC", 300
+        )
+        assert fp_upper == fp_lower
+
+    def test_currency_case_variants_produce_same_fingerprint(self):
+        # F1 regression (2026-05-17): currency tickers are conventionally
+        # uppercase but not enforced by the 402 spec; canonicalisation must
+        # uppercase `currency` before hashing.
+        fp_upper = compute_fingerprint("https://api.example.com", "0xabc", "0.01", "USDC", 300)
+        fp_lower = compute_fingerprint("https://api.example.com", "0xabc", "0.01", "usdc", 300)
+        assert fp_upper == fp_lower
+
     def test_pipe_in_resource_url_does_not_collide_with_other_tuples(self):
         # F-D regression: prior `"|".join(...)` canonicalisation was ambiguous
         # under server-controlled `resource_url`. JSON-array canonicalisation


### PR DESCRIPTION
## Summary

- **F1 (MEDIUM, CWE-20):** canonicalise `pay_to` (lowercase) and `currency` (uppercase) in `compute_fingerprint` so case-variant EVM addresses cannot bypass replay detection.
- **F2 (LOW, CWE-778):** log ERROR (matching `replay_guard.py`) when `PRESIDIO_X402_CHAIN_KEY` is unset, instead of silent per-process fallback.
- **F3 (LOW, CWE-400):** cap `X-PAYMENT` header at 64 KiB before `json.loads` to bound client-side DoS exposure from hostile 402 servers.

Risk: MEDIUM → LOW. Full disposition in `security-audit/audit-response-2026-05-17.md` (outer repo).

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `pytest tests/` — 274 passed, 2 skipped (+4 new regression tests for F1×2, F2, F3)
- [x] No public API change; `compute_fingerprint` is internal
- [x] Redis-backed `_RedisStore` pre-upgrade entries degrade safely for one TTL window (same profile as F-D last cycle)