### PR TITLE
security: batch library Low-severity audit fixes (F-04..F-07, local F4/F6)

### DIFF
--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -119,10 +119,21 @@ def _parse_402_header(header_value: str) -> PaymentDetails:
         )
     try:
         data = json.loads(header_value)
-    except json.JSONDecodeError as exc:
-        # Never embed the raw JSON (which may carry wallet/PII fragments) in
-        # the message. Original cause remains on __cause__ for debugging.
+    except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+        # Also catch RecursionError: deeply nested JSON (small byte payload, under
+        # the size cap above) makes json.loads recurse to the interpreter limit;
+        # without this it would propagate uncaught and bypass the sanitised audit
+        # path (F-04, 2026-06-03). Never embed the raw JSON (which may carry
+        # wallet/PII fragments) in the message; the parse-error cause itself
+        # carries only position info, so it is kept on __cause__ for debugging.
         raise X402PaymentError("Invalid X-PAYMENT header JSON") from exc
+
+    # The top level must be a JSON object. A valid-but-non-object payload (a
+    # bare array/number/string, e.g. a moderately nested list that parses before
+    # the recursion limit) would otherwise reach data.get() and raise an uncaught
+    # AttributeError outside the sanitised audit path (F-04, 2026-06-03).
+    if not isinstance(data, dict):
+        raise X402PaymentError("Invalid X-PAYMENT header JSON")
 
     accepts = data.get("accepts", [])
     if not accepts:
@@ -291,8 +302,16 @@ class HardenedX402Client:
         self._httpx = httpx_client or httpx.AsyncClient(timeout=30.0)
         self._mpa = mpa_engine
         self._metrics = metrics_collector
+        # Store allowlisted wallet addresses lower-cased: EVM addresses are
+        # case-insensitive (EIP-55 checksum casing is optional), so comparing
+        # verbatim would reject a valid checksummed/lower-case variant and cause
+        # an avoidable payment outage (F-06 local audit, 2026-06-03). pay_to is
+        # lower-cased at comparison time to match.
         self._trusted_wallets: dict[str, frozenset[str]] | None = (
-            {origin.rstrip("/"): frozenset(wallets) for origin, wallets in trusted_wallets.items()}
+            {
+                origin.rstrip("/"): frozenset(w.lower() for w in wallets)
+                for origin, wallets in trusted_wallets.items()
+            }
             if trusted_wallets is not None
             else None
         )
@@ -380,7 +399,13 @@ class HardenedX402Client:
                 outcome="blocked",
                 error_message=safe_msg,
             )
-            raise X402PaymentError("Payment signing failed") from exc
+            # Drop the cause (F-07, 2026-06-03): a wallet/signer SDK exception can
+            # carry key material, mnemonics, or raw payloads in its message and
+            # traceback. Preserving it on __cause__ would leak that into any
+            # caller that logs the exception chain — outside this library's
+            # sanitised audit path. The truncated+redacted message is already in
+            # the audit record above.
+            raise X402PaymentError("Payment signing failed") from None
 
         # Retry request with payment token
         headers = dict(kwargs.pop("headers", {}) or {})
@@ -459,6 +484,17 @@ class HardenedX402Client:
                 details.reason,
                 entities=self._pii_entities,
             )
+            # Defense-in-depth (F-06, 2026-06-03): the remote screener is the
+            # only scan of the three primary fields, so a mis-redacting, empty,
+            # or silently degraded response would pass PII through unredacted.
+            # Re-run the fast local regex filter over its output as a cheap
+            # backstop. On a correct remote response the fields are already
+            # masked, so this finds nothing; it only catches what the remote
+            # missed, and feeds those entities into the block/redact decision.
+            clean_url, url_ent = self._pii_filter.scan_and_redact(clean_url)
+            clean_desc, desc_ent = self._pii_filter.scan_and_redact(clean_desc)
+            clean_reason, reason_ent = self._pii_filter.scan_and_redact(clean_reason)
+            pii_entities = list(pii_entities) + url_ent + desc_ent + reason_ent
         else:
             clean_url, clean_desc, clean_reason, pii_entities = (
                 self._pii_filter.scan_payment_fields(
@@ -535,7 +571,7 @@ class HardenedX402Client:
             # (CWE-348 / F-02, 2026-06-03).
             origin = _resource_origin(original_resource_url)
             allowed = self._trusted_wallets.get(origin)
-            if allowed is not None and details.pay_to not in allowed:
+            if allowed is not None and details.pay_to.lower() not in allowed:
                 # The raw origin may contain a redactable host; keep it out of
                 # the persisted audit message and surface only the redacted URL.
                 self._audit.emit(

--- a/src/presidio_x402/mpa.py
+++ b/src/presidio_x402/mpa.py
@@ -126,14 +126,21 @@ def _validate_webhook_url(url: str) -> None:
         raise MPAWebhookURLError(f"MPA webhook URL host {host!r} is in a blocked network range")
 
 
-def _resolve_and_check_host(host: str) -> None:
+async def _resolve_and_check_host(host: str) -> None:
     """Resolve *host* and raise if any A/AAAA record falls in a blocked range.
 
     Defeats DNS-rebinding attacks where a public hostname briefly resolves to
     an internal IP between config time and request time.
+
+    Resolution runs on the event loop's executor (``loop.getaddrinfo``) rather
+    than the blocking ``socket.getaddrinfo``. A slow/hostile DNS authority would
+    otherwise block the entire event loop — stalling all concurrent approvals —
+    and the surrounding ``asyncio.wait_for`` timeout could not fire during a
+    synchronous C call (F-05, 2026-06-03).
     """
+    loop = asyncio.get_running_loop()
     try:
-        infos = socket.getaddrinfo(host, None)
+        infos = await loop.getaddrinfo(host, None)
     except socket.gaierror as exc:
         raise MPAWebhookURLError(f"DNS resolution failed for {host!r}") from exc
     for info in infos:
@@ -468,7 +475,7 @@ class MPAEngine:
                     ipaddress.ip_address(host)
                 except ValueError:
                     if host:
-                        _resolve_and_check_host(host)
+                        await _resolve_and_check_host(host)
             # Outbound request authentication. When a shared_secret is
             # configured, sign the request body with HMAC-SHA256 so the
             # approver can verify the request originated from this MPA engine

--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -24,9 +24,16 @@ import unicodedata
 from dataclasses import dataclass
 from typing import Literal
 
+from .exceptions import X402PaymentError
+
 logger = logging.getLogger("presidio_x402.pii_filter")
 
 REDACTED_TEMPLATE = "<REDACTED>"
+
+# Maximum nesting depth for scan_dict over the untrusted `extra` field. Deeper
+# structures are rejected to prevent a RecursionError DoS (F-04). 32 is far above
+# any legitimate x402 `extra` payload.
+_MAX_SCAN_DEPTH = 32
 
 # Invisible codepoints stripped before matching: zero-width space/non-joiner/joiner,
 # byte-order mark, soft hyphen. Present them in metadata purely to evade regex.
@@ -345,14 +352,27 @@ class PIIFilter:
 
         Returns ``(redacted_data, entities)``. ``redacted_data`` is a new
         container of the same shape as the input.
+
+        Raises :class:`~presidio_x402.exceptions.X402PaymentError` if the nesting
+        depth exceeds ``_MAX_SCAN_DEPTH``. A malicious 402 server could otherwise
+        send a deeply nested ``extra`` payload that exhausts the interpreter
+        recursion limit and surfaces as an uncaught ``RecursionError`` rather
+        than a structured payment error (F-04, 2026-06-03).
         """
+        return self._scan_dict(data, _depth=0)
+
+    def _scan_dict(self, data: object, _depth: int) -> tuple[object, list[EntityResult]]:
+        if _depth > _MAX_SCAN_DEPTH:
+            raise X402PaymentError(
+                f"payment metadata 'extra' nesting exceeds maximum depth of {_MAX_SCAN_DEPTH}"
+            )
         if isinstance(data, str):
             return self.scan_and_redact(data)
         if isinstance(data, dict):
             redacted_dict: dict[object, object] = {}
             entities: list[EntityResult] = []
             for k, v in data.items():
-                clean_v, v_entities = self.scan_dict(v)
+                clean_v, v_entities = self._scan_dict(v, _depth + 1)
                 redacted_dict[k] = clean_v
                 entities.extend(v_entities)
             return redacted_dict, entities
@@ -360,7 +380,7 @@ class PIIFilter:
             redacted_list: list[object] = []
             entities = []
             for item in data:
-                clean_item, item_entities = self.scan_dict(item)
+                clean_item, item_entities = self._scan_dict(item, _depth + 1)
                 redacted_list.append(clean_item)
                 entities.extend(item_entities)
             return redacted_list, entities

--- a/src/presidio_x402/screening_client.py
+++ b/src/presidio_x402/screening_client.py
@@ -51,6 +51,12 @@ logger = logging.getLogger("presidio_x402.screening_client")
 _DEFAULT_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
 _RETRY_BACKOFF_SECONDS = 0.5
 
+# Max size of a screening response body before JSON parsing. A compromised or
+# misconfigured screening endpoint could otherwise return a huge body and force
+# memory-heavy parsing in the agent process (F4 local audit, 2026-06-03). 1 MiB
+# is far above any legitimate screening result.
+_SCREENING_RESPONSE_MAX_BYTES = 1_048_576
+
 
 class ScreeningClient:
     """HTTPS client for the Presidio screening service.
@@ -189,6 +195,8 @@ class ScreeningClient:
 
             status = resp.status_code
             if status == 200:
+                if len(resp.content) > _SCREENING_RESPONSE_MAX_BYTES:
+                    raise ScreeningUnavailableError("Screening response too large")
                 try:
                     return resp.json()
                 except ValueError as exc:

--- a/tests/test_adversary_chains.py
+++ b/tests/test_adversary_chains.py
@@ -310,9 +310,11 @@ class TestChain05ExceptionExfiltration:
     async def test_site_c_signer_exception_not_reraised_in_message(self):
         """Signer exception text does not leak into the raised X402PaymentError.
 
-        The fix contract is: ``X402PaymentError`` message is a constant; the
-        original cause is preserved on ``__cause__`` for local debug only.
-        Callers (and anything consuming ``str(exc)``) see no payload.
+        The fix contract is: ``X402PaymentError`` message is a constant AND the
+        signer cause is dropped (``from None``) so a caller that logs the
+        exception chain cannot leak key material the signer SDK put in its
+        message/traceback (F-07, 2026-06-03). The redacted detail still reaches
+        the sanitised audit record.
         """
 
         async def _leaky_signer(details: PaymentDetails) -> PaymentResponse:
@@ -336,7 +338,8 @@ class TestChain05ExceptionExfiltration:
         assert msg == "Payment signing failed"
         assert self._SECRET_KEY_FRAGMENT not in msg
         assert self._SECRET_WALLET not in msg
-        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        # F-07: signer cause is suppressed so it cannot leak via a logged chain.
+        assert exc_info.value.__cause__ is None
 
     @pytest.mark.asyncio
     async def test_site_c_signer_structural_pii_scrubbed_from_audit(self):
@@ -590,6 +593,30 @@ class TestChain06WalletSubstitution:
 
         assert not signed_details, "Signer must not run: redacted host must still gate pay_to"
         assert [e for e in audit.events if e.event_type == "WALLET_BLOCKED"]
+
+    @pytest.mark.asyncio
+    async def test_allowlist_is_case_insensitive_for_evm_address(self):
+        """local-F6 (2026-06-03): EVM addresses are case-insensitive, so a valid
+        case variant of an allowlisted wallet must be accepted, not rejected as a
+        substitution — otherwise checksum-casing differences cause a payment
+        outage."""
+        checksummed = "0xAbCdEf1234567890aBcDeF1234567890AbCdEf12"
+        with respx.mock:
+            route = respx.get("https://api.example.com/v1/data")
+            route.side_effect = [
+                # Server pays the lower-case form of the allowlisted address.
+                httpx.Response(402, headers={"X-PAYMENT": _header_for(checksummed.lower())}),
+                httpx.Response(200, text="ok"),
+            ]
+            client = HardenedX402Client(
+                payment_signer=_mock_signer,
+                trusted_wallets={"https://api.example.com": {checksummed}},
+            )
+            try:
+                resp = await client.get("https://api.example.com/v1/data")
+            finally:
+                await client.aclose()
+        assert resp.status_code == 200
 
 
 # Suppress "unused import" for ``replace`` — retained in case future POC tests

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -139,6 +139,34 @@ async def test_malformed_x_payment_header_raises_x402_error():
 
 
 @pytest.mark.asyncio
+async def test_deeply_nested_x_payment_header_raises_x402_error():
+    # F-04 (2026-06-03): a small but deeply nested JSON header (under the size
+    # cap) makes json.loads hit the recursion limit. The parse guard must catch
+    # RecursionError and surface a structured X402PaymentError, not crash.
+    nested = "[" * 10000 + "]" * 10000  # ~20 KB, < 64 KiB cap; triggers RecursionError
+    with respx.mock:
+        respx.get("https://api.example.com/v1/data").mock(
+            return_value=httpx.Response(402, headers={"X-PAYMENT": nested})
+        )
+        async with _make_client() as client:
+            with pytest.raises(X402PaymentError, match="Invalid X-PAYMENT header JSON"):
+                await client.get("https://api.example.com/v1/data")
+
+
+@pytest.mark.asyncio
+async def test_non_object_x_payment_header_raises_x402_error():
+    # F-04 (2026-06-03): a valid-but-non-object header (here a bare JSON array)
+    # must not reach data.get() and raise an uncaught AttributeError.
+    with respx.mock:
+        respx.get("https://api.example.com/v1/data").mock(
+            return_value=httpx.Response(402, headers={"X-PAYMENT": "[1, 2, 3]"})
+        )
+        async with _make_client() as client:
+            with pytest.raises(X402PaymentError, match="Invalid X-PAYMENT header JSON"):
+                await client.get("https://api.example.com/v1/data")
+
+
+@pytest.mark.asyncio
 async def test_oversized_x_payment_header_raises_before_json_parse():
     # F3 regression (2026-05-17): a hostile 402 server could return a
     # multi-megabyte X-PAYMENT header and force json.loads to allocate memory

--- a/tests/test_gateway_remote_screening.py
+++ b/tests/test_gateway_remote_screening.py
@@ -110,6 +110,36 @@ class TestRemoteScreeningHappyPath:
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
+    async def test_local_backstop_catches_remote_miss(self) -> None:
+        """F-06 (2026-06-03): a degraded remote that returns a field unredacted
+        with no entities must not pass PII through — the local regex filter
+        re-scans the remote output as defense-in-depth."""
+        degraded = {
+            **SCREEN_RESPONSE,
+            # Remote silently failed to redact and reported nothing.
+            "redacted_description": "Inference request for bob@evil.test",
+            "entities_found": [],
+        }
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=degraded))
+            respx.get(RESOURCE).mock(
+                return_value=httpx.Response(402, headers={"X-PAYMENT": PAYMENT_HEADER_VALUE})
+            )
+            screening = ScreeningClient(BASE, API_KEY)
+            try:
+                async with _make_client(
+                    screening_client=screening,
+                    remote_screening=True,
+                    pii_action="block",
+                ) as client:
+                    with pytest.raises(PIIBlockedError) as excinfo:
+                        await client.get(RESOURCE)
+            finally:
+                await screening.aclose()
+        # The local pass caught the email the remote missed.
+        assert "EMAIL_ADDRESS" in str(excinfo.value)
+
+    @pytest.mark.asyncio
     async def test_block_mode_raises_on_remote_detected_pii(self) -> None:
         with respx.mock:
             respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, json=SCREEN_RESPONSE))

--- a/tests/test_mpa.py
+++ b/tests/test_mpa.py
@@ -11,13 +11,27 @@ import pytest
 import respx
 
 from presidio_x402._types import PaymentDetails
-from presidio_x402.exceptions import MPADeniedError
+from presidio_x402.exceptions import MPADeniedError, MPAWebhookURLError
 from presidio_x402.mpa import (
     MPAApproverConfig,
     MPAConfig,
     MPAEngine,
     _canonical_payload,
+    _resolve_and_check_host,
 )
+
+
+class TestResolveAndCheckHost:
+    """F-05 (2026-06-03): DNS-rebinding resolution runs off the event loop and
+    still flags hosts that resolve into a blocked range."""
+
+    @pytest.mark.asyncio
+    async def test_loopback_resolution_is_blocked(self):
+        # localhost resolves to a loopback address (blocked range) — deterministic
+        # and offline. Exercises the async loop.getaddrinfo path.
+        with pytest.raises(MPAWebhookURLError, match="blocked address"):
+            await _resolve_and_check_host("localhost")
+
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_pii_filter.py
+++ b/tests/test_pii_filter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from presidio_x402.exceptions import X402PaymentError
 from presidio_x402.pii_filter import PIIFilter
 
 
@@ -181,6 +182,22 @@ class TestPIIFilterRegexMode:
         clean, entities = self.filt.scan_dict({})
         assert clean == {}
         assert entities == []
+
+    def test_scan_dict_rejects_excessive_nesting(self):
+        """F-04 (2026-06-03): deeply nested data raises a structured payment
+        error rather than an uncaught RecursionError."""
+        deep: object = "leaf"
+        for _ in range(200):
+            deep = {"k": deep}
+        with pytest.raises(X402PaymentError, match="nesting exceeds maximum depth"):
+            self.filt.scan_dict(deep)
+
+    def test_scan_dict_allows_reasonable_nesting(self):
+        # A modestly nested structure is still scanned normally.
+        nested = {"a": {"b": {"c": ["alice@example.com"]}}}
+        clean, entities = self.filt.scan_dict(nested)
+        assert entities and entities[0].entity_type == "EMAIL_ADDRESS"
+        assert clean["a"]["b"]["c"][0] != "alice@example.com"
 
     # ------------------------------------------------------------------
     # NLP mode import error

--- a/tests/test_screening_client.py
+++ b/tests/test_screening_client.py
@@ -79,6 +79,20 @@ class TestInit:
             ScreeningClient(base_url="ftp://example.com", api_key=API_KEY)
 
 
+class TestResponseSizeCap:
+    @pytest.mark.asyncio
+    async def test_oversized_response_rejected_before_parse(self) -> None:
+        """local-F4 (2026-06-03): a 200 body over the size cap is rejected before
+        json parsing so a hostile/misconfigured endpoint cannot force memory-heavy
+        parsing in the agent process."""
+        huge = b'{"x":"' + b"a" * 1_200_000 + b'"}'  # > 1 MiB
+        with respx.mock:
+            respx.post(SCREEN_URL).mock(return_value=httpx.Response(200, content=huge))
+            async with ScreeningClient(BASE, API_KEY) as c:
+                with pytest.raises(ScreeningUnavailableError, match="too large"):
+                    await c.scan_payment_fields("https://api.example.com/x", "d", "")
+
+
 class TestHappyPath:
     @pytest.mark.asyncio
     async def test_200_response_returns_redacted_tuple(self) -> None:


### PR DESCRIPTION
Closes the actionable **Low** findings from both 2026-06-03 audits in one pass. All confirmed against source and covered by regression tests.

| Finding | Fix | Files |
|---|---|---|
| **F-04** recursion DoS | `scan_dict` enforces max nesting depth (32); `_parse_402_header` catches `RecursionError` and rejects non-object top-level JSON → structured `X402PaymentError`, never an uncaught `RecursionError`/`AttributeError` | `pii_filter.py`, `gateway.py` |
| **F-05** blocking DNS on async path | MPA DNS-rebinding check uses `loop.getaddrinfo` instead of blocking `socket.getaddrinfo` — can't stall the event loop or evade the `wait_for` timeout | `mpa.py` |
| **F-06** remote-screening SPOF | re-run the fast local regex `PIIFilter` over remote output as defense-in-depth, so a mis-redacting/degraded remote can't pass PII through on the 3 primary fields | `gateway.py` |
| **F-07** signer `__cause__` leak | `raise ... from None` on the signer path so a caller logging the exception chain can't leak key material from a wallet-SDK exception (the parse path keeps its safe `JSONDecodeError` cause) | `gateway.py` |
| **local-F4** unbounded response | cap `ScreeningClient` response body (1 MiB) before JSON parsing | `screening_client.py` |
| **local-F6** wallet case | case-fold `trusted_wallets` addresses (EVM is case-insensitive) so a valid checksum variant isn't rejected | `gateway.py` |

### Note on a contract change (F-07)
`test_site_c` previously asserted the signer `__cause__` was *preserved*; F-07 reverses that (cause now dropped) because preserving it is the leak vector. The parse-path cause (`JSONDecodeError`, carries only position info) is intentionally kept, matching `test_site_a`.

### Deferred
- **F-08** (MPA countersignature nonce/timestamp binding) — changes the approver signing contract (breaking); needs its own design PR.
- Info items I-01/I-02/I-04/I-05.

## Test plan
- [x] `ruff check` + `ruff format --check` (src + tests)
- [x] `pytest tests/` — **296 passed, 2 skipped**
- [x] New regression tests: deep-nesting (header + scan_dict), non-object header, async loopback resolve, remote-miss backstop, oversized response, wallet case-fold