### PR TITLE
security: close audit findings F-01, F-02, F-09 (2026-06-03)

### DIFF
--- a/src/presidio_x402/adapters/langchain.py
+++ b/src/presidio_x402/adapters/langchain.py
@@ -105,7 +105,7 @@ try:  # pragma: no cover
 
         async def aclose(self) -> None:
             """Close the underlying httpx client."""
-            await self._client._http.aclose()
+            await self._client.aclose()
 
 except ImportError:
 

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -495,22 +495,31 @@ class HardenedX402Client:
         # 2. Trusted-wallet allowlist (pay_to substitution defence)
         # ------------------------------------------------------------------
         if self._trusted_wallets is not None:
-            origin = _resource_origin(details.resource_url)
+            # Key the allowlist off the ORIGINAL (pre-redaction) origin. PII
+            # redaction can rewrite the host (IP literals via IP_ADDRESS,
+            # digit-laden DNS labels via US_SSN/PHONE_NUMBER), which would shift
+            # the origin string out of the allowlist, miss the lookup, and
+            # silently skip the pay_to check entirely. The host is a
+            # security-control key, not PII — this mirrors the replay
+            # fingerprint, which also keys off original_resource_url below
+            # (CWE-348 / F-02, 2026-06-03).
+            origin = _resource_origin(original_resource_url)
             allowed = self._trusted_wallets.get(origin)
             if allowed is not None and details.pay_to not in allowed:
+                # The raw origin may contain a redactable host; keep it out of
+                # the persisted audit message and surface only the redacted URL.
                 self._audit.emit(
                     "WALLET_BLOCKED",
                     resource_url=clean_url,
                     amount_usd=amount_usd,
                     network=details.network,
                     outcome="blocked",
-                    error_message=f"pay_to {details.pay_to!r} not in allowlist for {origin!r}",
+                    error_message=f"pay_to {details.pay_to!r} not in trusted wallet allowlist",
                 )
                 if self._metrics:
                     self._metrics.record_payment_blocked("wallet", amount_usd)
                 raise X402PaymentError(
-                    f"pay_to wallet {details.pay_to!r} not in trusted allowlist "
-                    f"for origin {origin!r}"
+                    f"pay_to wallet {details.pay_to!r} not in trusted allowlist"
                 )
 
         # ------------------------------------------------------------------

--- a/src/presidio_x402/policy_engine.py
+++ b/src/presidio_x402/policy_engine.py
@@ -21,7 +21,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from .exceptions import PolicyViolationError
 
@@ -97,6 +97,22 @@ class _SpendLedger:
             self._entries.clear()
 
 
+def _endpoint_prefix_matches(prefix: str, url: str) -> bool:
+    """True if *url* falls under per-endpoint *prefix* on a host/path boundary.
+
+    Requires an exact (scheme, host[:port]) match and, when the configured
+    prefix carries a path, alignment on a ``/`` segment boundary. This prevents
+    prefix-confusion bypasses where a sibling host or path merely shares a
+    leading substring with a trusted prefix (F-01, 2026-06-03).
+    """
+    p = urlsplit(prefix)
+    u = urlsplit(url)
+    if (p.scheme, p.netloc) != (u.scheme, u.netloc):
+        return False
+    base = p.path.rstrip("/")
+    return base == "" or u.path == base or u.path.startswith(base + "/")
+
+
 class PolicyEngine:
     """Enforces spending policy for x402 payments.
 
@@ -127,13 +143,20 @@ class PolicyEngine:
             return self._endpoint_ledgers[prefix]
 
     def _matching_endpoint_prefix(self, resource_url: str) -> str | None:
-        """Return the longest matching per_endpoint prefix, or None."""
-        parsed = urlparse(resource_url)
-        base = f"{parsed.scheme}://{parsed.netloc}"
-        # Try full URL, then base URL, then any configured prefix
+        """Return the longest matching per_endpoint prefix, or None.
+
+        Matching is boundary-aware: the prefix and the URL must share the same
+        scheme and host exactly, and any prefix path must align on a ``/``
+        boundary. A raw ``startswith`` (the prior implementation) let a hostile
+        origin whose hostname merely *begins with* a trusted prefix — e.g.
+        ``https://api.example.com.attacker.com`` against a configured
+        ``https://api.example.com`` — inherit that endpoint's budget
+        (CWE-697 / F-01, 2026-06-03). Candidates are tried longest-first so the
+        most specific configured prefix wins.
+        """
         candidates = sorted(self.config.per_endpoint.keys(), key=len, reverse=True)
         for prefix in candidates:
-            if resource_url.startswith(prefix) or base.startswith(prefix):
+            if _endpoint_prefix_matches(prefix, resource_url):
                 return prefix
         return None
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -27,6 +27,38 @@ class TestLangchainAdapterStub:
             HardenedX402Tool(payment_signer=None)
 
 
+class TestLangchainAdapterClose:
+    """F-09 (2026-06-03): the adapter's aclose() must delegate to the client's
+    public aclose(), not a non-existent ``_http`` attribute."""
+
+    @pytest.mark.asyncio
+    async def test_aclose_delegates_to_client_public_aclose(self):
+        try:
+            import langchain_core  # noqa: F401
+        except ImportError:
+            pytest.skip("langchain-core not installed — adapter aclose() is the stub")
+
+        from presidio_x402.adapters.langchain import HardenedX402Tool
+
+        closed = {"called": False}
+
+        class _FakeClient:
+            async def aclose(self) -> None:
+                closed["called"] = True
+
+        tool = HardenedX402Tool.__new__(HardenedX402Tool)
+        tool._client = _FakeClient()
+        await tool.aclose()
+        assert closed["called"]
+
+    def test_client_exposes_public_aclose_and_no_underscore_http(self):
+        # Guards the attribute the adapter relies on, independent of langchain.
+        from presidio_x402 import HardenedX402Client
+
+        assert callable(getattr(HardenedX402Client, "aclose", None))
+        assert not hasattr(HardenedX402Client, "_http")
+
+
 class TestCrewAIAdapterStub:
     """CrewAI is not installed in test env — adapter should raise ImportError at init."""
 

--- a/tests/test_adversary_chains.py
+++ b/tests/test_adversary_chains.py
@@ -553,6 +553,44 @@ class TestChain06WalletSubstitution:
             finally:
                 await client.aclose()
 
+    @pytest.mark.asyncio
+    async def test_allowlist_keyed_on_original_origin_not_redacted_host(self):
+        """F-02 (2026-06-03): redaction of a PII-shaped host must not disable the
+        wallet allowlist.
+
+        An operator pins an IP-literal facilitator origin. The IP_ADDRESS PII
+        pattern rewrites the host to ``<REDACTED>`` during redaction; if the
+        allowlist were keyed off the post-redaction URL the lookup would miss,
+        ``allowed`` would be None, and the pay_to check would be silently
+        skipped. Keying off the original origin keeps the attacker blocked.
+        """
+        signed_details: list[PaymentDetails] = []
+
+        async def _capture_signer(details: PaymentDetails) -> PaymentResponse:
+            signed_details.append(details)
+            return PaymentResponse(token="mock-signed-token", details=details)  # noqa: S106
+
+        audit = _RecordingAuditWriter()
+        ip_resource = "https://10.20.30.40:8080/v1/data"
+        attacker_header = _header_for(self._ATTACKER, resource=ip_resource)
+        with respx.mock:
+            respx.get(ip_resource).mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": attacker_header})
+            )
+            client = HardenedX402Client(
+                payment_signer=_capture_signer,
+                audit_writer=audit,
+                trusted_wallets={"https://10.20.30.40:8080": {self._LEGIT}},
+            )
+            try:
+                with pytest.raises(X402PaymentError, match="not in trusted allowlist"):
+                    await client.get(ip_resource)
+            finally:
+                await client.aclose()
+
+        assert not signed_details, "Signer must not run: redacted host must still gate pay_to"
+        assert [e for e in audit.events if e.event_type == "WALLET_BLOCKED"]
+
 
 # Suppress "unused import" for ``replace`` — retained in case future POC tests
 # need to mutate PaymentDetails fixtures without rebuilding them.

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -80,6 +80,43 @@ class TestPolicyEnginePerEndpointLimit:
             engine.check_and_record(resource_url="https://premium-api.io/another", amount_usd=0.04)
 
 
+class TestPolicyEnginePrefixConfusion:
+    """F-01 (2026-06-03): a sibling host/path sharing a leading substring with a
+    configured per-endpoint prefix must NOT inherit that prefix's budget."""
+
+    def test_lookalike_host_does_not_inherit_endpoint_budget(self):
+        # api.example.com has a generous $5.00 endpoint limit. A hostile origin
+        # whose hostname merely begins with it must not borrow that budget.
+        engine = PolicyEngine(
+            PolicyConfig(
+                daily_limit_usd=100.0,
+                per_endpoint={"https://api.example.com": 5.00},
+            )
+        )
+        assert (
+            engine._matching_endpoint_prefix("https://api.example.com.attacker.com/drain") is None
+        )
+        assert engine._matching_endpoint_prefix("https://api.example.com/data") == (
+            "https://api.example.com"
+        )
+
+    def test_path_prefix_requires_segment_boundary(self):
+        engine = PolicyEngine(PolicyConfig(per_endpoint={"https://api.example.com/v1": 0.50}))
+        # Exact and child paths match; a sibling that merely shares the substring does not.
+        assert engine._matching_endpoint_prefix("https://api.example.com/v1") == (
+            "https://api.example.com/v1"
+        )
+        assert engine._matching_endpoint_prefix("https://api.example.com/v1/data") == (
+            "https://api.example.com/v1"
+        )
+        assert engine._matching_endpoint_prefix("https://api.example.com/v1beta") is None
+
+    def test_scheme_and_port_must_match_exactly(self):
+        engine = PolicyEngine(PolicyConfig(per_endpoint={"https://api.example.com": 0.50}))
+        assert engine._matching_endpoint_prefix("http://api.example.com/data") is None
+        assert engine._matching_endpoint_prefix("https://api.example.com:8443/data") is None
+
+
 class TestPolicyEngineFromDict:
     def test_from_dict_creates_correct_config(self):
         engine = PolicyEngine({"max_per_call_usd": 0.05, "daily_limit_usd": 1.0})


### PR DESCRIPTION
Closes three findings from the 2026-06-03 source audit (`SECURITY-AUDIT-2026-06-03.md`, PR #34). All confirmed against source and covered by regression tests.

## Summary
- **F-01 (Medium, CWE-697)** — `policy_engine._matching_endpoint_prefix` used raw `startswith`, so `https://api.example.com.attacker.com` matched a configured `https://api.example.com` prefix and inherited its per-endpoint budget. Now matches on exact scheme+host plus a `/`-segment path boundary.
- **F-02 (Medium, CWE-348)** — the trusted-wallet allowlist was keyed off `details.resource_url` *after* PII redaction, so a redactable host (IP literal, digit-laden label) shifted the origin out of the allowlist and silently skipped the `pay_to` check. Now keyed off the original pre-redaction origin, mirroring the replay fingerprint. Raw origin kept out of the persisted audit message.
- **F-09 (Low)** — langchain adapter `aclose()` called a non-existent `_http` attribute (client exposes `_httpx`); now delegates to the client's public `aclose()`.

## Deferred (not in this PR)
- **F-03** (budget/replay committed before payment) — needs deliberate control-flow reordering + regression tests; tracked separately.

## Test plan
- [x] `ruff check src tests` + `ruff format --check src tests`
- [x] `pytest tests/` — all pass
- [x] New: prefix-confusion (host/path/scheme-port) tests
- [x] New: wallet allowlist survives host redaction (IP-literal origin)
- [x] New: langchain adapter aclose delegation + client contract guard