### PR TITLE
chore: add LICENSE + pin CI actions to SHAs (config audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -26,8 +26,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
         run: pytest tests/ --cov=presidio_x402 --cov-report=xml --cov-fail-under=90
       - name: Upload coverage
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           file: coverage.xml
 
@@ -44,8 +44,8 @@ jobs:
     name: Lockfile drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Verify uv.lock is up to date with pyproject.toml
         run: uv lock --locked

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,9 +15,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   webhooks and the audit log (F2, audit 2026-06-07; CWE-200).
 - Add explicit `idna>=3.15` floor (previously only transitive via httpx) to
   evict CVE-2026-45409 on a fresh resolve (defense-in-depth; family audit rec R3).
+- Pin all GitHub Actions in CI/CodeQL workflows to commit SHAs (was floating
+  `@v6`/`@v7` tags), closing a supply-chain tag-mutation vector. Dependabot's
+  `github-actions` ecosystem keeps the pins current (config audit, 2026-06-07).
+
+### Added (packaging)
+- Top-level `LICENSE` file (MIT) so GitHub detects the license badge; the
+  package already declared `license = "MIT"` in `pyproject.toml` (config audit).
 
 ### Documentation
 - `SECURITY.md` now documents which security controls are automatic vs. opt-in,

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Presidio Security
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Remediates two items from the 2026-06-07 third-party GitHub **config** audit (Grok 4.3) that apply to this public repo:

- **License detection (audit #7):** add a top-level `LICENSE` file (MIT, "Copyright (c) 2026 Presidio Security" — matches the family + `pyproject.toml`). The repo showed `license: null` / no badge despite `license = "MIT"` in `pyproject.toml`, because GitHub needs an actual LICENSE file.
- **Action pinning (audit #9):** pin all GitHub Actions to commit SHAs (`checkout`, `setup-python`, `codecov-action`, `setup-uv`) instead of floating `@v6`/`@v7` tags — closes a tag-mutation supply-chain vector. The already-configured `github-actions` Dependabot ecosystem keeps the pins current.

Repo-level settings from the same audit (auto-delete branches, squash+rebase only, Projects off) were applied directly via the API and are not part of this PR.

## Test plan
- [x] All actions resolve to current `@v6`/`@v7` SHAs (verified via API)
- [x] No source changes — existing CI matrix (lint + tests 3.10–3.13 + Lockfile drift + Bandit/CodeQL) validates the workflow edits on this PR
- [x] GitHub will detect SPDX MIT once `LICENSE` lands on the default branch

Source: `presidio-third-party-audits/github-config-audit-20260607-113359.md`.