### PR TITLE
experiments: bootstrap CIs + Piiranha transformer baseline

### DIFF
--- a/experiments/bootstrap_ci.py
+++ b/experiments/bootstrap_ci.py
@@ -1,0 +1,202 @@
+"""Bootstrap 95% confidence intervals for the recommended Presidio NLP config.
+
+Approach: case-bootstrap over corpus samples. Run Presidio NLP once to collect
+per-sample (per-entity) TP/FP/FN, then resample samples with replacement N times
+and recompute micro-P/R/F1 + per-entity F1 from the aggregated counts.
+
+This is the standard non-parametric CI procedure for classifier metrics; see
+Wilson (1927) for the analytic alternative when only proportions are needed.
+
+Usage::
+
+    python -m experiments.bootstrap_ci
+    python -m experiments.bootstrap_ci --n-bootstrap 10000 --seed 42
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_ROOT = Path(__file__).parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from corpus.generate import CORPUS_DIR, load_corpus
+from experiments.evaluate import _overlaps  # noqa: PLC2701
+
+RESULTS_DIR = Path(__file__).parent / "results"
+
+ALL_ENTITIES = [
+    "EMAIL_ADDRESS", "PERSON", "PHONE_NUMBER",
+    "US_SSN", "CREDIT_CARD", "IBAN_CODE",
+]
+
+
+def _per_sample_counts(samples, pii_filter) -> list[dict[str, list[int]]]:
+    """For each sample, return {entity_type: [tp, fp, fn]}.
+
+    Mirrors evaluate_corpus's matching logic; partial-span overlap.
+    """
+    out = []
+    for sample in samples:
+        per_field = {"resource_url": [], "description": [], "reason": []}
+        for fname, fval in (
+            ("resource_url", sample.resource_url),
+            ("description", sample.description),
+            ("reason", sample.reason),
+        ):
+            if not fval:
+                continue
+            _, ents = pii_filter.scan_and_redact(fval)
+            for e in ents:
+                per_field[fname].append((e.entity_type, e.start, e.end))
+
+        per_entity: dict[str, list[int]] = {et: [0, 0, 0] for et in ALL_ENTITIES}
+        matched_preds: set = set()
+
+        for gold in sample.labels:
+            etype = gold.entity_type
+            preds = per_field.get(gold.field, [])
+            found = False
+            for pe, ps, pe_end in preds:
+                key = (gold.field, pe, ps, pe_end)
+                if key in matched_preds:
+                    continue
+                if pe == etype and _overlaps(ps, pe_end, gold.start, gold.end):
+                    per_entity.setdefault(etype, [0, 0, 0])[0] += 1
+                    matched_preds.add(key)
+                    found = True
+                    break
+            if not found:
+                per_entity.setdefault(etype, [0, 0, 0])[2] += 1
+
+        for fname, preds in per_field.items():
+            for pe, ps, pe_end in preds:
+                key = (fname, pe, ps, pe_end)
+                if key not in matched_preds:
+                    per_entity.setdefault(pe, [0, 0, 0])[1] += 1
+
+        out.append(per_entity)
+    return out
+
+
+def _aggregate(per_sample: list[dict[str, list[int]]], indices: np.ndarray):
+    """Sum per-sample counts at the given resample indices."""
+    totals: dict[str, list[int]] = {et: [0, 0, 0] for et in ALL_ENTITIES}
+    for i in indices:
+        for et, (tp, fp, fn) in per_sample[i].items():
+            if et not in totals:
+                totals[et] = [0, 0, 0]
+            totals[et][0] += tp
+            totals[et][1] += fp
+            totals[et][2] += fn
+    return totals
+
+
+def _f1(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return p, r, f1
+
+
+def bootstrap(
+    samples,
+    pii_filter,
+    *,
+    n_bootstrap: int = 10000,
+    seed: int = 42,
+) -> dict:
+    print(f"  Running Presidio NLP over {len(samples)} samples...")
+    per_sample = _per_sample_counts(samples, pii_filter)
+    print(f"  Bootstrap-resampling {n_bootstrap} times (seed={seed})...")
+
+    rng = np.random.default_rng(seed)
+    N = len(per_sample)
+
+    micro_p = np.empty(n_bootstrap)
+    micro_r = np.empty(n_bootstrap)
+    micro_f1 = np.empty(n_bootstrap)
+    per_entity_f1: dict[str, np.ndarray] = {
+        et: np.empty(n_bootstrap) for et in ALL_ENTITIES
+    }
+
+    for k in range(n_bootstrap):
+        idx = rng.integers(0, N, size=N)
+        totals = _aggregate(per_sample, idx)
+        TP = sum(t[0] for t in totals.values())
+        FP = sum(t[1] for t in totals.values())
+        FN = sum(t[2] for t in totals.values())
+        p, r, f1 = _f1(TP, FP, FN)
+        micro_p[k] = p
+        micro_r[k] = r
+        micro_f1[k] = f1
+        for et in ALL_ENTITIES:
+            tp, fp, fn = totals.get(et, (0, 0, 0))
+            _, _, f1_e = _f1(tp, fp, fn)
+            per_entity_f1[et][k] = f1_e
+
+    def _ci(arr: np.ndarray) -> tuple[float, float, float]:
+        return (
+            float(np.percentile(arr, 2.5)),
+            float(np.percentile(arr, 50)),
+            float(np.percentile(arr, 97.5)),
+        )
+
+    return {
+        "n_samples": N,
+        "n_bootstrap": n_bootstrap,
+        "seed": seed,
+        "micro_precision": _ci(micro_p),
+        "micro_recall": _ci(micro_r),
+        "micro_f1": _ci(micro_f1),
+        "per_entity_f1": {et: _ci(per_entity_f1[et]) for et in ALL_ENTITIES},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bootstrap CIs for Presidio NLP")
+    parser.add_argument("--corpus", type=Path, default=CORPUS_DIR / "corpus.jsonl")
+    parser.add_argument("--n-bootstrap", type=int, default=10000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--min-score", type=float, default=0.4)
+    parser.add_argument("--out", type=Path, default=RESULTS_DIR / "bootstrap_ci.json")
+    args = parser.parse_args()
+
+    from presidio_x402.pii_filter import PIIFilter
+
+    print(f"Loading corpus from {args.corpus}...")
+    samples = load_corpus(args.corpus)
+    print(f"  Loaded {len(samples)} samples.")
+
+    print(f"Building PIIFilter(mode=nlp, all entities, min_score={args.min_score})...")
+    f = PIIFilter(mode="nlp", entities=ALL_ENTITIES, min_score=args.min_score)
+
+    result = bootstrap(samples, f, n_bootstrap=args.n_bootstrap, seed=args.seed)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as fh:
+        json.dump(result, fh, indent=2)
+
+    print("\n=== 95% bootstrap CIs (Presidio NLP recommended config) ===")
+    p_lo, p_med, p_hi = result["micro_precision"]
+    r_lo, r_med, r_hi = result["micro_recall"]
+    f_lo, f_med, f_hi = result["micro_f1"]
+    print(f"  micro precision: {p_med:.3f}  [{p_lo:.3f}, {p_hi:.3f}]")
+    print(f"  micro recall:    {r_med:.3f}  [{r_lo:.3f}, {r_hi:.3f}]")
+    print(f"  micro F1:        {f_med:.3f}  [{f_lo:.3f}, {f_hi:.3f}]")
+    print()
+    print("  Per-entity F1:")
+    for et in ALL_ENTITIES:
+        lo, med, hi = result["per_entity_f1"][et]
+        print(f"    {et:<16} {med:.3f}  [{lo:.3f}, {hi:.3f}]")
+    print(f"\nResults written to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/transformer_baseline/analyze.py
+++ b/experiments/transformer_baseline/analyze.py
@@ -1,0 +1,121 @@
+"""Compare Piiranha baseline results against the Presidio sweep.
+
+Produces a side-by-side per-entity comparison table and the head-to-head
+all-entities row that goes into Table III of the paper. Reads:
+
+  - experiments/results/sweep_results_both.jsonl  (Presidio regex+nlp)
+  - experiments/results/baseline_eval.jsonl       (Piiranha)
+
+Usage::
+
+    python -m experiments.transformer_baseline.analyze
+    python -m experiments.transformer_baseline.analyze --out /tmp/cmp.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ALL_ENTITIES = [
+    "EMAIL_ADDRESS",
+    "PERSON",
+    "PHONE_NUMBER",
+    "US_SSN",
+    "CREDIT_CARD",
+    "IBAN_CODE",
+]
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def _is_all_entities(row: dict[str, Any]) -> bool:
+    return sorted(row.get("entities", [])) == sorted(ALL_ENTITIES)
+
+
+def _best_all_entities(rows: list[dict[str, Any]], filter_fn=None) -> dict[str, Any] | None:
+    candidates = [r for r in rows if _is_all_entities(r)]
+    if filter_fn is not None:
+        candidates = [r for r in candidates if filter_fn(r)]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda r: r.get("micro_f1", 0))
+
+
+def _per_entity_rows(row: dict[str, Any]) -> dict[str, dict[str, float]]:
+    return {e["entity_type"]: e for e in row.get("per_entity", [])}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare Piiranha vs Presidio")
+    parser.add_argument(
+        "--presidio",
+        type=Path,
+        default=Path("experiments/results/sweep_results_both.jsonl"),
+    )
+    parser.add_argument(
+        "--piiranha",
+        type=Path,
+        default=Path("experiments/results/baseline_eval.jsonl"),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("experiments/results/baseline_comparison.json"),
+    )
+    args = parser.parse_args()
+
+    presidio = _load_jsonl(args.presidio) if args.presidio.exists() else []
+    piiranha = _load_jsonl(args.piiranha) if args.piiranha.exists() else []
+
+    print(f"Presidio rows: {len(presidio)}")
+    print(f"Piiranha rows: {len(piiranha)}")
+
+    best_regex = _best_all_entities(presidio, lambda r: r.get("mode") == "regex")
+    best_nlp = _best_all_entities(presidio, lambda r: r.get("mode") == "nlp")
+    best_piiranha = _best_all_entities(piiranha)
+
+    out = {
+        "best_regex": best_regex,
+        "best_nlp": best_nlp,
+        "best_piiranha": best_piiranha,
+    }
+
+    print("\n=== Best all-entities config per backend ===")
+    for label, row in [("regex", best_regex), ("nlp", best_nlp), ("piiranha", best_piiranha)]:
+        if row is None:
+            print(f"  {label:<10} (no data)")
+            continue
+        ms = row.get("min_score", "-")
+        print(
+            f"  {label:<10} min_score={ms}  "
+            f"P={row.get('micro_precision', 0):.3f}  "
+            f"R={row.get('micro_recall', 0):.3f}  "
+            f"F1={row.get('micro_f1', 0):.3f}"
+        )
+
+    print("\n=== Per-entity F1 (best all-entities config per backend) ===")
+    print(f"{'Entity':<16} {'regex':>8} {'nlp':>8} {'piiranha':>10}")
+    print("-" * 46)
+    rx = _per_entity_rows(best_regex) if best_regex else {}
+    nlp = _per_entity_rows(best_nlp) if best_nlp else {}
+    pir = _per_entity_rows(best_piiranha) if best_piiranha else {}
+    for ent in ALL_ENTITIES:
+        rx_f1 = rx.get(ent, {}).get("f1", 0.0)
+        nlp_f1 = nlp.get(ent, {}).get("f1", 0.0)
+        pir_f1 = pir.get(ent, {}).get("f1", 0.0)
+        print(f"{ent:<16} {rx_f1:>8.3f} {nlp_f1:>8.3f} {pir_f1:>10.3f}")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as fh:
+        json.dump(out, fh, indent=2)
+    print(f"\nComparison written to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/transformer_baseline/label_mapping.py
+++ b/experiments/transformer_baseline/label_mapping.py
@@ -1,0 +1,21 @@
+"""Maps Piiranha (DeBERTa-v3 PII) output labels to the x402 corpus entity_type vocabulary.
+
+Verified against ``iiiorg/piiranha-v1-detect-personal-information`` config.id2label.
+Unmapped Piiranha labels (STREET, CITY, ZIPCODE, DATEOFBIRTH, DRIVERLICENSENUM,
+PASSWORD, TAXNUM, BUILDINGNUM, IDCARDNUM) are intentionally dropped: they fall
+outside the six x402 evaluation entity types.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+PIIRANHA_TO_X402: Final[dict[str, str]] = {
+    "EMAIL": "EMAIL_ADDRESS",
+    "GIVENNAME": "PERSON",
+    "SURNAME": "PERSON",
+    "TELEPHONENUM": "PHONE_NUMBER",
+    "SOCIALNUM": "US_SSN",
+    "CREDITCARDNUMBER": "CREDIT_CARD",
+    "ACCOUNTNUM": "IBAN_CODE",
+}

--- a/experiments/transformer_baseline/piiranha_filter.py
+++ b/experiments/transformer_baseline/piiranha_filter.py
@@ -1,0 +1,100 @@
+"""Piiranha (DeBERTa-v3 PII) wrapper exposing PIIFilter's interface.
+
+Implements ``scan_and_redact(text)`` and ``scan_payment_fields(...)`` so the
+existing ``experiments/evaluate.py`` and ``experiments/run_latency.py`` can
+score Piiranha against the 2,000-sample x402 corpus with partial-span
+matching, identical to Presidio runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from transformers import AutoModelForTokenClassification, AutoTokenizer, pipeline
+
+from .label_mapping import PIIRANHA_TO_X402
+
+
+@dataclass
+class _Result:
+    """Minimal entity record matching the shape evaluate.py expects."""
+
+    entity_type: str
+    start: int
+    end: int
+    score: float
+
+
+_PIPELINE_CACHE: dict[tuple[str, str], object] = {}
+
+
+def _get_pipeline(model_id: str, device: str):
+    """Cache the HuggingFace pipeline so a config sweep doesn't reload weights."""
+    key = (model_id, device)
+    pipe = _PIPELINE_CACHE.get(key)
+    if pipe is None:
+        tok = AutoTokenizer.from_pretrained(model_id)
+        mod = AutoModelForTokenClassification.from_pretrained(model_id)
+        pipe = pipeline(
+            "token-classification",
+            model=mod,
+            tokenizer=tok,
+            aggregation_strategy="simple",
+            device=0 if device == "cuda" else -1,
+        )
+        _PIPELINE_CACHE[key] = pipe
+    return pipe
+
+
+class PiiranhaFilter:
+    MODEL_ID = "iiiorg/piiranha-v1-detect-personal-information"
+
+    def __init__(
+        self,
+        *,
+        min_score: float = 0.5,
+        device: str = "cpu",
+        entities: Iterable[str] | None = None,
+    ):
+        self.mode = "transformer"
+        self.min_score = min_score
+        self.entities = set(entities) if entities else None
+        self._pipe = _get_pipeline(self.MODEL_ID, device)
+
+    def scan_and_redact(self, text: str) -> tuple[str, list[_Result]]:
+        if not text:
+            return text, []
+        raw = self._pipe(text)
+        results: list[_Result] = []
+        for ent in raw:
+            if ent["score"] < self.min_score:
+                continue
+            group = ent["entity_group"]
+            x402_type = PIIRANHA_TO_X402.get(group)
+            if x402_type is None:
+                continue
+            if self.entities is not None and x402_type not in self.entities:
+                continue
+            results.append(
+                _Result(
+                    entity_type=x402_type,
+                    start=int(ent["start"]),
+                    end=int(ent["end"]),
+                    score=float(ent["score"]),
+                )
+            )
+        redacted = self._redact(text, results)
+        return redacted, results
+
+    @staticmethod
+    def _redact(text: str, results: list[_Result]) -> str:
+        if not results:
+            return text
+        out = text
+        for r in sorted(results, key=lambda r: -r.start):
+            out = out[: r.start] + f"<{r.entity_type}>" + out[r.end :]
+        return out
+
+    def scan_payment_fields(self, resource_url: str, description: str, reason: str):
+        return tuple(self.scan_and_redact(f) for f in (resource_url, description, reason))

--- a/experiments/transformer_baseline/run_baseline.py
+++ b/experiments/transformer_baseline/run_baseline.py
@@ -1,0 +1,149 @@
+"""Precision/recall sweep for the Piiranha (DeBERTa-v3 PII) baseline.
+
+Mirrors ``experiments/run_sweep.py`` but uses ``PiiranhaFilter``. The sweep
+covers (entity_subset x min_score) combinations matching the existing NLP
+sweep so per-detector results sit on the same axes in the paper's tables.
+
+Usage::
+
+    python -m experiments.transformer_baseline.run_baseline
+    python -m experiments.transformer_baseline.run_baseline --sample 200    # quick
+    python -m experiments.transformer_baseline.run_baseline --device cuda   # GPU
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).parent.parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from corpus.generate import CORPUS_DIR, load_corpus
+from experiments.evaluate import evaluate_corpus
+from experiments.run_sweep import ALL_ENTITY_TYPES
+from experiments.transformer_baseline.piiranha_filter import PiiranhaFilter
+
+RESULTS_DIR = Path(__file__).parent.parent / "results"
+
+_ENTITY_SUBSETS: list[list[str]] = [[et] for et in ALL_ENTITY_TYPES] + [ALL_ENTITY_TYPES]
+_MIN_SCORES = [0.30, 0.40, 0.50, 0.60, 0.70]
+
+
+def _build_configs() -> list[dict[str, Any]]:
+    return [
+        {"entities": sorted(entities), "min_score": ms}
+        for entities in _ENTITY_SUBSETS
+        for ms in _MIN_SCORES
+    ]
+
+
+def run_sweep(
+    corpus_path: Path,
+    out_path: Path,
+    *,
+    sample_n: int | None = None,
+    overlap_mode: str = "partial",
+    device: str = "cpu",
+) -> None:
+    print(f"Loading corpus from {corpus_path}...")
+    samples = load_corpus(corpus_path)
+    if sample_n is not None and sample_n < len(samples):
+        import random
+
+        rng = random.Random(42)
+        samples = rng.sample(samples, sample_n)
+        print(f"  Downsampled to {len(samples)} samples.")
+    else:
+        print(f"  Loaded {len(samples)} samples.")
+
+    configs = _build_configs()
+    print(f"Sweep: {len(configs)} configurations on Piiranha (device={device})")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with out_path.open("w", encoding="utf-8") as fh:
+        for i, cfg in enumerate(configs, 1):
+            entities = cfg["entities"]
+            min_score = cfg["min_score"]
+
+            pii_filter = PiiranhaFilter(min_score=min_score, device=device, entities=entities)
+
+            t0 = time.perf_counter()
+            report = evaluate_corpus(samples, pii_filter, overlap_mode=overlap_mode)
+            elapsed = time.perf_counter() - t0
+
+            row = {
+                "backend": "piiranha",
+                "model": PiiranhaFilter.MODEL_ID,
+                "entities": entities,
+                "min_score": min_score,
+                "n_samples": len(samples),
+                "overlap_mode": overlap_mode,
+                "device": device,
+                "elapsed_s": round(elapsed, 3),
+                **report.to_dict(),
+            }
+            fh.write(json.dumps(row) + "\n")
+            fh.flush()
+
+            print(
+                f"  [{i:>3}/{len(configs)}] entities=[{','.join(e[:3] for e in entities)}...] "
+                f"min_score={min_score}  P={report.micro_precision():.3f} "
+                f"R={report.micro_recall():.3f} F1={report.micro_f1():.3f} "
+                f"({elapsed:.1f}s)"
+            )
+
+    print(f"\nResults written to {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Piiranha baseline sweep")
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=CORPUS_DIR / "corpus.jsonl",
+        help="Path to corpus JSONL file",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=RESULTS_DIR / "baseline_eval.jsonl",
+        help="Output JSONL path",
+    )
+    parser.add_argument(
+        "--sample",
+        type=int,
+        default=None,
+        help="Downsample corpus to N samples for quick runs",
+    )
+    parser.add_argument(
+        "--overlap",
+        choices=["partial", "exact"],
+        default="partial",
+        help="Span matching mode (default: partial)",
+    )
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="Inference device (default: cpu)",
+    )
+    args = parser.parse_args()
+
+    run_sweep(
+        corpus_path=args.corpus,
+        out_path=args.out,
+        sample_n=args.sample,
+        overlap_mode=args.overlap,
+        device=args.device,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/transformer_baseline/run_latency.py
+++ b/experiments/transformer_baseline/run_latency.py
@@ -1,0 +1,121 @@
+"""Latency benchmark for the Piiranha (DeBERTa-v3 PII) baseline.
+
+Mirrors ``experiments/run_latency.py``: 200 warmup + 1000 timed iterations
+cycling through the corpus, calling ``scan_payment_fields`` per sample, and
+recording p50/p95/p99 in milliseconds.
+
+Usage::
+
+    python -m experiments.transformer_baseline.run_latency
+    python -m experiments.transformer_baseline.run_latency --device cuda
+    python -m experiments.transformer_baseline.run_latency --n 200 --warmup 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path(__file__).parent.parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from corpus.generate import CORPUS_DIR, load_corpus
+from experiments.run_sweep import ALL_ENTITY_TYPES
+from experiments.transformer_baseline.piiranha_filter import PiiranhaFilter
+
+RESULTS_DIR = Path(__file__).parent.parent / "results"
+
+
+def _percentile(data: list[float], p: float) -> float:
+    if not data:
+        return 0.0
+    s = sorted(data)
+    idx = (p / 100) * (len(s) - 1)
+    lo = int(idx)
+    hi = lo + 1
+    if hi >= len(s):
+        return s[-1]
+    return s[lo] + (idx - lo) * (s[hi] - s[lo])
+
+
+def benchmark(
+    corpus_path: Path,
+    *,
+    n_warmup: int = 200,
+    n_timed: int = 1000,
+    device: str = "cpu",
+    entities: list[str] | None = None,
+    min_score: float = 0.5,
+) -> dict:
+    samples = load_corpus(corpus_path)
+    if not samples:
+        raise ValueError(f"No samples found in {corpus_path}")
+
+    print(f"  Building PiiranhaFilter(device={device!r}, min_score={min_score})...")
+    pii_filter = PiiranhaFilter(min_score=min_score, device=device, entities=entities)
+
+    n = len(samples)
+    print(f"  Warming up ({n_warmup} iterations)...")
+    for i in range(n_warmup):
+        s = samples[i % n]
+        pii_filter.scan_payment_fields(s.resource_url, s.description, s.reason)
+
+    print(f"  Timing ({n_timed} iterations)...")
+    latencies_ms: list[float] = []
+    for i in range(n_timed):
+        s = samples[i % n]
+        t0 = time.perf_counter()
+        pii_filter.scan_payment_fields(s.resource_url, s.description, s.reason)
+        latencies_ms.append((time.perf_counter() - t0) * 1000)
+
+    return {
+        "backend": "piiranha",
+        "model": PiiranhaFilter.MODEL_ID,
+        "device": device,
+        "entities": entities or list(ALL_ENTITY_TYPES),
+        "min_score": min_score,
+        "n_warmup": n_warmup,
+        "n_timed": n_timed,
+        "p50_ms": round(_percentile(latencies_ms, 50), 3),
+        "p95_ms": round(_percentile(latencies_ms, 95), 3),
+        "p99_ms": round(_percentile(latencies_ms, 99), 3),
+        "mean_ms": round(statistics.mean(latencies_ms), 3),
+        "min_ms": round(min(latencies_ms), 3),
+        "max_ms": round(max(latencies_ms), 3),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Piiranha latency benchmark")
+    parser.add_argument("--corpus", type=Path, default=CORPUS_DIR / "corpus.jsonl")
+    parser.add_argument("--out", type=Path, default=RESULTS_DIR / "baseline_latency.json")
+    parser.add_argument("--n", type=int, default=1000)
+    parser.add_argument("--warmup", type=int, default=200)
+    parser.add_argument("--device", choices=["cpu", "cuda"], default="cpu")
+    args = parser.parse_args()
+
+    print(f"\n--- Benchmarking Piiranha (device={args.device}) ---")
+    result = benchmark(
+        corpus_path=args.corpus,
+        n_warmup=args.warmup,
+        n_timed=args.n,
+        device=args.device,
+    )
+    print(
+        f"  Results: p50={result['p50_ms']:.2f}ms  "
+        f"p95={result['p95_ms']:.2f}ms  p99={result['p99_ms']:.2f}ms"
+    )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as fh:
+        json.dump([result], fh, indent=2)
+    print(f"\nLatency results written to {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds two research/evaluation additions behind the paper's metrics. **Research harness only — not part of the shipped `presidio_x402` package.**

## What's added
- **`experiments/bootstrap_ci.py`** — non-parametric **95% confidence intervals** (case-bootstrap resampling over corpus samples) for the recommended Presidio NLP config: micro-P/R/F1 + per-entity F1.
- **`experiments/transformer_baseline/`** — a head-to-head baseline using **Piiranha (DeBERTa-v3 PII NER)**, wrapped behind the library's `PIIFilter` interface so it scores on the **same 2,000-sample x402 corpus and sweep axes** as the Presidio runs:
  - `piiranha_filter.py` (interface wrapper), `run_baseline.py` (P/R sweep), `run_latency.py`, `label_mapping.py`, `analyze.py`

## Notes
- **Not CI-gated:** the Lint and Test jobs scope to `src/ tests/`, so these files don't affect checks (consistent with the existing `experiments/` modules). `ruff check experiments/` has pre-existing style findings — left as-is to avoid altering research scripts.
- The transformer baseline needs **extra runtime deps (`transformers`/`torch`)** installed manually; it's run on demand, not imported by the package or tests.
- `__pycache__`/`.pyc` already gitignored — only `.py` sources committed.

## Test plan
- [x] No package/CI-path changes; `src/` + `tests/` untouched → existing checks unaffected