### PR TITLE
docs: add v0.4.0 release notes

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,79 @@
+# v0.4.0 — Screening API Launch
+
+> The library half of a paired release. `presidio-hardened-x402` v0.4.0 ships
+> alongside the public `screen.presidio-group.eu` screening service (live since
+> 2026-04-20), giving x402 agent clients an opt-in remote PII / endpoint-screening
+> backend without an in-process spaCy dependency.
+
+## Highlights
+
+- **`remote_screening=True` mode.** New `ScreeningClient` (httpx-injectable)
+  lets `HardenedX402Client` offload PII analysis to the hosted screening
+  service. Falls back to local regex / NLP modes when the network is unhealthy.
+- **Per-origin wallet allowlist.** `gateway.py` now supports a per-origin
+  `pay_to` allowlist, closing the DNS-poisoning wallet-substitution surface
+  (chain-06) when operators configure it. See README for the config shape.
+- **Replay fingerprint is now case-insensitive on `pay_to` / `currency`.** EVM
+  addresses and currency tickers are normalised before HMAC, so a server cannot
+  bypass duplicate-payment detection by toggling case across retries (F1).
+- **Audit chain key falls back loudly.** Missing `PRESIDIO_X402_CHAIN_KEY` and
+  `PRESIDIO_X402_FINGERPRINT_KEY` now both log at ERROR with a "deployment
+  defect" explanation, so silently insecure deployments are observable in any
+  log aggregator (F2).
+- **64 KiB hard cap on `X-PAYMENT`.** Hostile 402 servers can no longer force
+  unbounded `json.loads` allocation in the agent process (F3).
+
+## Breaking changes
+
+None. `remote_screening=True` is opt-in. The replay fingerprint format is
+unchanged on the wire (HMAC-SHA256 over JSON-encoded payment tuple); only the
+canonical-form inputs are normalised, so existing Redis-backed deployments
+treat in-flight pre-upgrade fingerprints as not-yet-seen for one TTL window
+after deploy (≤300 s by default) and then converge — no migration required.
+
+## Security
+
+All audit findings dispositioned between v0.3.0 and v0.4.0 are closed in this
+release:
+
+| Cycle | Findings closed |
+|---|---|
+| 2026-05-03 | F-A (PII `extra` dict scan), F-B (MPA webhook response HMAC) |
+| 2026-05-10 | F-C (Bandit `--exit-zero` removed → blocking), F-D (replay fingerprint canonical form), F-E (replay event → ERROR with structured `extra`) |
+| 2026-05-17 | F1 (replay case-canonicalisation), F2 (audit chain-key ERROR log), F3 (`X-PAYMENT` length cap) |
+
+Adversary chain status (8 chains, see `adversary-attack/README.md` in the parent repo):
+
+- **3 CLOSED**: 04 Unicode evasion · 05 exception exfiltration · 07 MPA SSRF.
+- **3 MITIGATED (config)**: 02 cross-process replay · 03 audit OOM · 06 wallet hijack. Operators must set `PRESIDIO_X402_FINGERPRINT_KEY` + `PRESIDIO_X402_CHAIN_KEY` and populate the wallet allowlist at deploy time.
+- **2 PARTIAL** (residual scope deferred to v0.5.0): 01 spaCy model not yet wheel-pinned · 08 full SLSA L3 / digest-pinned `tools/` sidecar image.
+
+No CRITICAL or HIGH chain is OPEN with zero in-tree control.
+
+### Dependency CVE closures since v0.3.0
+
+| Package | Range | CVE |
+|---|---|---|
+| `urllib3` | 2.6.3 → 2.7.0 | CVE-2026-44431, CVE-2026-44432 |
+| `langsmith` | 0.7.32 → 0.8.4 | CVE-2026-45134 |
+| `langchain-core` | 1.3.0 → 1.3.3 | CVE-2026-44843 |
+| `python-multipart` | 0.0.26 → 0.0.27 | CVE-2026-42561 |
+| `python-dotenv` | 1.1.1 → 1.2.2 | GHSA-mf9w-mj56-hr94 |
+
+## Tested on
+
+Python **3.10**, **3.11**, **3.12**, **3.13**. **274 passing tests** (2 skipped) including dedicated regression coverage for adversary chains 02, 03, 04, 05, 06, 07.
+
+## Install
+
+```bash
+pip install presidio-hardened-x402==0.4.0
+# or with NLP mode:
+pip install "presidio-hardened-x402[nlp]==0.4.0"
+```
+
+## Related
+
+- Hosted screening service: <https://screen.presidio-group.eu>
+- Companion preprint (v0.2.0 design + corpus): [`arXiv:2604.11430`](https://arxiv.org/abs/2604.11430)
+- Full changelog: `CHANGELOG.md`


### PR DESCRIPTION
## Summary

- Adds `docs/releases/v0.4.0.md` — persistent copy of the v0.4.0 GitHub Release notes (lifted from the draft, paired with the screening-api launch and the arXiv companion).
- Punchier than `CHANGELOG.md`; intended to be pasted into the GitHub Release UI when the v0.4.0 tag goes out.

## Test plan

- [x] Doc-only change; no source/test edits
- [ ] After merge: tag `v0.4.0` + publish to PyPI + create the GitHub Release using this file as the body