### PR TITLE
security: close audit finding F-03 — atomic spend/replay commit

### DIFF
--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -352,8 +352,9 @@ class HardenedX402Client:
             )
             raise
 
-        # Apply security controls; get (possibly modified) details back
-        secure_details = await self._apply_security_controls(
+        # Apply security controls; get (possibly modified) details + the replay
+        # fingerprint back so a signing failure can roll the commit back.
+        secure_details, fingerprint = await self._apply_security_controls(
             details, mpa_signatures=mpa_signatures
         )
 
@@ -361,6 +362,15 @@ class HardenedX402Client:
         try:
             payment_response = await self._invoke_signer(secure_details)
         except Exception as exc:
+            # The spend + replay slot were committed before signing; a signer
+            # failure means no payment was made, so release them (F-03) —
+            # otherwise a hostile server inducing repeated signer failures could
+            # drain the accounting budget and block legitimate retries.
+            self._rollback_commit(
+                resource_url=secure_details.resource_url,
+                amount_usd=_amount_to_usd(secure_details.amount, secure_details.currency),
+                fingerprint=fingerprint,
+            )
             safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
             self._audit.emit(
                 "PAYMENT_ERROR",
@@ -390,18 +400,38 @@ class HardenedX402Client:
             self._metrics.record_payment_allowed(paid_usd)
         return resp
 
+    def _rollback_commit(self, *, resource_url: str, amount_usd: float, fingerprint: str) -> None:
+        """Reverse the spend + replay fingerprint speculatively committed in
+        :meth:`_apply_security_controls`.
+
+        The policy spend and replay fingerprint are recorded *before* the payment
+        is signed (so the TOCTOU-critical check+record stays atomic under a
+        single lock — a guarantee that cannot span the async signer ``await``).
+        When the payment is subsequently denied (MPA) or fails to sign, this
+        compensating rollback keeps the spend ledger consistent with payments
+        that actually committed and frees the fingerprint for a legitimate retry
+        (F-03, 2026-06-03).
+        """
+        self._policy.refund(resource_url=resource_url, amount_usd=amount_usd)
+        self._replay.release(fingerprint)
+
     async def _apply_security_controls(
         self,
         details: PaymentDetails,
         *,
         mpa_signatures: dict[str, str] | None = None,
-    ) -> PaymentDetails:
+    ) -> tuple[PaymentDetails, str]:
         """Apply PIIFilter → PolicyEngine → ReplayGuard → MPAEngine → AuditLog.
 
-        Returns (possibly modified) :class:`~presidio_x402._types.PaymentDetails`
-        with PII redacted from metadata fields if ``pii_action="redact"``.
+        Returns a ``(details, fingerprint)`` tuple: the (possibly modified)
+        :class:`~presidio_x402._types.PaymentDetails` with PII redacted from
+        metadata fields if ``pii_action="redact"``, plus the replay fingerprint
+        recorded for this payment so the caller can roll it back if signing
+        fails.
 
         Raises on policy violation, replay, PII block, or MPA denial/timeout.
+        On MPA denial/timeout the spend + replay commit is rolled back before
+        re-raising.
         """
         amount_usd = _amount_to_usd(details.amount, details.currency)
 
@@ -578,6 +608,15 @@ class HardenedX402Client:
                 if self._metrics:
                     self._metrics.record_mpa_event("approved")
             except (MPADeniedError, MPATimeoutError) as exc:
+                # Roll back the spend + replay fingerprint committed at steps 3–4:
+                # an MPA-denied/timed-out payment was never signed, so it must not
+                # charge the budget or burn the fingerprint (which would block the
+                # legitimate crypto-mode retry that carries the countersignatures).
+                self._rollback_commit(
+                    resource_url=details.resource_url,
+                    amount_usd=amount_usd,
+                    fingerprint=fingerprint,
+                )
                 outcome = "timeout" if isinstance(exc, MPATimeoutError) else "denied"
                 safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
                 self._audit.emit(
@@ -593,7 +632,7 @@ class HardenedX402Client:
                     self._metrics.record_payment_blocked(f"mpa_{outcome}", amount_usd)
                 raise
 
-        return details
+        return details, fingerprint
 
     # ------------------------------------------------------------------
     # Context manager support

--- a/src/presidio_x402/policy_engine.py
+++ b/src/presidio_x402/policy_engine.py
@@ -89,6 +89,20 @@ class _SpendLedger:
             self._evict_stale(now)
             self._entries.append((now, amount_usd))
 
+    def release(self, amount_usd: float) -> bool:
+        """Reverse a single previously recorded *amount_usd* entry.
+
+        Removes the most-recent entry matching the amount (the one just
+        recorded). Returns True if an entry was removed. Used for compensating
+        rollback when a recorded spend is later denied or fails to settle.
+        """
+        with self._lock:
+            for i in range(len(self._entries) - 1, -1, -1):
+                if self._entries[i][1] == amount_usd:
+                    del self._entries[i]
+                    return True
+        return False
+
     def would_exceed(self, amount_usd: float, limit_usd: float) -> bool:
         return self.total() + amount_usd > limit_usd
 
@@ -244,6 +258,21 @@ class PolicyEngine:
                 self._get_endpoint_ledger(prefix).record(amount_usd)
 
         logger.debug("Policy check passed: %.4f USD for %s", amount_usd, resource_url)
+
+    def refund(self, *, resource_url: str, amount_usd: float) -> None:
+        """Reverse a spend recorded by :meth:`check_and_record`.
+
+        Compensating rollback for a payment that passed policy but was then
+        denied (MPA) or failed to sign, so the ledger only reflects payments
+        that actually committed (F-03). Mirrors the global + per-endpoint
+        recording done at check time, under the same serialisation lock. A
+        no-op if the entry has already aged out of the window.
+        """
+        with self._check_lock:
+            self._global_ledger.release(amount_usd)
+            prefix = self._matching_endpoint_prefix(resource_url)
+            if prefix is not None:
+                self._get_endpoint_ledger(prefix).release(amount_usd)
 
     def reset(self) -> None:
         """Reset all spend ledgers (useful in tests)."""

--- a/src/presidio_x402/replay_guard.py
+++ b/src/presidio_x402/replay_guard.py
@@ -129,6 +129,11 @@ class _MemoryStore:
         for k in expired:
             del self._store[k]
 
+    def release(self, key: str) -> None:
+        """Forget *key* if present (compensating rollback)."""
+        with self._lock:
+            self._store.pop(key, None)
+
     def clear(self) -> None:
         with self._lock:
             self._store.clear()
@@ -152,6 +157,10 @@ class _RedisStore:
         # SET NX EX is atomic on the Redis server — no TOCTOU window.
         result = self._client.set(self._prefix + key, "1", ex=ttl, nx=True)
         return result is not None
+
+    def release(self, key: str) -> None:
+        """Delete the fingerprint key (compensating rollback)."""
+        self._client.delete(self._prefix + key)
 
     def clear(self) -> None:
         keys = self._client.keys(self._prefix + "*")
@@ -199,6 +208,19 @@ class ReplayGuard:
                 fingerprint=fingerprint,
             )
         logger.debug("Replay guard: new fingerprint recorded %s...", fingerprint[:16])
+
+    def release(self, fingerprint: str) -> None:
+        """Forget a fingerprint recorded by :meth:`check_and_record`.
+
+        Compensating rollback: when a payment passes the replay check but is
+        then denied (MPA) or fails to sign, the fingerprint must be released so
+        the legitimate retry of the same canonical payment is not rejected as a
+        replay. This is what makes the documented MPA crypto-mode
+        countersignature retry workflow work — the signature-less first attempt
+        no longer poisons the retry (F-03).
+        """
+        self._store.release(fingerprint)
+        logger.debug("Replay guard: released fingerprint %s...", fingerprint[:16])
 
     def reset(self) -> None:
         """Clear all recorded fingerprints (useful in tests)."""

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -12,11 +12,13 @@ from presidio_x402 import HardenedX402Client
 from presidio_x402._types import PaymentDetails, PaymentResponse
 from presidio_x402.audit_log import NullAuditWriter
 from presidio_x402.exceptions import (
+    MPADeniedError,
     PIIBlockedError,
     PolicyViolationError,
     ReplayDetectedError,
     X402PaymentError,
 )
+from presidio_x402.mpa import MPAApproverConfig, MPAConfig, MPAEngine
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -300,6 +302,101 @@ async def test_signer_failure_raises_x402_payment_error():
         async with _make_client(payment_signer=failing_signer) as client:
             with pytest.raises(X402PaymentError, match="Payment signing failed"):
                 await client.get("https://api.example.com/v1/data")
+
+
+# ---------------------------------------------------------------------------
+# F-03: spend + replay are rolled back when the payment never commits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_signer_failure_rolls_back_spend_and_replay():
+    """A signer failure must not leak budget or burn the replay fingerprint:
+    the payment was committed to the ledgers before signing, so a failed sign
+    has to be compensated (F-03)."""
+
+    async def failing_signer(details):
+        raise RuntimeError("transient wallet error")
+
+    with respx.mock:
+        respx.get("https://api.example.com/v1/data").mock(
+            return_value=httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE})
+        )
+        async with _make_client(
+            payment_signer=failing_signer,
+            policy={"daily_limit_usd": 1.0},
+            replay_ttl=300,
+        ) as client:
+            with pytest.raises(X402PaymentError, match="Payment signing failed"):
+                await client.get("https://api.example.com/v1/data")
+
+            # Spend ledger rolled back to zero; fingerprint released.
+            assert client._policy._global_ledger.total() == 0.0
+            assert client._replay._store._store == {}
+
+
+@pytest.mark.asyncio
+async def test_retry_after_signer_failure_is_not_blocked_as_replay():
+    """End-to-end: a transient signer failure on attempt 1 must not poison the
+    legitimate retry of the same canonical payment (F-03)."""
+    calls = {"n": 0}
+
+    async def flaky_signer(details: PaymentDetails) -> PaymentResponse:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient wallet error")
+        return PaymentResponse(token="ok-token", details=details)  # noqa: S106
+
+    with respx.mock:
+        route = respx.get("https://api.example.com/v1/data")
+        route.side_effect = [
+            # attempt 1: 402 → signer fails (rolled back)
+            httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE}),
+            # attempt 2: 402 → signer succeeds → 200
+            httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE}),
+            httpx.Response(200, text="paid"),
+        ]
+        async with _make_client(
+            payment_signer=flaky_signer,
+            policy={"daily_limit_usd": 1.0},
+            replay_ttl=300,
+        ) as client:
+            with pytest.raises(X402PaymentError, match="Payment signing failed"):
+                await client.get("https://api.example.com/v1/data")
+
+            resp = await client.get("https://api.example.com/v1/data")
+            assert resp.status_code == 200
+            assert resp.text == "paid"
+
+
+@pytest.mark.asyncio
+async def test_mpa_denial_rolls_back_spend_and_replay():
+    """An MPA-denied payment must not consume budget or burn the replay
+    fingerprint — the latter would block the legitimate crypto-mode retry that
+    carries the countersignatures (F-03)."""
+    mpa = MPAEngine(
+        MPAConfig(
+            threshold=1,
+            approvers=[MPAApproverConfig("alice", mode="crypto", shared_secret=b"alice-secret")],
+            min_amount_usd=0.0,
+            dns_rebinding_protection=False,
+        )
+    )
+    with respx.mock:
+        respx.get("https://api.example.com/v1/data").mock(
+            return_value=httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE})
+        )
+        async with _make_client(
+            mpa_engine=mpa,
+            policy={"daily_limit_usd": 1.0},
+            replay_ttl=300,
+        ) as client:
+            # No mpa_signatures supplied → crypto approver denies.
+            with pytest.raises(MPADeniedError):
+                await client.get("https://api.example.com/v1/data")
+
+            assert client._policy._global_ledger.total() == 0.0
+            assert client._replay._store._store == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -163,3 +163,29 @@ class TestPolicyEngineWindowExpiry:
         time.sleep(1.1)
         # Old entry expired; new payment should be allowed
         engine.check_and_record(resource_url="https://api.example.com", amount_usd=0.08)
+
+
+class TestPolicyEngineRefund:
+    """F-03 compensating rollback: refund reverses a recorded spend on both the
+    global and per-endpoint ledgers."""
+
+    def test_refund_frees_global_budget(self):
+        engine = PolicyEngine(PolicyConfig(daily_limit_usd=0.10))
+        engine.check_and_record(resource_url="https://api.example.com", amount_usd=0.08)
+        # A second 0.08 would exceed the 0.10 daily limit...
+        with pytest.raises(PolicyViolationError):
+            engine.check_and_record(resource_url="https://api.example.com", amount_usd=0.08)
+        # ...but after refunding the first, it fits again.
+        engine.refund(resource_url="https://api.example.com", amount_usd=0.08)
+        engine.check_and_record(resource_url="https://api.example.com", amount_usd=0.08)
+
+    def test_refund_frees_per_endpoint_budget(self):
+        engine = PolicyEngine(PolicyConfig(per_endpoint={"https://api.example.com": 0.10}))
+        engine.check_and_record(resource_url="https://api.example.com/data", amount_usd=0.08)
+        engine.refund(resource_url="https://api.example.com/data", amount_usd=0.08)
+        # Endpoint ledger reversed → same payment is allowed again.
+        engine.check_and_record(resource_url="https://api.example.com/data", amount_usd=0.08)
+
+    def test_refund_without_matching_entry_is_noop(self):
+        engine = PolicyEngine(PolicyConfig(daily_limit_usd=0.10))
+        engine.refund(resource_url="https://api.example.com", amount_usd=0.05)  # must not raise

--- a/tests/test_replay_guard.py
+++ b/tests/test_replay_guard.py
@@ -92,6 +92,15 @@ class TestReplayGuardMemory:
         self.guard.check_and_record("fp-a")
         self.guard.check_and_record("fp-b")  # different fingerprint — should not raise
 
+    def test_release_allows_same_fingerprint_again(self):
+        # F-03 compensating rollback: a released fingerprint can be re-recorded.
+        self.guard.check_and_record("fp-rollback")
+        self.guard.release("fp-rollback")
+        self.guard.check_and_record("fp-rollback")  # must not raise
+
+    def test_release_unknown_fingerprint_is_noop(self):
+        self.guard.release("never-recorded")  # must not raise
+
     def test_replay_error_message_contains_fingerprint_prefix(self):
         self.guard.check_and_record("abcdef1234567890")
         with pytest.raises(ReplayDetectedError, match="abcdef12"):


### PR DESCRIPTION
Closes **F-03** (Medium) from the 2026-06-03 source audit — the last actionable finding from that report.

## Problem
In `_apply_security_controls` the order was: PII → wallet → **policy.check_and_record (commits spend)** → **replay.check_and_record (commits fingerprint)** → MPA → return, with signing happening afterward in `_request`. So the spend ledger and replay fingerprint were durably recorded *before* MPA was evaluated and *before* the payment was signed:

- An MPA-denied / timed-out payment still charged the daily + per-endpoint budget and burned a replay slot.
- The documented MPA crypto-mode retry was broken: the signature-less first attempt recorded the fingerprint, so the legitimate retry (same canonical payment, now with countersignatures) failed with `ReplayDetectedError`.
- A signer failure leaked budget and burned the fingerprint with no payment made — a hostile server inducing repeated signer failures could drain the accounting budget and block legitimate retries.

## Fix — compensating rollback
Record-on-success was rejected: the check+record must stay atomic under a single lock to preserve the existing TOCTOU protection, and a `threading.Lock` cannot span the async signer `await`. Instead the speculative commit is reversed on every path where the payment does not settle:

- `PolicyEngine.refund()` — reverses the recorded global + per-endpoint spend (under the same `_check_lock`).
- `ReplayGuard.release()` — forgets a recorded fingerprint (memory + Redis backends).
- `gateway._rollback_commit()` — reverses both, invoked on MPA denial/timeout and on signer failure before re-raising.

## Test plan
- [x] `ruff check` + `ruff format --check` (src + tests)
- [x] `pytest tests/` — 288 passed, 2 skipped
- [x] New: signer-failure rolls back spend + replay (white-box)
- [x] New: transient signer failure does not block the retry (end-to-end)
- [x] New: MPA-denied payment rolls back spend + replay
- [x] New: unit tests for `PolicyEngine.refund` (global + per-endpoint) and `ReplayGuard.release`