### PR TITLE
security: bind MPA crypto countersignatures to a freshness timestamp (F-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `presidio-hardened-x402` are documented here. Format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **BREAKING (crypto-mode MPA):** countersignatures are now freshness-bound. The
+  wire format is `"<unix_ts>:<hmac_hex>"` and the signed payload includes the
+  approver's timestamp; the engine rejects signatures outside the new
+  `MPAConfig.max_signature_age_seconds` window (default 300s). This prevents a
+  captured countersignature from being replayed for an identical payment once the
+  ReplayGuard TTL elapses (F-8, audit 2026-06-03). Approvers should produce
+  signatures with the new `build_countersignature()` helper; bare-hex signatures
+  from prior versions no longer validate.
+
+### Added
+- `mpa.build_countersignature(shared_secret, details, amount_usd)` — public
+  helper that produces the timestamped crypto-mode countersignature.
+
 ## [0.4.0] — 2026-05-17
 
 The screening-api release. Pairs the published `screen.presidio-group.eu`

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -43,7 +43,7 @@ from .exceptions import (
 )
 from .gateway import HardenedX402Client
 from .metrics import MetricsCollector
-from .mpa import MPAApproverConfig, MPAConfig, MPAEngine
+from .mpa import MPAApproverConfig, MPAConfig, MPAEngine, build_countersignature
 from .pii_filter import PIIFilter
 from .policy_engine import PolicyConfig, PolicyEngine
 from .replay_guard import ReplayGuard, compute_fingerprint
@@ -59,6 +59,7 @@ __all__ = [
     "MPAConfig",
     "MPAApproverConfig",
     "MPAEngine",
+    "build_countersignature",
     # Prometheus metrics
     "MetricsCollector",
     # Remote screening

--- a/src/presidio_x402/mpa.py
+++ b/src/presidio_x402/mpa.py
@@ -36,8 +36,7 @@ Usage (webhook mode)::
 
 Usage (crypto mode)::
 
-    import hashlib
-    import hmac
+    from presidio_x402.mpa import build_countersignature
 
     mpa = MPAEngine(MPAConfig(
         threshold=2,
@@ -48,11 +47,15 @@ Usage (crypto mode)::
         ],
     ))
 
-    # Collect countersignatures out-of-band; pass in kwargs:
+    # Each approver signs the payment out-of-band with build_countersignature,
+    # which embeds a freshness timestamp ("<unix_ts>:<hmac_hex>"). Pass in kwargs:
     response = await client.get(url, mpa_signatures={
-        "alice": hmac.new(b"alice-secret", payload, hashlib.sha256).hexdigest(),
-        "bob":   hmac.new(b"bob-secret",   payload, hashlib.sha256).hexdigest(),
+        "alice": build_countersignature(b"alice-secret", details, amount_usd),
+        "bob":   build_countersignature(b"bob-secret",   details, amount_usd),
     })
+
+    # Signatures older than MPAConfig.max_signature_age_seconds are rejected, so
+    # they cannot be replayed once the ReplayGuard TTL has elapsed.
 """
 
 from __future__ import annotations
@@ -64,6 +67,7 @@ import ipaddress
 import json
 import logging
 import socket
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
@@ -212,6 +216,13 @@ class MPAConfig:
         loopback, IMDS, etc.). Default ``True``. Set ``False`` only in test
         fixtures that mock the HTTP transport and do not own real DNS for
         the configured approver hostnames.
+    max_signature_age_seconds:
+        Freshness window for ``crypto``-mode countersignatures (default ``300``).
+        Each countersignature embeds the approver's signing timestamp; the engine
+        rejects any whose timestamp is older (or further in the future) than this
+        many seconds. Without it a captured valid countersignature could be
+        replayed for an identical payment once the ReplayGuard TTL expires
+        (CWE-294 / F-8, 2026-06-03).
     """
 
     threshold: int
@@ -219,6 +230,7 @@ class MPAConfig:
     min_amount_usd: float = 0.0
     timeout_seconds: float = 30.0
     dns_rebinding_protection: bool = True
+    max_signature_age_seconds: int = 300
 
     def __post_init__(self) -> None:
         if self.threshold < 1:
@@ -228,6 +240,8 @@ class MPAConfig:
                 f"MPAConfig.threshold ({self.threshold}) cannot exceed "
                 f"number of approvers ({len(self.approvers)})"
             )
+        if self.max_signature_age_seconds < 1:
+            raise ValueError("MPAConfig.max_signature_age_seconds must be >= 1")
 
 
 @dataclass(frozen=True)
@@ -252,8 +266,12 @@ class ApprovalResponse:
     reason: str | None = None
 
 
-def _canonical_payload(details: PaymentDetails, amount_usd: float) -> bytes:
-    """Build a deterministic canonical bytes payload for HMAC countersignature."""
+def _canonical_payload(details: PaymentDetails, amount_usd: float, timestamp: int) -> bytes:
+    """Build a deterministic canonical bytes payload for HMAC countersignature.
+
+    The approver's signing *timestamp* is part of the signed material so the
+    engine can enforce a freshness window and reject replayed signatures (F-8).
+    """
     canonical = json.dumps(
         {
             "resource_url": details.resource_url,
@@ -263,11 +281,33 @@ def _canonical_payload(details: PaymentDetails, amount_usd: float) -> bytes:
             "network": details.network,
             "deadline_seconds": details.deadline_seconds,
             "amount_usd": f"{amount_usd:.6f}",
+            "timestamp": timestamp,
         },
         sort_keys=True,
         separators=(",", ":"),
     )
     return canonical.encode()
+
+
+def build_countersignature(
+    shared_secret: bytes,
+    details: PaymentDetails,
+    amount_usd: float,
+    *,
+    timestamp: int | None = None,
+) -> str:
+    """Produce a crypto-mode MPA countersignature for *details*.
+
+    Returns a ``"<unix_ts>:<hmac_hex>"`` string: the approver's signing
+    timestamp and an HMAC-SHA256 over the canonical payment fields *including*
+    that timestamp. Approvers call this; the value is passed back to the agent
+    and supplied to :meth:`MPAEngine.request_approval` via
+    ``provided_signatures``. The engine rejects signatures whose timestamp is
+    outside ``MPAConfig.max_signature_age_seconds`` (F-8, 2026-06-03).
+    """
+    ts = int(time.time()) if timestamp is None else int(timestamp)
+    sig = hmac.new(shared_secret, _canonical_payload(details, amount_usd, ts), hashlib.sha256)
+    return f"{ts}:{sig.hexdigest()}"
 
 
 class MPAEngine:
@@ -313,9 +353,11 @@ class MPAEngine:
         amount_usd:
             Payment amount in USD.
         provided_signatures:
-            For ``crypto``-mode approvers: mapping of
-            ``approver_id`` → hex-encoded HMAC-SHA256 countersignature.
-            Signatures are verified against each approver's ``shared_secret``.
+            For ``crypto``-mode approvers: mapping of ``approver_id`` →
+            ``"<unix_ts>:<hmac_hex>"`` countersignature (produced by
+            :func:`build_countersignature`). Each is verified against the
+            approver's ``shared_secret`` and rejected if its timestamp is outside
+            ``config.max_signature_age_seconds``.
 
         Raises
         ------
@@ -341,11 +383,12 @@ class MPAEngine:
         # 1. Crypto mode: verify pre-collected HMAC countersignatures
         # ------------------------------------------------------------------
         if crypto_approvers:
-            payload = _canonical_payload(details, amount_usd)
             sigs = provided_signatures or {}
+            now = int(time.time())
+            max_age = self.config.max_signature_age_seconds
             for approver in crypto_approvers:
-                sig = sigs.get(approver.approver_id)
-                if not sig:
+                raw = sigs.get(approver.approver_id)
+                if not raw:
                     continue
                 if approver.shared_secret is None:
                     logger.warning(
@@ -353,8 +396,36 @@ class MPAEngine:
                         approver.approver_id,
                     )
                     continue
-                expected = hmac.new(approver.shared_secret, payload, hashlib.sha256).hexdigest()
-                if hmac.compare_digest(expected, sig.lower()):
+                # Wire format: "<unix_ts>:<hmac_hex>" (see build_countersignature).
+                ts_str, sep, hexsig = raw.partition(":")
+                if not sep or not hexsig:
+                    logger.warning(
+                        "MPA crypto signature for %s missing timestamp prefix",
+                        approver.approver_id,
+                    )
+                    continue
+                try:
+                    ts = int(ts_str)
+                except ValueError:
+                    logger.warning(
+                        "MPA crypto signature for %s has non-integer timestamp",
+                        approver.approver_id,
+                    )
+                    continue
+                if abs(now - ts) > max_age:
+                    logger.warning(
+                        "MPA crypto signature for %s is stale (age %ds, max %ds) — rejected",
+                        approver.approver_id,
+                        now - ts,
+                        max_age,
+                    )
+                    continue
+                expected = hmac.new(
+                    approver.shared_secret,
+                    _canonical_payload(details, amount_usd, ts),
+                    hashlib.sha256,
+                ).hexdigest()
+                if hmac.compare_digest(expected, hexsig.lower()):
                     approved_ids.add(approver.approver_id)
                     logger.info("MPA crypto approval verified: %s", approver.approver_id)
                 else:

--- a/tests/test_mpa.py
+++ b/tests/test_mpa.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import time
 
 import httpx
 import pytest
@@ -18,6 +19,7 @@ from presidio_x402.mpa import (
     MPAEngine,
     _canonical_payload,
     _resolve_and_check_host,
+    build_countersignature,
 )
 
 
@@ -53,9 +55,11 @@ def _make_details(**overrides) -> PaymentDetails:
     return PaymentDetails(**defaults)
 
 
-def _make_crypto_sig(secret: bytes, details: PaymentDetails, amount_usd: float) -> str:
-    payload = _canonical_payload(details, amount_usd)
-    return hmac.new(secret, payload, hashlib.sha256).hexdigest()
+def _make_crypto_sig(
+    secret: bytes, details: PaymentDetails, amount_usd: float, *, timestamp: int | None = None
+) -> str:
+    # Now produces the "<unix_ts>:<hmac_hex>" freshness-bound format (F-8).
+    return build_countersignature(secret, details, amount_usd, timestamp=timestamp)
 
 
 ALICE_SECRET = b"alice-shared-secret"
@@ -236,6 +240,73 @@ class TestMPACryptoMode:
             await engine.request_approval(self.details, self.amount_usd, provided_signatures=sigs)
         assert exc_info.value.approvals_received == 1
         assert exc_info.value.threshold == 2
+
+
+class TestMPACryptoFreshness:
+    """F-8 (2026-06-03): crypto countersignatures embed a timestamp and are
+    rejected outside MPAConfig.max_signature_age_seconds, so a captured signature
+    cannot be replayed for an identical payment after the ReplayGuard TTL."""
+
+    def setup_method(self):
+        self.details = _make_details(amount="2.00")
+        self.amount_usd = 2.00
+
+    def _engine(self, max_age: int = 300):
+        return MPAEngine(
+            MPAConfig(
+                dns_rebinding_protection=False,
+                threshold=1,
+                max_signature_age_seconds=max_age,
+                approvers=[MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET)],
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_signature_accepted(self):
+        sig = _make_crypto_sig(ALICE_SECRET, self.details, self.amount_usd)  # now()
+        await self._engine().request_approval(
+            self.details, self.amount_usd, provided_signatures={"alice": sig}
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_signature_rejected(self):
+        old = int(time.time()) - 3600  # 1h ago, well past the 300s window
+        sig = _make_crypto_sig(ALICE_SECRET, self.details, self.amount_usd, timestamp=old)
+        with pytest.raises(MPADeniedError):
+            await self._engine().request_approval(
+                self.details, self.amount_usd, provided_signatures={"alice": sig}
+            )
+
+    @pytest.mark.asyncio
+    async def test_legacy_format_without_timestamp_rejected(self):
+        # A bare hex signature (old format, no "<ts>:" prefix) must not validate.
+        legacy = hmac.new(
+            ALICE_SECRET, _canonical_payload(self.details, self.amount_usd, 0), hashlib.sha256
+        ).hexdigest()
+        with pytest.raises(MPADeniedError):
+            await self._engine().request_approval(
+                self.details, self.amount_usd, provided_signatures={"alice": legacy}
+            )
+
+    @pytest.mark.asyncio
+    async def test_tampered_timestamp_rejected(self):
+        # Take a valid sig, bump its timestamp — the HMAC no longer matches.
+        sig = _make_crypto_sig(ALICE_SECRET, self.details, self.amount_usd)
+        ts, _, hexsig = sig.partition(":")
+        tampered = f"{int(ts) + 1}:{hexsig}"
+        with pytest.raises(MPADeniedError):
+            await self._engine().request_approval(
+                self.details, self.amount_usd, provided_signatures={"alice": tampered}
+            )
+
+    def test_invalid_max_age_rejected(self):
+        with pytest.raises(ValueError, match="max_signature_age_seconds"):
+            MPAConfig(
+                dns_rebinding_protection=False,
+                threshold=1,
+                max_signature_age_seconds=0,
+                approvers=[MPAApproverConfig("alice", mode="crypto", shared_secret=ALICE_SECRET)],
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -555,24 +626,30 @@ class TestMPAMixedMode:
 
 
 class TestCanonicalPayload:
-    def test_same_details_produce_same_payload(self):
+    def test_same_details_and_timestamp_produce_same_payload(self):
         details = _make_details()
-        p1 = _canonical_payload(details, 1.00)
-        p2 = _canonical_payload(details, 1.00)
+        p1 = _canonical_payload(details, 1.00, 1000)
+        p2 = _canonical_payload(details, 1.00, 1000)
         assert p1 == p2
 
     def test_different_amounts_produce_different_payloads(self):
         details = _make_details()
-        p1 = _canonical_payload(details, 1.00)
-        p2 = _canonical_payload(details, 2.00)
+        p1 = _canonical_payload(details, 1.00, 1000)
+        p2 = _canonical_payload(details, 2.00, 1000)
         assert p1 != p2
+
+    def test_different_timestamp_produces_different_payload(self):
+        # F-8: the timestamp is part of the signed material.
+        details = _make_details()
+        assert _canonical_payload(details, 1.00, 1000) != _canonical_payload(details, 1.00, 2000)
 
     def test_payload_is_valid_json(self):
         details = _make_details()
-        payload = _canonical_payload(details, 1.00)
+        payload = _canonical_payload(details, 1.00, 1700000000)
         parsed = json.loads(payload)
         assert parsed["resource_url"] == details.resource_url
         assert "amount_usd" in parsed
+        assert parsed["timestamp"] == 1700000000
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes **F-8** (Low, CWE-294) from the 2026-06-03 audit — the last open library finding.

## Problem
Crypto-mode MPA countersignatures were an HMAC over the payment fields only, with no nonce or timestamp. A captured valid countersignature stayed valid for any future payment with identical fields — within the ReplayGuard TTL the duplicate is blocked, but **after TTL expiry** an observed approver signature could be replayed to satisfy MPA for an identical recurring payment.

## Fix — freshness binding
- Countersignature wire format is now **`"<unix_ts>:<hmac_hex>"`**; the canonical signed payload includes the approver's timestamp.
- The engine rejects any signature whose timestamp is outside **`MPAConfig.max_signature_age_seconds`** (new field, default 300s; validated ≥ 1). Constant-time HMAC compare is preserved.
- New public helper **`mpa.build_countersignature(shared_secret, details, amount_usd)`** produces the format so approvers don't hand-roll it.

## ⚠️ Breaking change (crypto-mode MPA only)
Bare-hex countersignatures from prior versions no longer validate — approvers must switch to `build_countersignature()`. **Webhook-mode MPA is unaffected.** Recorded under `[Unreleased]` in CHANGELOG.md.

Why timestamp (not engine-issued request-id): crypto-mode signatures are collected out-of-band before the engine computes a request-id, so an approver-chosen timestamp is the implementable freshness mechanism.

## Test plan
- [x] `ruff check` + `ruff format --check`
- [x] `pytest tests/` — **302 passed, 2 skipped**
- [x] New: fresh accepted; stale / legacy-bare-hex / tampered-timestamp rejected; `max_signature_age_seconds` validation; canonical-payload timestamp binding