### PR TITLE
docs: update SECURITY.md supported versions to 0.4.x (I-03)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.3.x   | ✓ (current) |
-| 0.2.x   | ✓ |
-| 0.1.x   | security fixes only |
+| 0.4.x   | ✓ (current) |
+| 0.3.x   | ✓ |
+| 0.2.x   | security fixes only |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Closes **I-03** (Informational) from the 2026-06-03 audit.

The `## Supported Versions` table listed `0.3.x` as current, but the package is `0.4.0` — signalling an unsupported release as current. Shifted the window up by one:

| Version | Supported |
|---------|-----------|
| 0.4.x   | ✓ (current) |
| 0.3.x   | ✓ |
| 0.2.x   | security fixes only |

## Test plan
- [x] Docs-only change; no code paths affected