### PR TITLE
security+deps+docs: v0.4.1 — audit LOW fixes (F1,F2) + family recs R3,R5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   values. PII embedded as a dict key (e.g. `{"alice@example.com": ...}`) in the
   server-controlled `extra` field previously passed through unredacted to MPA
   webhooks and the audit log (F2, audit 2026-06-07; CWE-200).
+- Add explicit `idna>=3.15` floor (previously only transitive via httpx) to
+  evict CVE-2026-45409 on a fresh resolve (defense-in-depth; family audit rec R3).
+
+### Documentation
+- `SECURITY.md` now documents which security controls are automatic vs. opt-in,
+  removing ambiguity in the prior controls list (family audit rec R5).
 
 ## [0.4.0] — 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `mpa.build_countersignature(shared_secret, details, amount_usd)` — public
   helper that produces the timestamped crypto-mode countersignature.
 
+### Security
+- Harden `_parse_402_header` against non-dict `accepts[]` entries. A hostile 402
+  server sending a primitive (e.g. `{"accepts": ["exact"]}`) previously raised an
+  uncaught `AttributeError` that bypassed the sanitised audit path; non-dict
+  entries are now skipped and surface as the structured "No supported payment
+  scheme" `X402PaymentError` (F1, audit 2026-06-07; CWE-20).
+- `PIIFilter.scan_dict` now scans and redacts string **keys** in addition to
+  values. PII embedded as a dict key (e.g. `{"alice@example.com": ...}`) in the
+  server-controlled `extra` field previously passed through unredacted to MPA
+  webhooks and the audit log (F2, audit 2026-06-07; CWE-200).
+
 ## [0.4.0] — 2026-05-17
 
 The screening-api release. Pairs the published `screen.presidio-group.eu`

--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -282,7 +282,11 @@ v0.5.0). No CRITICAL/HIGH chain remains OPEN with zero in-tree control.
 
 ### Out of v0.4.0 (moved to later milestones per ADR-0006)
 
-- Third-party external security audit → v0.5.0 (closes RSK-019)
+- Third-party external security audit → **DONE 2026-06-06**: external second-set-of-eyes
+  review performed by Grok 4.3 (xAI) across the published `tools/` package and research
+  tree (report in `presidio-third-party-audits/`). No Critical/High; advisory-only
+  family-lens findings. Mitigates RSK-019. Residual: a commissioned human penetration
+  test before paid tiers go live remains tracked under v0.5.0 (see below).
 - Multi-tenant key scoping + remote audit sinks (S3 / Splunk / Datadog) → v0.5.0
 - Email-hash per-install salt → v0.5.0 (closes RSK-002)
 - `/v1/revoke` endpoint → v0.4.1
@@ -304,8 +308,9 @@ the multi-tenant work required to take paid tiers live.
 - Remote audit sink interfaces: `S3AuditWriter`, `SplunkAuditWriter`,
   `DatadogAuditWriter` (enterprise tier)
 - Per-install salt for `email:<sha256>` audit prefix (closes RSK-002)
-- Third-party security audit (closes RSK-019); blocks Track 1/Track 2 paid
-  tiers
+- Commissioned human penetration test before paid tiers (closes RSK-019 residual;
+  the 2026-06-06 AI-based external review already mitigated the "no second set of
+  eyes" risk); blocks Track 1/Track 2 paid tiers
 - SLSA L3 hardened build worker + provenance attestation; digest-pinned base
   image for `tools/docker/` and pinned spaCy model wheel (closes chain-01 and
   chain-08 residuals)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,30 @@ presidio-hardened-x402 provides the following security controls for x402 payment
 6. **Prometheus metrics** — Structured telemetry for all security control activations,
    enabling real-time alerting on policy violations, PII detections, and replay attempts (v0.3.0+)
 
+### Automatic vs. opt-in controls
+
+To avoid over-claiming, the table below states exactly which controls are applied
+automatically by `HardenedX402Client` on every payment flow and which require
+explicit configuration by the integrator. Controls marked **opt-in** are *not*
+active unless you enable them.
+
+| Control | Mode | How to enable |
+|---------|------|---------------|
+| PII detection + redaction of payment metadata | **Automatic** | On by default (`pii_action="redact"`); `regex` engine, zero-setup |
+| `pii_action="block"` / `"warn"` instead of redact | Opt-in | Pass `pii_action=` to the client |
+| spaCy NER (`nlp`) PII engine | Opt-in | Install `presidio-hardened-x402[nlp]` + set the regex/nlp mode flag; `regex` is the default |
+| Spending-policy enforcement | **Automatic when a policy is set** | Pass `policy={...}`; with no policy, no budget limits are enforced |
+| Replay detection | **Automatic** (in-memory) | On by default; set `PRESIDIO_X402_FINGERPRINT_KEY` + the Redis backend for cross-process durability |
+| Audit logging (HMAC-chained JSON-L) | **Automatic when an audit writer is set** | Provide an `audit_writer`; set `PRESIDIO_X402_CHAIN_KEY` for a stable chain key (else per-process key + ERROR log) |
+| Multi-party authorization (MPA) | Opt-in | Construct and pass an `MPAEngine` |
+| Hosted screening service | Opt-in | `remote_screening=True` + a `screening_client` (local regex still runs as backstop) |
+| Prometheus metrics | Opt-in | Install `prometheus-client` and wire a `MetricsCollector` (graceful no-op when absent) |
+
+Header/secret redaction at the logging sink is being added in v0.5.0 (family
+audit rec R2); until then, do not pass secrets or wallet key material into log
+calls — the client itself never logs them, but integrator code must follow the
+same discipline.
+
 ## Threat Model
 
 See `PRESIDIO-REQ.md` for the full threat model and security design rationale.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
     # (CVE-2024-0727, CVE-2023-50782, GHSA-h4gh-qq45-vh27, PYSEC-2024-225,
     # CVE-2026-26007, CVE-2026-34073). Audit 2026-04-26.
     "cryptography>=46.0.6",
+    # Transitive of httpx; pin minimum to the CVE-2026-45409 fix line (idna < 3.15
+    # is vulnerable — the lock shipped 3.11 before the 2026-06-03 cycle). Explicit
+    # floor is defense-in-depth so a fresh resolve cannot regress below the fix.
+    # Family audit rec R3 (Grok 4.3, 2026-06-06); audit 2026-06-07.
+    "idna>=3.15",
 ]
 
 [project.optional-dependencies]

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -139,14 +139,17 @@ def _parse_402_header(header_value: str) -> PaymentDetails:
     if not accepts:
         raise X402PaymentError("X-PAYMENT header contains no 'accepts' entries")
 
-    # Pick the first supported scheme
+    # Pick the first supported scheme. Each accepts[] entry must be a JSON object;
+    # a hostile server can send a primitive (e.g. {"accepts": ["exact"]} or [42]),
+    # and entry.get() on a non-dict would raise an uncaught AttributeError outside
+    # the sanitised audit path (F1, 2026-06-07). Skip non-dict entries.
     chosen = None
     for entry in accepts:
-        if entry.get("scheme") == _SUPPORTED_SCHEME:
+        if isinstance(entry, dict) and entry.get("scheme") == _SUPPORTED_SCHEME:
             chosen = entry
             break
     if chosen is None:
-        schemes = [e.get("scheme") for e in accepts]
+        schemes = [e.get("scheme") for e in accepts if isinstance(e, dict)]
         raise X402PaymentError(
             f"No supported payment scheme found. Server offered: {schemes}; "
             f"client supports: [{_SUPPORTED_SCHEME!r}]"

--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -372,8 +372,14 @@ class PIIFilter:
             redacted_dict: dict[object, object] = {}
             entities: list[EntityResult] = []
             for k, v in data.items():
+                # Scan string keys too: a server can embed PII as a dict key
+                # (e.g. {"alice@example.com": ...}), which would otherwise be
+                # copied verbatim into the redacted output and reach MPA webhooks
+                # and the audit log unredacted (F2, 2026-06-07).
+                clean_k, k_entities = self.scan_and_redact(k) if isinstance(k, str) else (k, [])
                 clean_v, v_entities = self._scan_dict(v, _depth + 1)
-                redacted_dict[k] = clean_v
+                redacted_dict[clean_k] = clean_v
+                entities.extend(k_entities)
                 entities.extend(v_entities)
             return redacted_dict, entities
         if isinstance(data, list):

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -194,6 +194,35 @@ async def test_unsupported_scheme_raises_x402_error():
                 await client.get("https://api.example.com/v1/data")
 
 
+@pytest.mark.parametrize(
+    "hostile_accepts",
+    [
+        ["exact"],  # bare string entry
+        [42],  # bare int entry
+        [None],  # null entry
+        [["exact"]],  # nested list entry
+        [{"scheme": "other"}, "exact"],  # dict miss followed by string
+    ],
+)
+@pytest.mark.asyncio
+async def test_non_dict_accepts_entry_raises_clean_x402_error(hostile_accepts):
+    """Non-dict accepts[] entries must surface as X402PaymentError, not AttributeError.
+
+    A hostile 402 server can send primitives in accepts[] (e.g. {"accepts": ["exact"]}).
+    Calling entry.get() on a non-dict would raise an uncaught AttributeError that bypasses
+    the sanitised audit path (F1, 2026-06-07). The guard skips non-dict entries so the
+    request falls through to the structured "No supported payment scheme" error.
+    """
+    header = json.dumps({"accepts": hostile_accepts})
+    with respx.mock:
+        respx.get("https://api.example.com/v1/data").mock(
+            return_value=httpx.Response(402, headers={"X-PAYMENT": header})
+        )
+        async with _make_client() as client:
+            with pytest.raises(X402PaymentError, match="No supported payment scheme"):
+                await client.get("https://api.example.com/v1/data")
+
+
 # ---------------------------------------------------------------------------
 # PII blocking
 # ---------------------------------------------------------------------------

--- a/tests/test_pii_filter.py
+++ b/tests/test_pii_filter.py
@@ -158,6 +158,22 @@ class TestPIIFilterRegexMode:
         assert clean["tier"] == "gold"
         assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
 
+    def test_scan_dict_redacts_pii_in_keys(self):
+        """F2 (2026-06-07): PII embedded as a dict key is detected and redacted.
+
+        A hostile 402 server can place PII in a key (e.g. {"alice@example.com": ...}).
+        The key must be scanned, not copied verbatim, so it cannot reach MPA webhooks
+        or the audit log unredacted.
+        """
+        clean, entities = self.filt.scan_dict({"alice@example.com": "ignored_value"})
+        assert "alice@example.com" not in str(clean)
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    def test_scan_dict_redacts_pii_in_nested_keys(self):
+        clean, entities = self.filt.scan_dict({"outer": {"bob@example.com": "v"}})
+        assert "bob@example.com" not in str(clean)
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
     def test_scan_dict_recurses_nested_dicts_and_lists(self):
         clean, entities = self.filt.scan_dict(
             {

--- a/uv.lock
+++ b/uv.lock
@@ -2992,6 +2992,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
+    { name = "idna" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
 ]
@@ -3032,6 +3033,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.6" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.23" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.21.0" },
     { name = "jsonschema", marker = "extra == 'schema'", specifier = ">=4.21.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3" },


### PR DESCRIPTION
## Summary
v0.4.1 cycle. Closes the two LOW findings from the 2026-06-07 Felix audit and the two low-effort family recommendations (R3, R5) from the 2026-06-06 third-party audit (Grok 4.3/xAI).

**Audit fixes**
- **F1 (CWE-20, gateway.py):** harden `_parse_402_header` against non-dict `accepts[]` entries — a hostile `{"accepts": ["exact"]}` no longer raises an uncaught `AttributeError` that bypassed the sanitised audit path; it now resolves to a structured `X402PaymentError`.
- **F2 (CWE-200, pii_filter.py):** `PIIFilter.scan_dict` now scans and redacts string **keys** as well as values — PII as a dict key in the server-controlled `extra` field no longer reaches MPA webhooks or the audit log unredacted. Closes the REQ-1 PARTIAL gap.

**Family recommendations**
- **R3:** explicit `idna>=3.15` floor (was only transitive via httpx) so a fresh resolve can't regress below the CVE-2026-45409 fix line. `uv.lock` already resolves 3.17.
- **R5:** `SECURITY.md` now documents which controls are automatic vs. opt-in.

> R2 (sink-level log redaction) is deferred to its own v0.5.0 PR. R1 (shared `presidio-hardened-core`) is under deliberation.

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] Regression tests: `test_non_dict_accepts_entry_raises_clean_x402_error` (5 hostile shapes), `test_scan_dict_redacts_pii_in_keys`, `test_scan_dict_redacts_pii_in_nested_keys`
- [x] Full `pytest tests/` suite passes (2 pre-existing skips)
- [x] `uv lock` consistent; idna resolves to 3.17

Source: Felix audit `security-audit/x402-audit-2026-06-07.md`; response `security-audit/audit-response-2026-06-07.md`; family summary `presidio-third-party-audits/…-presidio-hardened-20260606-144041.md`.