### PR TITLE
docs: update README + PRESIDIO-REQ.md for v0.4.0

### DIFF
--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -215,17 +215,110 @@ on controlled data with known ground truth, then confirm the threat model on liv
 
 ---
 
-## v0.4.0 Requirements (Production Hardening)
+## v0.4.0 Requirements (Screening API Launch) — Delivered
 
-- Third-party security audit of all v0.1.0–v0.3.0 modules
-- Performance regression test suite: p99 < 50ms latency SLO enforced in CI
-- Policy hot-reload: update `PolicyConfig` at runtime without client restart
-- OpenTelemetry span export for every security control activation
-- Operator runbook (GitHub Pages)
+**Re-scoped from the original "production hardening 2027" plan per
+[ADR-0006](../sdlc/adr/0006-v040-scope-redefinition.md).** v0.4.0 now pairs the
+library release with the hosted `screen.presidio-group.eu` screening service
+that acts as its authoritative remote backend. The 2027-hardening umbrella is
+redistributed across v0.5.0+ (see below).
+
+### Hosted screening service
+
+- **`screen.presidio-group.eu`** — FastAPI service behind nginx on an OVHcloud
+  VPS (deploy 2026-04-20: SSH key-only, UFW, fail2ban, unattended-upgrades,
+  Let's Encrypt ECDSA cert with certbot.timer auto-renewal). Free tier only:
+  regex mode, 100 screenings/day/key, no audit token. Paid tiers gated on real
+  usage data and deferred to v0.4.1+.
+- Baseline load test (`run/load-tests/health-baseline.js`, 2026-04-20):
+  100 req/s × 5 min on `GET /health` → 29,989 requests, 100.00% 2xx,
+  p95 33 ms, p99 92 ms, 0 failures.
+
+### Client-side integration
+
+- **`screening_client.py`** — `ScreeningClient`: httpx-injectable client that
+  posts metadata fields to the screening service and consumes the structured
+  PII analysis response.
+- **Gateway integration**: `HardenedX402Client(remote_screening=True, screening_api_key=...)`
+  routes PII analysis to the hosted service instead of the in-process PIIFilter;
+  falls back to local regex/NLP modes when the network is unhealthy.
+
+### New library-side controls
+
+- **Per-origin `pay_to` allowlist** (`gateway.py:495-512`): defence against
+  DNS-poisoning attacks that substitute the recipient wallet in a 402 response.
+  Configured via `HardenedX402Client(trusted_wallets={origin: {pay_to, ...}})`.
+  Adversary-attack chain-06 mitigation.
+- **Replay fingerprint case-canonicalisation** (F1, audit 2026-05-17):
+  `compute_fingerprint` now lowercases `pay_to` and uppercases `currency`
+  before HMAC, so a server cannot bypass replay detection by toggling case
+  across retries.
+- **`PRESIDIO_X402_CHAIN_KEY` startup ERROR log** (F2, audit 2026-05-17):
+  matches the existing `PRESIDIO_X402_FINGERPRINT_KEY` pattern; silent
+  fallback to a per-process key is no longer observable-free.
+- **`X-PAYMENT` length cap** (F3, audit 2026-05-17): 64 KiB hard cap before
+  `json.loads` to bound client-side DoS exposure from hostile 402 servers.
+
+### Audit cycle closures rolled up into 0.4.0
+
+- 2026-05-03: F-A (PII `scan_dict` covers `extra` dict), F-B (MPA webhook
+  outbound HMAC).
+- 2026-05-10: F-C (Bandit `--exit-zero` removed → MEDIUM+ findings now block
+  CI), F-D (replay fingerprint JSON-array canonical form replaces pipe-joined
+  string), F-E (replay-detected event promoted from WARNING to ERROR with
+  structured `extra` for SIEM).
+- 2026-05-17: F1, F2, F3 (listed above).
+
+### Adversary-chain disposition
+
+All 8 chains in `adversary-attack/` dispositioned per the closure table in the
+parent repo's `adversary-attack/README.md`: 3 CLOSED (04 Unicode evasion,
+05 exception exfiltration, 07 MPA SSRF), 3 MITIGATED-config (02 replay,
+03 audit OOM, 06 wallet hijack — operator must set
+`PRESIDIO_X402_FINGERPRINT_KEY` + `PRESIDIO_X402_CHAIN_KEY` and populate the
+wallet allowlist at deploy), 2 PARTIAL (01 spaCy model not yet wheel-pinned,
+08 tools/ sidecar Dockerfile not digest-pinned — residual scope deferred to
+v0.5.0). No CRITICAL/HIGH chain remains OPEN with zero in-tree control.
+
+### Out of v0.4.0 (moved to later milestones per ADR-0006)
+
+- Third-party external security audit → v0.5.0 (closes RSK-019)
+- Multi-tenant key scoping + remote audit sinks (S3 / Splunk / Datadog) → v0.5.0
+- Email-hash per-install salt → v0.5.0 (closes RSK-002)
+- `/v1/revoke` endpoint → v0.4.1
+- Prometheus `/metrics` on the hosted service → v0.4.1
+- SLSA L3 hardened build worker → v0.5.0+
+- Hard startup-gates for `PRESIDIO_X402_*_KEY` env vars → v0.5.0
+- Policy hot-reload, OpenTelemetry span export, performance regression CI →
+  v0.5.0
 
 ---
 
-## v0.5.0 Requirements (SLO Payment Broker)
+## v0.5.0 Requirements (Multi-Tenant + Audit Sink + SLSA L3)
+
+Converts the single-tenant v0.4.0 screening service into a production platform.
+Largely the "production hardening" scope previously carried under v0.4.0, plus
+the multi-tenant work required to take paid tiers live.
+
+- Multi-tenant key scoping with per-tenant Redis namespace
+- Remote audit sink interfaces: `S3AuditWriter`, `SplunkAuditWriter`,
+  `DatadogAuditWriter` (enterprise tier)
+- Per-install salt for `email:<sha256>` audit prefix (closes RSK-002)
+- Third-party security audit (closes RSK-019); blocks Track 1/Track 2 paid
+  tiers
+- SLSA L3 hardened build worker + provenance attestation; digest-pinned base
+  image for `tools/docker/` and pinned spaCy model wheel (closes chain-01 and
+  chain-08 residuals)
+- Performance regression test suite: p99 < 50ms latency SLO enforced in CI
+- Policy hot-reload: update `PolicyConfig` at runtime without client restart
+- OpenTelemetry span export for every security control activation
+- Hard startup-gates: `PRESIDIO_X402_REQUIRE_FINGERPRINT_KEY=1` and
+  `PRESIDIO_X402_REQUIRE_CHAIN_KEY=1` opt-ins that hard-fail import when the
+  corresponding env var is unset
+
+---
+
+## v0.6.0 Requirements (SLO Payment Broker)
 
 This version fills a second white spot: **market-based SLO enforcement**. Current
 autoscaling is reactive and rule-based. This milestone makes the agent an economic actor

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![CI](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml/badge.svg)](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml)
 
-> v0.3.0 — PII redaction, spending policy, replay detection, audit logging, multi-party authorization, and Prometheus metrics for x402 payments
+> v0.4.0 — PII redaction, spending policy, replay detection, audit logging, multi-party authorization, Prometheus metrics, and opt-in remote screening for x402 payments
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -14,10 +14,12 @@ Intercepts x402 payment requests **before transmission to servers and facilitato
 
 - **PII redaction** — Presidio-based detection and redaction of personal data (emails, names, SSNs, credit cards, etc.) from payment metadata fields before they are sent to the payment server or facilitator API
 - **Spending policy** — per-agent, per-endpoint, and per-time-window budget limits that block or throttle payments before execution
-- **Replay detection** — HMAC-SHA256 fingerprinting of canonical payment fields to prevent duplicate and replayed payments
+- **Replay detection** — HMAC-SHA256 fingerprinting of canonical payment fields to prevent duplicate and replayed payments; case-canonicalised on `pay_to` and `currency` *(v0.4.0)*
 - **Audit logging** — HMAC-chained JSON-L audit trail for every payment attempt (including blocked ones)
 - **Multi-party authorization** — n-of-m approval requirement for high-value payments, via webhook or HMAC-SHA256 cryptographic countersignature modes *(v0.3.0)*
 - **Prometheus metrics** — structured telemetry for every security control activation *(v0.3.0)*
+- **Remote screening** — opt-in `remote_screening=True` mode offloads PII analysis to the hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu) service via `ScreeningClient`; avoids the in-process spaCy dependency *(v0.4.0)*
+- **Per-origin wallet allowlist** — per-origin `pay_to` allowlist blocks payments to attacker-controlled addresses when a DNS-poisoned 402 response substitutes the recipient (chain-06 mitigation) *(v0.4.0)*
 
 Part of the [presidio-hardened-*](https://github.com/presidio-v) toolkit family.
 
@@ -266,6 +268,45 @@ client = HardenedX402Client(payment_signer=signer, policy=policy)
 
 ---
 
+## Remote Screening (v0.4.0)
+
+Offload PII analysis to the hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu)
+service. Useful when you want to keep the agent process small (no in-process spaCy
+model) and centralise screening policy across many agents.
+
+```python
+from presidio_x402 import HardenedX402Client
+
+client = HardenedX402Client(
+    payment_signer=signer,
+    remote_screening=True,
+    screening_api_key="...",   # obtain by registering at screen.presidio-group.eu
+)
+```
+
+The free tier serves the regex-mode screening backend at 100 screenings/day per key.
+Falls back to local regex / NLP modes if the network is unhealthy, so the client never
+hard-fails on a screening-service outage.
+
+### Per-origin wallet allowlist (v0.4.0)
+
+Defence against DNS-poisoning attacks that substitute the recipient wallet in a 402
+response. Configure the trusted `pay_to` addresses per resource origin:
+
+```python
+client = HardenedX402Client(
+    payment_signer=signer,
+    trusted_wallets={
+        "https://api.example.com": {"0xAbC...123"},
+    },
+)
+```
+
+Payments to a `pay_to` not in the allowlist for the response's origin are blocked
+before signing.
+
+---
+
 ## Kubernetes Deployment (v0.3.0)
 
 Deploy as a sidecar using the bundled Helm chart:
@@ -315,9 +356,10 @@ All exceptions are importable from `presidio_x402`.
 | v0.1.0 | PII redaction + spending policy + replay detection |
 | v0.2.0 | Synthetic corpus + 42-configuration precision/recall sweep, LangChain/CrewAI adapters, compliance report · [arXiv:2604.11430](https://arxiv.org/abs/2604.11430) |
 | v0.2.1 | Live ecosystem characterisation via Dune Analytics (20 projects, 96 wallets, 11 chains, ≥79M transactions); IEEE S&P magazine article submitted; IEEE TIFS paper under review · Corpus: [`v0.2.1/dataport/`](v0.2.1/dataport/), [Hugging Face](https://huggingface.co/datasets/vstantch/x402-pii-corpus), [IEEE DataPort (doi:10.21227/kpsz-nq73)](https://doi.org/10.21227/kpsz-nq73) |
-| **v0.3.0** | **Multi-party authorization** (`mpa.py`: n-of-m, webhook + crypto modes) · **Policy-as-code** JSON Schema (IETF draft candidate) · **Prometheus metrics** exporter · Kubernetes Helm chart + Docker image · SOC2 reference architecture — **current** |
-| v0.4.0 | Production hardening: security audit, OpenTelemetry spans, policy hot-reload, operator runbook |
-| v0.5.0 | **SLO payment broker** — x402 micropayments as runtime infrastructure bids; `presidio-hardened-arch-translucency` integration |
+| v0.3.0 | **Multi-party authorization** (`mpa.py`: n-of-m, webhook + crypto modes) · **Policy-as-code** JSON Schema (IETF draft candidate) · **Prometheus metrics** exporter · Kubernetes Helm chart + Docker image · SOC2 reference architecture |
+| **v0.4.0** | **Screening API launch** — hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu) free tier (regex mode, 100 req/day) · `ScreeningClient` + `remote_screening=True` mode · per-origin `pay_to` allowlist (chain-06 mitigation) · audit-cycle hardening (F-A/B 2026-05-03, F-C/D/E 2026-05-10, F1/F2/F3 2026-05-17); see [`CHANGELOG.md`](CHANGELOG.md) — **current** |
+| v0.5.0 | Multi-tenant key scoping · enterprise-tier remote audit sinks (S3 / Splunk / Datadog) · third-party security audit · SLSA L3 hardened build worker · hard startup-gates for `PRESIDIO_X402_*_KEY` env vars |
+| v0.6.0 | **SLO payment broker** — x402 micropayments as runtime infrastructure bids; `presidio-hardened-arch-translucency` integration |
 
 See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 


### PR DESCRIPTION
## Summary

- **README.md**: bump tagline to v0.4.0, add `remote_screening` + per-origin `pay_to` allowlist to the feature list, add a new "Remote Screening (v0.4.0)" section that documents the `screen.presidio-group.eu` integration, refresh the Roadmap table — v0.4.0 row now reflects what shipped (Screening API launch + audit-cycle hardening), v0.5.0 absorbs multi-tenant / SLSA L3 / external audit per ADR-0006, v0.6.0 is the SLO payment broker.
- **PRESIDIO-REQ.md**: rewrite the old v0.4.0 "Production Hardening" stub to describe the hosted screening service, the client integration, the new gateway controls, the audit-cycle closures rolled up into 0.4.0, and the chain disposition. Add a fresh v0.5.0 (Multi-Tenant + Audit Sink + SLSA L3) section that picks up the production-hardening scope previously stranded on v0.4.0; renumber the SLO Payment Broker section to v0.6.0.

Doc-only.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] No source/test edits