### PR TITLE
security: sink-level log secret redaction (v0.5.0, family audit rec R2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - `mpa.build_countersignature(shared_secret, details, amount_usd)` — public
   helper that produces the timestamped crypto-mode countersignature.
+- Sink-level secret redaction: `install_log_redaction()` attaches a
+  `RedactingFilter` (`SecretRedactor`) to every logger in the `presidio_x402`
+  namespace at import time, scrubbing API keys, bearer tokens, and 32-byte hex
+  key/signature material from log records before they reach any handler. Wallet
+  *addresses* (20-byte) are intentionally preserved. Closes the call-site-only
+  redaction gap flagged by the third-party family audit (rec R2, 2026-06-06).
 
 ## [0.4.0] — 2026-05-17
 

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -42,6 +42,7 @@ from .exceptions import (
     X402PaymentError,
 )
 from .gateway import HardenedX402Client
+from .log_redaction import RedactingFilter, SecretRedactor, install_log_redaction
 from .metrics import MetricsCollector
 from .mpa import MPAApproverConfig, MPAConfig, MPAEngine, build_countersignature
 from .pii_filter import PIIFilter
@@ -85,9 +86,19 @@ __all__ = [
     "NullAuditWriter",
     "StreamAuditWriter",
     "FileAuditWriter",
+    # Log-sink secret redaction
+    "install_log_redaction",
+    "RedactingFilter",
+    "SecretRedactor",
 ]
 
 logger = logging.getLogger("presidio_x402")
+
+# Enforce sink-level secret redaction across the whole presidio_x402 logger
+# namespace as soon as the package is imported (family audit rec R2, 2026-06-06).
+# Runs before _on_import_audit() below so even the audit's own log lines are
+# filtered. All submodule loggers already exist (imported above).
+install_log_redaction()
 
 # ---------------------------------------------------------------------------
 # On-import security audit

--- a/src/presidio_x402/log_redaction.py
+++ b/src/presidio_x402/log_redaction.py
@@ -1,0 +1,123 @@
+"""Sink-level secret redaction for the ``presidio_x402`` logger.
+
+The gateway, audit log, replay guard, and MPA engine all emit structured log
+events, and integrator code logs through child loggers of ``presidio_x402``.
+Manual redaction at individual call sites is insufficient: a single ``logger``
+call that interpolates a wallet key, bearer token, or signed ``X-PAYMENT`` token
+would leak it to whatever sink the deployment has configured (stdout, files, a
+SIEM forwarder).
+
+This module installs a :class:`logging.Filter` on the ``presidio_x402`` logger at
+package import time so the "secrets never reach the log sink" guarantee is
+enforced for *every* record on that logger and its children — not just the calls
+that remember to redact. This mirrors the family pattern established in
+``presidio_angellist.hardening`` (family audit recommendation R2, 2026-06-06).
+
+Note: this does **not** touch the tamper-evident audit trail. ``audit_log`` writes
+JSON-L through its own file/stream writers, not through the ``logging`` module, so
+the HMAC chain and payment records are unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+# Each tuple is ``(pattern, replacement)``. Patterns keep a non-secret prefix in a
+# capture group so the redacted line still says *what kind* of secret was scrubbed,
+# which keeps logs useful for debugging without exposing the value.
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Generic provider API keys (Stripe-style, Anthropic-style).
+    (re.compile(r"(sk_(?:live|test)_)[A-Za-z0-9]+"), r"\1***REDACTED***"),
+    (re.compile(r"(sk-ant-)[A-Za-z0-9\-_]+"), r"\1***REDACTED***"),
+    # Auth headers / query params.
+    (re.compile(r"(Bearer\s+)[A-Za-z0-9\-._~+/]+=*"), r"\1***REDACTED***"),
+    (re.compile(r"(access_token=)[^&\s]+"), r"\1***REDACTED***"),
+    (re.compile(r"(api_key=)[^&\s]+"), r"\1***REDACTED***"),
+    (re.compile(r"(Authorization:\s*)[^\r\n]+", re.IGNORECASE), r"\1***REDACTED***"),
+    # x402-specific: EVM/SVM private keys and HMAC key/signature material are
+    # 32-byte hex (optionally 0x-prefixed). Wallet *addresses* are 20-byte
+    # (40 hex) and are intentionally not matched here — they are pseudo-public
+    # and appear in allowlists and audit records by design.
+    (re.compile(r"\b(0x)?[0-9a-fA-F]{64}\b"), r"\g<1>***REDACTED***"),
+]
+
+
+class SecretRedactor:
+    """Scrubs secret-shaped substrings from a string before it reaches a sink."""
+
+    def redact(self, text: str) -> str:
+        for pattern, replacement in _SECRET_PATTERNS:
+            text = pattern.sub(replacement, text)
+        return text
+
+
+class RedactingFilter(logging.Filter):
+    """A ``logging.Filter`` that scrubs secrets from every record at the sink.
+
+    Installed on the ``presidio_x402`` logger at import time. The filter renders
+    the record (applying any ``%``-args), redacts the resulting message, stores it
+    back on ``record.msg`` and clears ``record.args`` so downstream handlers only
+    ever format already-redacted text.
+    """
+
+    def __init__(self, redactor: SecretRedactor | None = None) -> None:
+        super().__init__()
+        self._redactor = redactor or SecretRedactor()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:  # pragma: no cover - never let logging crash a payment
+            return True
+        record.msg = self._redactor.redact(message)
+        record.args = None
+        return True
+
+
+_NAMESPACE = "presidio_x402"
+
+
+def _namespace_loggers() -> list[logging.Logger]:
+    """The ``presidio_x402`` logger plus every existing logger beneath it.
+
+    A ``logging.Filter`` attached to a parent logger is **not** applied to records
+    emitted by child loggers — filters only run on the logger the record
+    originates from (and on handlers along the propagation path). The library logs
+    through per-module child loggers (``presidio_x402.gateway`` etc.), so the
+    filter must be attached to each of them individually. All module loggers
+    already exist by the time this runs because ``__init__`` imports every
+    submodule before calling :func:`install_log_redaction`.
+    """
+    loggers = [logging.getLogger(_NAMESPACE)]
+    manager = loggers[0].manager
+    prefix = _NAMESPACE + "."
+    for name in list(manager.loggerDict):
+        if name.startswith(prefix):
+            loggers.append(logging.getLogger(name))
+    return loggers
+
+
+def install_log_redaction(redactor: SecretRedactor | None = None) -> RedactingFilter:
+    """Attach a :class:`RedactingFilter` to every ``presidio_x402`` logger.
+
+    Idempotent and re-runnable: a single filter instance is shared across the
+    namespace, and a logger that already carries it is skipped. Safe to call again
+    after creating new child loggers (it will cover any not yet filtered). Returns
+    the active filter.
+    """
+    loggers = _namespace_loggers()
+    flt: RedactingFilter | None = None
+    for logger in loggers:
+        for existing in logger.filters:
+            if isinstance(existing, RedactingFilter):
+                flt = existing
+                break
+        if flt is not None:
+            break
+    if flt is None:
+        flt = RedactingFilter(redactor)
+    for logger in loggers:
+        if not any(isinstance(f, RedactingFilter) for f in logger.filters):
+            logger.addFilter(flt)
+    return flt

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,95 @@
+"""Tests for sink-level secret redaction on the presidio_x402 logger (R2)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from presidio_x402.log_redaction import (
+    RedactingFilter,
+    SecretRedactor,
+    install_log_redaction,
+)
+
+
+class TestSecretRedactor:
+    def setup_method(self):
+        self.r = SecretRedactor()
+
+    @pytest.mark.parametrize(
+        ("raw", "must_not_contain", "must_contain"),
+        [
+            ("key=sk_live_abcDEF123456", "sk_live_abcDEF123456", "sk_live_"),
+            ("anthropic sk-ant-api03-XyZ_-99", "XyZ_-99", "sk-ant-"),
+            ("token Bearer abc.def.ghi end", "abc.def.ghi", "Bearer ***REDACTED***"),
+            ("Authorization: Bearer abc.def.ghi", "abc.def.ghi", "Authorization: ***REDACTED***"),
+            ("url?access_token=tok123&x=1", "tok123", "access_token="),
+            ("url?api_key=KKK999&y=2", "KKK999", "api_key="),
+            (
+                # EVM private key / HMAC material: 32-byte hex (0x-prefixed)
+                "signing with 0x" + "a" * 64,
+                "0x" + "a" * 64,
+                "0x***REDACTED***",
+            ),
+            (
+                # bare 64-hex (e.g. a chain key dump)
+                "chain_key=" + "b" * 64,
+                "b" * 64,
+                "***REDACTED***",
+            ),
+        ],
+    )
+    def test_redacts_secret_shapes(self, raw, must_not_contain, must_contain):
+        out = self.r.redact(raw)
+        assert must_not_contain not in out
+        assert must_contain in out
+
+    def test_wallet_address_not_redacted(self):
+        # 20-byte (40 hex) addresses are pseudo-public and must survive.
+        addr = "0x" + "c" * 40
+        assert addr in self.r.redact(f"pay_to={addr}")
+
+    def test_clean_text_unchanged(self):
+        msg = "payment ok amount=0.01 USDC to base-sepolia"
+        assert self.r.redact(msg) == msg
+
+
+class TestInstallLogRedaction:
+    def test_idempotent_single_filter_per_logger(self):
+        install_log_redaction()
+        before = [
+            f for f in logging.getLogger("presidio_x402").filters if isinstance(f, RedactingFilter)
+        ]
+        install_log_redaction()
+        after = [
+            f for f in logging.getLogger("presidio_x402").filters if isinstance(f, RedactingFilter)
+        ]
+        assert len(before) == 1
+        assert len(after) == 1
+
+    def test_installed_at_import_on_parent(self):
+        # importing presidio_x402 (done at module load) installs the filter
+        filters = logging.getLogger("presidio_x402").filters
+        assert any(isinstance(f, RedactingFilter) for f in filters)
+
+    def test_covers_child_loggers(self):
+        # A filter on the parent does not cover child records; install must attach
+        # to each namespace logger. gateway logs through presidio_x402.gateway.
+        child = logging.getLogger("presidio_x402.gateway")
+        assert any(isinstance(f, RedactingFilter) for f in child.filters)
+
+    def test_child_logger_record_is_redacted(self, caplog):
+        install_log_redaction()
+        child = logging.getLogger("presidio_x402.gateway")
+        with caplog.at_level(logging.INFO, logger="presidio_x402.gateway"):
+            child.info("leaked Bearer %s now", "abc.def.ghi")
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "abc.def.ghi" not in joined
+        assert "Bearer ***REDACTED***" in joined
+
+    def test_newly_created_child_logger_covered_after_reinstall(self):
+        logging.getLogger("presidio_x402.brand_new_child")
+        install_log_redaction()
+        child = logging.getLogger("presidio_x402.brand_new_child")
+        assert any(isinstance(f, RedactingFilter) for f in child.filters)


### PR DESCRIPTION
## Summary
Closes the **R2** family third-party audit recommendation (Grok 4.3/xAI, 2026-06-06): redaction in `presidio_x402` was call-site only, so any log call interpolating a secret could leak it to the configured sink. The auditor cited `presidio_angellist.hardening` as the reference; this mirrors that pattern.

- New `log_redaction` module: `SecretRedactor` + `RedactingFilter` + `install_log_redaction()`, called at import in `__init__.py` (before the on-import dependency audit, so even its log lines are filtered).
- Scrubs API keys (`sk_live`/`sk_test`/`sk-ant-`), `Bearer`/`Authorization`/`access_token=`/`api_key=`, and **32-byte hex** (EVM/SVM private keys, HMAC key/signature material). Wallet **addresses** (20-byte) are deliberately preserved — they are pseudo-public and appear in allowlists/audit records by design.
- Correctness detail: a `logging.Filter` on a parent logger is **not** applied to child-logger records, and the library logs through per-module child loggers (`presidio_x402.gateway`, etc.). `install_log_redaction()` therefore attaches to every namespace logger individually; it is idempotent and re-runnable.
- The JSON-L tamper-evident audit trail is **unaffected** — it writes through its own file/stream writers, not the `logging` module.

## Test plan
- [x] `ruff check` + `ruff format --check` pass on new/changed files
- [x] New `tests/test_log_redaction.py`: pattern coverage, address-preservation, idempotency, import-time install, **child-logger coverage**, and end-to-end caplog redaction
- [x] Full `pytest tests/` suite passes (2 pre-existing skips) — no existing log-assertion tests regressed by the 64-hex pattern

## Notes
- Targeted **v0.5.0** (separate from the v0.4.1 audit-fix PR #41).
- Follow-up when this merges: the SECURITY.md "added in v0.5.0" note (landing in #41) can be flipped to "implemented."

Source: family summary `presidio-third-party-audits/…-presidio-hardened-20260606-144041.md`, rec R2.