### PR TITLE
release: v0.4.0 — screening-api launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to `presidio-hardened-x402` are documented here. Format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] — 2026-05-17
+
+The screening-api release. Pairs the published `screen.presidio-group.eu`
+service (deploy 2026-04-20) with the library `remote_screening=True` mode.
+
+### Added
+- `screening_client.ScreeningClient` — httpx-injectable client for the hosted
+  Presidio screening service; opt-in via `HardenedX402Client(remote_screening=True)`.
+- Per-origin `pay_to` allowlist in `gateway.py` (chain-06 mitigation).
+
+### Changed
+- `compute_fingerprint` now canonicalises `pay_to` (lowercase) and `currency`
+  (uppercase) before HMAC, closing the case-variant replay-bypass surface (F1,
+  audit 2026-05-17).
+- `audit_log` now logs at ERROR when `PRESIDIO_X402_CHAIN_KEY` is unset,
+  matching the existing `replay_guard` pattern (F2, audit 2026-05-17).
+- Replay fingerprint canonicalisation switched from pipe-joined string to
+  JSON-array encoding to avoid server-controlled-`resource_url` collisions
+  (F-D, audit 2026-05-10).
+- Replay detection event now emits at ERROR with a structured `extra` payload
+  for SIEM correlation (F-E, audit 2026-05-10).
+- Bandit SAST step in `tools/.github/workflows/codeql.yml` no longer uses
+  `--exit-zero`; MEDIUM+ findings at MEDIUM+ confidence now block CI (F-C,
+  audit 2026-05-10).
+
+### Security
+- New length cap on the `X-PAYMENT` header (64 KiB) before `json.loads`,
+  blocking client-side DoS from hostile 402 servers (F3, audit 2026-05-17).
+- Outbound MPA HMAC + response-side `compare_digest` validation closes the
+  chain-07 SSRF surface (F-A/F-B, audit 2026-05-03).
+- PII filter `scan_dict` now covers the `extra` metadata dict on
+  `PaymentDetails`, closing the chain-04 / F-A surface (audit 2026-05-03).
+- Dependency bumps: `urllib3` 2.6.3 → 2.7.0 (CVE-2026-44431, CVE-2026-44432),
+  `langsmith` 0.7.32 → 0.8.4 (CVE-2026-45134), `python-multipart` 0.0.26 →
+  0.0.27 (CVE-2026-42561), `langchain-core` 1.3.0 → 1.3.3 (CVE-2026-44843),
+  `python-dotenv` 1.1.1 → 1.2.2 (GHSA-mf9w-mj56-hr94).
+
+### Notes
+- 274 tests pass on Python 3.10 / 3.11 / 3.12 / 3.13.
+- 8 adversary chains dispositioned per `adversary-attack/README.md` (3 CLOSED,
+  3 MITIGATED-config, 2 PARTIAL with residual scope deferred to v0.5.0).
+- Two configuration env vars are required for full security posture in
+  multi-replica / persistent deployments: `PRESIDIO_X402_FINGERPRINT_KEY` and
+  `PRESIDIO_X402_CHAIN_KEY`. Both fall back to per-process keys with ERROR-level
+  startup logs; hard startup-gates are queued for v0.5.0.
+
+## [0.3.0] — 2026-04 (no changelog entry kept)
+
+Multi-party authorisation engine (`MPAEngine`), policy-as-code JSON Schema
+(`x402_policy_schema.py`), Prometheus metrics (`MetricsCollector`), Helm chart
+and Docker sidecar image. See `git log v0.2.0..v0.3.0` for detail.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.3.0"
+version = "0.4.0"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -49,7 +49,7 @@ from .policy_engine import PolicyConfig, PolicyEngine
 from .replay_guard import ReplayGuard, compute_fingerprint
 from .screening_client import ScreeningClient
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __all__ = [
     # Primary public API
     "HardenedX402Client",

--- a/uv.lock
+++ b/uv.lock
@@ -2987,7 +2987,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- Bumps version 0.3.0 → 0.4.0 in `pyproject.toml` and `src/presidio_x402/__init__.py`.
- Adds `CHANGELOG.md` (new file; Keep a Changelog format) with the 0.4.0 entry — screening-api pairing, F-A/F-B, F-C/F-D/F-E, F1/F2/F3, urllib3 2.7.0, langsmith 0.8.4, python-multipart 0.0.27, langchain-core 1.3.3, python-dotenv 1.2.2.

This PR is the announce-track artifact for the v0.4.0 milestone. The deploy track (`screen.presidio-group.eu`) shipped on 2026-04-20; this PR is the library half of the release. Tag + PyPI publish + GitHub Release will happen after merge.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `pytest tests/` — 274 passed, 2 skipped
- [x] `import presidio_x402; presidio_x402.__version__ == "0.4.0"` verified locally
- [x] Adversary chain disposition refreshed in outer-repo `adversary-attack/README.md` — 3 CLOSED / 3 MITIGATED-config / 2 PARTIAL with v0.5.0 deferrals; no chain OPEN with zero in-tree control