### PR TITLE
v0.5.0: OEM embed kit + BREAKING MPA freshness binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,33 @@ jobs:
         run: pip install -e ".[dev]"
       - name: Run tests
         run: pytest tests/ --cov=presidio_x402 --cov-report=xml --cov-fail-under=90
+      - name: Partner conformance suite (the OEM embed-kit guarantee, SEMVER.md)
+        run: python -m presidio_x402.conformance
       - name: Upload coverage
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           file: coverage.xml
+
+  sbom:
+    name: SBOM (CycloneDX)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+      - name: Install package + SBOM tool
+        run: |
+          pip install -e .
+          pip install cyclonedx-bom
+      - name: Generate SBOM
+        run: cyclonedx-py environment --output-format JSON --output-file sbom.cdx.json
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom
+          path: sbom.cdx.json
 
   lock-drift:
     name: Lockfile drift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,53 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+(nothing yet)
+
+## [0.5.0] — 2026-06-12
+
+The OEM embed-kit release (session-3 T1+T2). Includes everything previously
+listed under Unreleased (MPA freshness binding, sink-level redaction, F1/F2
+hardening) — folded into this version. Founder-signed release pending.
+
+### Added
+- **Rail-agnostic screening core:** `core.ScreeningPipeline` — the four-control
+  sequence (PII → trusted-wallet → policy → replay → MPA, with audit and
+  speculative-commit rollback) extracted verbatim from the gateway. Operates on
+  `PaymentDetails` alone; contains no payment-protocol assumptions. Behaviour,
+  audit events, metrics, and exceptions are byte-identical to v0.4.0.
+- **Binding layer:** `bindings/x402.X402Binding` owns everything x402-specific
+  (402 status, `X-PAYMENT` header, scheme `exact`, `accepts[]` parsing with the
+  F-04/F1 hardening). New `PaymentProtocolBinding` protocol in `_types`;
+  `HardenedX402Client(binding=...)` accepts a custom rail binding — the hedge
+  against payment-rail fragmentation (Stripe ACP/Tempo, AP2).
+- `PIIFilter.scan_fields(mapping)` — rail-agnostic generalisation of
+  `scan_payment_fields` for bindings with different metadata field names.
+- **Partner conformance suite:** `python -m presidio_x402.conformance` — 7
+  end-to-end checks (API surface, pre-signing redaction, fail-closed PII block,
+  policy block, replay + rollback, audit-chain integrity incl. tamper
+  detection, binding parse hardening). No network; exit 0/1. Runs in CI on
+  every push and intended for OEM partners' CI on every upgrade.
+- **SEMVER.md** — public-API definition, pre-1.0 semver profile, behavioural
+  security invariants that outrank API stability, partner pin guidance.
+- Integration quickstarts: `docs/quickstarts/{coinbase-cdp,langchain,crewai}.md`.
+- SBOM job (CycloneDX) in CI; conformance-suite step in the test matrix.
+
+### Fixed
+- `ComplianceReport` chain verification now resolves the chain key live from
+  the `audit_log` module instead of a value snapshot taken at import. The
+  snapshot silently desynced writer and verifier when the key changed after
+  import (module reload), failing the chain check on untampered logs. Found by
+  the new partner conformance suite running inside the full pytest matrix.
+
 ### Changed
+- `gateway.py` is now a thin composition of `ScreeningPipeline` + the configured
+  binding. All pre-v0.5.0 import paths keep working, including the grandfathered
+  gateway aliases (`_parse_402_header`, `_HEADER_PAYMENT`, `_SUPPORTED_SCHEME`,
+  `_amount_to_usd`) — kept until v1.0.0 per SEMVER.md.
+- Roadmap re-slotted: the previously planned v0.5.0 scope (multi-tenant key
+  scoping, enterprise audit sinks, SLSA L3, key-env startup gates) moves to
+  v0.6.0; the SLO payment broker moves to v0.7.0. Rationale: OEM outreach (Q3)
+  needs the embed kit first; see PRESIDIO-REQ.md.
 - **BREAKING (crypto-mode MPA):** countersignatures are now freshness-bound. The
   wire format is `"<unix_ts>:<hmac_hex>"` and the signed payload includes the
   approver's timestamp; the engine rejects signatures outside the new

--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -298,11 +298,43 @@ v0.5.0). No CRITICAL/HIGH chain remains OPEN with zero in-tree control.
 
 ---
 
-## v0.5.0 Requirements (Multi-Tenant + Audit Sink + SLSA L3)
+## v0.5.0 Requirements (OEM Embed Kit + Binding Layer) — Delivered
+
+Re-slotted 2026-06-12 (session-3 T1+T2, founder-selected scope): OEM outreach in
+Q3 needs the embed kit before the multi-tenant platform work, and the patent
+posture wants the screening core demonstrably rail-agnostic (claims cover the
+method, not the rail — the binding layer is the hedge against protocol
+fragmentation: Stripe ACP/Tempo, AP2). The previous v0.5.0 scope moves to
+v0.6.0 unchanged; the SLO payment broker moves to v0.7.0.
+
+- Rail-agnostic screening core: `core.ScreeningPipeline` extracted verbatim from
+  the gateway (audit events, metrics, exceptions, rollback semantics
+  byte-identical; existing 326-test suite is the conformance proof) — Delivered
+- Binding layer: `bindings/x402.X402Binding` owns the 402 status, `X-PAYMENT`
+  header, scheme, and offer parsing (F-04/F1 hardening preserved);
+  `PaymentProtocolBinding` protocol; `HardenedX402Client(binding=...)`; proven
+  by an end-to-end fake-rail test (HTTP 419 + `X-FAKEPAY`, full pipeline
+  guarantees intact) — Delivered
+- Back-compat: every pre-0.5.0 import path works; grandfathered gateway aliases
+  kept until v1.0.0 (SEMVER.md) — Delivered
+- `PIIFilter.scan_fields(mapping)` for rails with different metadata fields — Delivered
+- Partner conformance suite `python -m presidio_x402.conformance` (7 end-to-end
+  checks, no network, exit 0/1), wired into CI — Delivered
+- SEMVER.md: public-API definition, pre-1.0 semver profile, behavioural security
+  invariants, partner pin guidance (`>=0.5,<0.6`) — Delivered
+- Quickstarts: Coinbase CDP, LangChain, CrewAI (`docs/quickstarts/`) — Delivered
+- SBOM (CycloneDX) job in CI — Delivered
+- Includes the previously-unreleased MPA freshness binding (F-8) and sink-level
+  log redaction (family audit R2) — see CHANGELOG 0.5.0
+
+---
+
+## v0.6.0 Requirements (Multi-Tenant + Audit Sink + SLSA L3)
 
 Converts the single-tenant v0.4.0 screening service into a production platform.
 Largely the "production hardening" scope previously carried under v0.4.0, plus
-the multi-tenant work required to take paid tiers live.
+the multi-tenant work required to take paid tiers live. (Re-slotted from v0.5.0
+on 2026-06-12; content unchanged.)
 
 - Multi-tenant key scoping with per-tenant Redis namespace
 - Remote audit sink interfaces: `S3AuditWriter`, `SplunkAuditWriter`,
@@ -323,7 +355,7 @@ the multi-tenant work required to take paid tiers live.
 
 ---
 
-## v0.6.0 Requirements (SLO Payment Broker)
+## v0.7.0 Requirements (SLO Payment Broker) — re-slotted from v0.6.0 on 2026-06-12
 
 This version fills a second white spot: **market-based SLO enforcement**. Current
 autoscaling is reactive and rule-based. This milestone makes the agent an economic actor

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![CI](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml/badge.svg)](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml)
 
-> v0.4.0 — PII redaction, spending policy, replay detection, audit logging, multi-party authorization, Prometheus metrics, and opt-in remote screening for x402 payments
+> v0.5.0 — OEM embed kit: rail-agnostic screening core + x402 binding layer, partner conformance suite, semver guarantees; plus PII redaction, spending policy, replay detection, audit logging, multi-party authorization, Prometheus metrics, and opt-in remote screening
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -20,6 +20,8 @@ Intercepts x402 payment requests **before transmission to servers and facilitato
 - **Prometheus metrics** — structured telemetry for every security control activation *(v0.3.0)*
 - **Remote screening** — opt-in `remote_screening=True` mode offloads PII analysis to the hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu) service via `ScreeningClient`; avoids the in-process spaCy dependency *(v0.4.0)*
 - **Per-origin wallet allowlist** — per-origin `pay_to` allowlist blocks payments to attacker-controlled addresses when a DNS-poisoned 402 response substitutes the recipient (chain-06 mitigation) *(v0.4.0)*
+- **Rail-agnostic core + binding layer** — the screening pipeline (`ScreeningPipeline`) is payment-protocol-independent; everything x402-specific lives in `bindings/x402`. Embed on a different rail by implementing `PaymentProtocolBinding` — the security guarantees travel with the core *(v0.5.0)*
+- **OEM embed kit** — [semver/stability guarantees](SEMVER.md), partner-runnable conformance suite (`python -m presidio_x402.conformance`, 7 end-to-end checks, no network), and integration quickstarts for [Coinbase CDP](docs/quickstarts/coinbase-cdp.md), [LangChain](docs/quickstarts/langchain.md), and [CrewAI](docs/quickstarts/crewai.md) *(v0.5.0)*
 
 Part of the [presidio-hardened-*](https://github.com/presidio-v) toolkit family.
 
@@ -357,9 +359,10 @@ All exceptions are importable from `presidio_x402`.
 | v0.2.0 | Synthetic corpus + 42-configuration precision/recall sweep, LangChain/CrewAI adapters, compliance report · [arXiv:2604.11430](https://arxiv.org/abs/2604.11430) |
 | v0.2.1 | Live ecosystem characterisation via Dune Analytics (20 projects, 96 wallets, 11 chains, ≥79M transactions); IEEE S&P magazine article submitted; IEEE TIFS paper under review · Corpus: [`v0.2.1/dataport/`](v0.2.1/dataport/), [Hugging Face](https://huggingface.co/datasets/vstantch/x402-pii-corpus), [IEEE DataPort (doi:10.21227/kpsz-nq73)](https://doi.org/10.21227/kpsz-nq73) |
 | v0.3.0 | **Multi-party authorization** (`mpa.py`: n-of-m, webhook + crypto modes) · **Policy-as-code** JSON Schema (IETF draft candidate) · **Prometheus metrics** exporter · Kubernetes Helm chart + Docker image · SOC2 reference architecture |
-| **v0.4.0** | **Screening API launch** — hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu) free tier (regex mode, 100 req/day) · `ScreeningClient` + `remote_screening=True` mode · per-origin `pay_to` allowlist (chain-06 mitigation) · audit-cycle hardening (F-A/B 2026-05-03, F-C/D/E 2026-05-10, F1/F2/F3 2026-05-17); see [`CHANGELOG.md`](CHANGELOG.md) — **current** |
-| v0.5.0 | Multi-tenant key scoping · enterprise-tier remote audit sinks (S3 / Splunk / Datadog) · third-party security audit · SLSA L3 hardened build worker · hard startup-gates for `PRESIDIO_X402_*_KEY` env vars |
-| v0.6.0 | **SLO payment broker** — x402 micropayments as runtime infrastructure bids; `presidio-hardened-arch-translucency` integration |
+| v0.4.0 | **Screening API launch** — hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu) free tier (regex mode, 100 req/day) · `ScreeningClient` + `remote_screening=True` mode · per-origin `pay_to` allowlist (chain-06 mitigation) · audit-cycle hardening (F-A/B 2026-05-03, F-C/D/E 2026-05-10, F1/F2/F3 2026-05-17); see [`CHANGELOG.md`](CHANGELOG.md) |
+| **v0.5.0** | **OEM embed kit** — rail-agnostic `ScreeningPipeline` core + `bindings/x402` layer (`PaymentProtocolBinding` protocol, hedge against rail fragmentation: ACP/Tempo, AP2) · [SEMVER.md](SEMVER.md) stability guarantees · partner conformance suite (`python -m presidio_x402.conformance`) · CDP/LangChain/CrewAI quickstarts · SBOM in CI · freshness-bound MPA countersignatures (F-8) — **current** |
+| v0.6.0 | Multi-tenant key scoping · enterprise-tier remote audit sinks (S3 / Splunk / Datadog) · third-party security audit · SLSA L3 hardened build worker · hard startup-gates for `PRESIDIO_X402_*_KEY` env vars |
+| v0.7.0 | **SLO payment broker** — x402 micropayments as runtime infrastructure bids; `presidio-hardened-arch-translucency` integration |
 
 See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.4.x   | ✓ (current) |
-| 0.3.x   | ✓ |
-| 0.2.x   | security fixes only |
+| 0.5.x   | ✓ (current) |
+| 0.4.x   | ✓ |
+| 0.3.x   | security fixes only |
 
 ## Reporting a Vulnerability
 
@@ -58,10 +58,13 @@ active unless you enable them.
 | Hosted screening service | Opt-in | `remote_screening=True` + a `screening_client` (local regex still runs as backstop) |
 | Prometheus metrics | Opt-in | Install `prometheus-client` and wire a `MetricsCollector` (graceful no-op when absent) |
 
-Header/secret redaction at the logging sink is being added in v0.5.0 (family
-audit rec R2); until then, do not pass secrets or wallet key material into log
-calls — the client itself never logs them, but integrator code must follow the
-same discipline.
+Header/secret redaction at the logging sink ships in v0.5.0 (family audit rec
+R2): `install_log_redaction()` runs at package import and scrubs API keys,
+bearer tokens, and 32-byte hex key/signature material from every
+`presidio_x402` log record. Integrator code outside this logger namespace must
+still follow the same discipline. From v0.5.0 the documented security
+guarantees can be verified end-to-end in your environment with the partner
+conformance suite: `python -m presidio_x402.conformance` (see SEMVER.md).
 
 ## Threat Model
 

--- a/SEMVER.md
+++ b/SEMVER.md
@@ -1,0 +1,43 @@
+# Stability & semver guarantees — presidio-hardened-x402
+
+For OEM partners embedding this library. Effective from v0.5.0.
+
+## What is the public API
+
+Everything exported in `presidio_x402.__all__`, plus the documented constructor/method signatures of those names, plus the modules `presidio_x402.core`, `presidio_x402.bindings.x402`, and the `presidio_x402.conformance` runner. Underscore-prefixed names are internal — but the pre-v0.5.0 gateway aliases (`gateway._parse_402_header`, `gateway._HEADER_PAYMENT`, `gateway._SUPPORTED_SCHEME`, `gateway._amount_to_usd`) are grandfathered and kept until v1.0.0.
+
+## Versioning rules (semver, pre-1.0 profile)
+
+- **Patch (0.x.Y):** bug fixes, security fixes, dependency floor bumps. No API change, no behaviour change except the fixed defect. Safe to auto-upgrade; this is the channel security releases ship on.
+- **Minor (0.X.0):** additive API (new exports, new optional parameters with defaults), new optional extras. Existing code keeps working — including audit event shapes, exception types, and the wire behaviour of the x402 binding. Deprecations are announced here (docstring + CHANGELOG) at least one minor before any change.
+- **Major (1.0.0+):** the only place deprecated surface may be removed. None scheduled.
+
+**Pin guidance for partners:** `presidio-hardened-x402>=0.5,<0.6` in production; run the conformance suite (below) in your CI on every upgrade.
+
+## Behavioural guarantees (stronger than API stability)
+
+These are security invariants, not just interfaces; weakening any of them is treated as a breaking change regardless of version component:
+
+1. **Fail-closed:** malformed payment offers, PII in block mode, policy violations, and replays raise — they never degrade to a warning.
+2. **Pre-signing screening:** all four controls (PII, policy, replay, MPA when configured) complete before the signer is invoked.
+3. **Rollback on non-commit:** a payment that is never signed (signer failure, MPA denial/timeout) refunds the budget and frees the replay fingerprint.
+4. **Sanitised audit path:** raw PII, signer exception chains, and oversized inputs never reach audit records or log sinks.
+5. **Audit chain integrity:** JSON-L audit records are HMAC-chained; tampering is detectable via `ComplianceReport`.
+
+## Verifying an installation
+
+```bash
+python -m presidio_x402.conformance
+```
+
+Runs the partner conformance suite (7 checks, no network) against the installed environment; exit code 0 means all guarantees above hold end-to-end. Run it in your CI next to your own integration tests.
+
+## Schema/wire stability
+
+- **x402 binding:** follows x402 spec v1 (`X-PAYMENT`, scheme `exact`). New schemes are additive (minor).
+- **Audit records:** fields are additive-only within a minor line; `ComplianceReport` reads all prior 0.x record shapes.
+- **Rail bindings:** `PaymentProtocolBinding` is a stable protocol from v0.5.0; custom bindings written against it will not break within 0.x.
+
+## Security response
+
+See [SECURITY.md](SECURITY.md). Security fixes ship as patch releases on the latest minor; the minimum-safe dependency floors (`_KNOWN_VULNERABLE`) are bumped in the same release.

--- a/docs/quickstarts/coinbase-cdp.md
+++ b/docs/quickstarts/coinbase-cdp.md
@@ -1,0 +1,60 @@
+# Quickstart: Coinbase CDP wallet + presidio-hardened-x402
+
+Embed the screening pipeline in front of a CDP-managed wallet so every x402 micropayment is PII-screened, policy-limited, replay-protected, and audited **before** the CDP signer is invoked.
+
+## Install
+
+```bash
+pip install "presidio-hardened-x402>=0.5,<0.6" cdp-sdk
+```
+
+## Wire the CDP signer
+
+The library never touches your keys — it calls your `PaymentSigner` with already-screened `PaymentDetails`. Adapt the token construction to the x402 facilitator you use; the screening behaviour is identical regardless.
+
+```python
+from presidio_x402 import HardenedX402Client, FileAuditWriter
+from presidio_x402._types import PaymentDetails, PaymentResponse
+
+# --- your CDP wallet setup (see CDP docs for auth) ---
+from cdp import CdpClient  # CDP SDK
+
+cdp = CdpClient()  # reads CDP_API_KEY_ID / CDP_API_KEY_SECRET / CDP_WALLET_SECRET
+account = await cdp.evm.get_or_create_account(name="agent-payments")
+
+async def cdp_signer(details: PaymentDetails) -> PaymentResponse:
+    """Sign the (already screened/redacted) payment with the CDP account.
+
+    `details` has passed all four controls: PII is redacted, the spend is
+    within policy, the fingerprint is fresh. Build the x402 payment token
+    for your facilitator here (EIP-712 typed-data signature).
+    """
+    signature = await account.sign_typed_data(
+        # typed-data payload per your x402 facilitator's scheme, built from:
+        # details.pay_to, details.amount, details.currency,
+        # details.network, details.deadline_seconds
+        ...
+    )
+    return PaymentResponse(token=signature, details=details)
+
+client = HardenedX402Client(
+    payment_signer=cdp_signer,
+    policy={"max_per_call_usd": 0.10, "daily_limit_usd": 5.0},
+    pii_action="redact",
+    trusted_wallets={"https://api.example.com": {"0xKnownVendorWallet..."}},
+    audit_writer=FileAuditWriter("audit/payments.jsonl"),
+    agent_id="agent-payments",
+)
+
+response = await client.get("https://api.example.com/paid-resource")
+```
+
+## What the embed gives you
+
+The 402 → screen → sign → retry loop is fully handled. A payment that fails any control raises (`PIIBlockedError`, `PolicyViolationError`, `ReplayDetectedError`, `X402PaymentError`) before `cdp_signer` runs — fail-closed, with the attempt in the audit log. A CDP outage mid-signing rolls back the budget and replay slot automatically.
+
+## Production checklist
+
+- Set `PRESIDIO_X402_CHAIN_KEY` and `PRESIDIO_X402_FINGERPRINT_KEY` (32-byte hex) — required for cross-restart audit-chain integrity and cross-replica replay detection.
+- Pin `>=0.5,<0.6` and run `python -m presidio_x402.conformance` in your CI (see [SEMVER.md](../../SEMVER.md)).
+- Use `trusted_wallets` for every origin you pay regularly — it defeats pay-to substitution by a compromised server.

--- a/docs/quickstarts/crewai.md
+++ b/docs/quickstarts/crewai.md
@@ -1,0 +1,48 @@
+# Quickstart: CrewAI crew + presidio-hardened-x402
+
+Let CrewAI agents purchase x402-gated resources under centrally enforced spending, PII, and replay controls — one shared budget and audit trail per crew, or one per agent.
+
+## Install
+
+```bash
+pip install "presidio-hardened-x402[crewai]>=0.5,<0.6"
+```
+
+## Use
+
+```python
+from presidio_x402.adapters.crewai import HardenedX402CrewTool
+from presidio_x402 import FileAuditWriter
+from crewai import Agent, Crew, Task
+
+pay_tool = HardenedX402CrewTool(
+    payment_signer=my_signer,           # your PaymentSigner (see CDP quickstart)
+    policy={
+        "max_per_call_usd": 0.05,
+        "daily_limit_usd": 2.0,
+        "per_endpoint": {"https://api.example.com": 1.0},
+    },
+    pii_action="block",                 # crews compose metadata from task context —
+                                        # block rather than redact if it may carry user data
+    audit_writer=FileAuditWriter("audit/crew-payments.jsonl"),
+    agent_id="research-crew",
+)
+
+researcher = Agent(
+    role="Researcher",
+    goal="Gather paid market data within budget",
+    tools=[pay_tool],
+)
+
+crew = Crew(agents=[researcher], tasks=[Task(description="...", agent=researcher)])
+result = await crew.kickoff_async()
+```
+
+## Budget topology choices
+
+- **One tool instance shared across agents** → one budget, one replay scope, one audit stream for the whole crew (the example above).
+- **One instance per agent** (distinct `agent_id`) → per-agent budgets and attributable audit trails; replay protection stays per-instance unless you set `PRESIDIO_X402_FINGERPRINT_KEY` and `redis_url` for cross-process scope.
+
+## Production checklist
+
+Same as the [CDP quickstart](coinbase-cdp.md): chain/fingerprint env keys, version pin `>=0.5,<0.6`, `python -m presidio_x402.conformance` in CI.

--- a/docs/quickstarts/langchain.md
+++ b/docs/quickstarts/langchain.md
@@ -1,0 +1,43 @@
+# Quickstart: LangChain agent + presidio-hardened-x402
+
+Give a LangChain agent the ability to pay for x402-gated resources with the full screening pipeline (PII redaction, spending limits, replay protection, audit) applied to every payment the agent decides to make.
+
+## Install
+
+```bash
+pip install "presidio-hardened-x402[langchain]>=0.5,<0.6"
+```
+
+The extra enforces `langchain-core>=1.3.3` (CVE-2026-44843 floor — see `_KNOWN_VULNERABLE` in the package).
+
+## Use
+
+```python
+from presidio_x402.adapters.langchain import HardenedX402Tool
+from presidio_x402 import FileAuditWriter
+
+tool = HardenedX402Tool(
+    payment_signer=my_signer,           # your PaymentSigner (see CDP quickstart)
+    policy={"max_per_call_usd": 0.05, "daily_limit_usd": 2.0},
+    pii_action="redact",
+    audit_writer=FileAuditWriter("audit/agent-payments.jsonl"),
+    agent_id="langchain-researcher",
+)
+
+# Any async LangChain agent executor:
+agent = create_react_agent(model, tools=[tool])
+result = await agent.ainvoke({"messages": [("user", "Fetch the paid dataset and summarise it")]})
+
+# Or call the tool directly:
+text = await tool.arun("https://api.example.com/paid-resource")
+```
+
+The tool is async-only (`arun`); the sync `run` path raises by design — payments should never block an event loop thread where timeouts and cancellation are invisible.
+
+## Why this matters for agents specifically
+
+The agent chooses *what* to pay for at runtime; you keep control of *how much, to whom, and with what data*. The agent cannot exceed `daily_limit_usd`, repeat a payment (fingerprint TTL), leak user PII through payment metadata it composes, or pay an unexpected wallet when `trusted_wallets` is set. Every attempt — allowed or blocked — lands in the HMAC-chained audit log keyed by `agent_id`.
+
+## Production checklist
+
+Same as the [CDP quickstart](coinbase-cdp.md): chain/fingerprint env keys, version pin, conformance suite in CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.4.0"
+version = "0.5.0"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -26,8 +26,11 @@ from __future__ import annotations
 
 import logging
 
+from ._types import PaymentProtocolBinding
 from .audit_log import AuditLog, FileAuditWriter, NullAuditWriter, StreamAuditWriter
+from .bindings.x402 import X402Binding
 from .compliance_report import ComplianceReport
+from .core import ScreeningPipeline
 from .exceptions import (
     MPADeniedError,
     MPATimeoutError,
@@ -50,12 +53,16 @@ from .policy_engine import PolicyConfig, PolicyEngine
 from .replay_guard import ReplayGuard, compute_fingerprint
 from .screening_client import ScreeningClient
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __all__ = [
     # Primary public API
     "HardenedX402Client",
     "PolicyConfig",
     "ComplianceReport",
+    # Rail-agnostic screening core + rail bindings (v0.5.0)
+    "ScreeningPipeline",
+    "PaymentProtocolBinding",
+    "X402Binding",
     # Multi-party authorization
     "MPAConfig",
     "MPAApproverConfig",

--- a/src/presidio_x402/_types.py
+++ b/src/presidio_x402/_types.py
@@ -101,3 +101,42 @@ class AuditWriter(Protocol):
     def write(self, event: AuditEvent) -> None:
         """Write a single audit event."""
         ...
+
+
+@runtime_checkable
+class PaymentProtocolBinding(Protocol):
+    """Protocol for payment-rail bindings (v0.5.0 binding-layer refactor).
+
+    A binding owns everything specific to one payment rail's wire format: how
+    a payment requirement is signalled, how the rail's payment offer parses
+    into the rail-agnostic :class:`PaymentDetails`, and how the signed token
+    travels on the retried request. The screening core
+    (:class:`~presidio_x402.core.ScreeningPipeline`) is reused unchanged across
+    bindings. Reference implementation:
+    :class:`~presidio_x402.bindings.x402.X402Binding`.
+    """
+
+    name: str
+    """Short rail identifier (e.g. ``"x402"``)."""
+
+    payment_required_status: int
+    """HTTP status code signalling that payment is required (402 for x402)."""
+
+    header_name: str
+    """Header carrying the payment offer / signed token."""
+
+    def payment_offer(self, status_code: int, headers: Any) -> str | None:
+        """Extract the raw payment-offer payload from a response, or ``None``."""
+        ...
+
+    def parse_payment_required(self, offer: str) -> PaymentDetails:
+        """Parse the rail's payment offer into :class:`PaymentDetails`.
+
+        Must fail closed: any malformed offer raises the library's payment
+        error rather than returning partial details.
+        """
+        ...
+
+    def token_headers(self, token: str) -> dict[str, str]:
+        """Headers carrying the signed payment token on the retried request."""
+        ...

--- a/src/presidio_x402/bindings/__init__.py
+++ b/src/presidio_x402/bindings/__init__.py
@@ -1,0 +1,23 @@
+"""Payment-rail bindings for the presidio-hardened screening core.
+
+The screening core (:mod:`presidio_x402.core`) is **rail-agnostic**: PII
+filtering, spending policy, replay detection, multi-party authorization, and
+audit logging operate on :class:`~presidio_x402._types.PaymentDetails` and know
+nothing about how a rail signals "payment required" or how a signed token is
+transmitted. Everything protocol-specific lives in a binding:
+
+- how a payment requirement is detected on an HTTP response,
+- how the rail's payment-offer payload parses into ``PaymentDetails``,
+- which header (or other channel) carries the signed payment token.
+
+``bindings.x402`` is the reference binding (HTTP 402 + ``X-PAYMENT`` header).
+A new rail (e.g. a future ACP/AP2-style protocol) is supported by adding a
+sibling module implementing :class:`~presidio_x402._types.PaymentProtocolBinding`
+— the screening core and its security guarantees are reused unchanged.
+"""
+
+from __future__ import annotations
+
+from .x402 import X402Binding
+
+__all__ = ["X402Binding"]

--- a/src/presidio_x402/bindings/x402.py
+++ b/src/presidio_x402/bindings/x402.py
@@ -1,0 +1,144 @@
+"""x402 protocol binding — HTTP 402 + ``X-PAYMENT`` header (x402 spec v1).
+
+This module owns every x402-specific assumption that used to live in the
+gateway: the payment header name, the supported scheme, and the parsing of the
+402 payment-offer JSON into the rail-agnostic
+:class:`~presidio_x402._types.PaymentDetails`. The screening core never sees
+any of these details (v0.5.0 binding-layer refactor; session-3 T2).
+
+Parsing hardening notes (F-04 2026-06-03, F1 2026-06-07) are preserved verbatim
+from the pre-refactor gateway implementation — the bytes and error behaviour
+are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+from .._types import PaymentDetails
+from ..exceptions import X402PaymentError
+
+# Header name per x402 spec.
+HEADER_PAYMENT = "X-PAYMENT"
+
+# Supported x402 scheme (since v0.1.0).
+SUPPORTED_SCHEME = "exact"
+
+# Max byte length of the raw X-PAYMENT header before JSON parsing. A malicious
+# 402 server could otherwise force the client to allocate arbitrary memory in
+# json.loads before any security control fires. 64 KiB is multiple orders of
+# magnitude above any legitimate x402 accepts payload.
+PAYMENT_HEADER_MAX_BYTES = 65_536
+
+
+def parse_402_header(header_value: str) -> PaymentDetails:
+    """Parse the ``X-PAYMENT`` header from a 402 response.
+
+    Expected JSON structure (x402 spec v1)::
+
+        {
+          "accepts": [{
+            "scheme": "exact",
+            "network": "base-mainnet",
+            "maxAmountRequired": "0.01",
+            "resource": "https://...",
+            "description": "...",
+            "mimeType": "application/json",
+            "payTo": "0x...",
+            "requiredDeadlineSeconds": 300,
+            "extra": {}
+          }]
+        }
+    """
+    if len(header_value.encode("utf-8")) > PAYMENT_HEADER_MAX_BYTES:
+        raise X402PaymentError(
+            f"X-PAYMENT header exceeds maximum length of {PAYMENT_HEADER_MAX_BYTES} bytes"
+        )
+    try:
+        data = json.loads(header_value)
+    except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+        # Also catch RecursionError: deeply nested JSON (small byte payload, under
+        # the size cap above) makes json.loads recurse to the interpreter limit;
+        # without this it would propagate uncaught and bypass the sanitised audit
+        # path (F-04, 2026-06-03). Never embed the raw JSON (which may carry
+        # wallet/PII fragments) in the message; the parse-error cause itself
+        # carries only position info, so it is kept on __cause__ for debugging.
+        raise X402PaymentError("Invalid X-PAYMENT header JSON") from exc
+
+    # The top level must be a JSON object. A valid-but-non-object payload (a
+    # bare array/number/string, e.g. a moderately nested list that parses before
+    # the recursion limit) would otherwise reach data.get() and raise an uncaught
+    # AttributeError outside the sanitised audit path (F-04, 2026-06-03).
+    if not isinstance(data, dict):
+        raise X402PaymentError("Invalid X-PAYMENT header JSON")
+
+    accepts = data.get("accepts", [])
+    if not accepts:
+        raise X402PaymentError("X-PAYMENT header contains no 'accepts' entries")
+
+    # Pick the first supported scheme. Each accepts[] entry must be a JSON object;
+    # a hostile server can send a primitive (e.g. {"accepts": ["exact"]} or [42]),
+    # and entry.get() on a non-dict would raise an uncaught AttributeError outside
+    # the sanitised audit path (F1, 2026-06-07). Skip non-dict entries.
+    chosen = None
+    for entry in accepts:
+        if isinstance(entry, dict) and entry.get("scheme") == SUPPORTED_SCHEME:
+            chosen = entry
+            break
+    if chosen is None:
+        schemes = [e.get("scheme") for e in accepts if isinstance(e, dict)]
+        raise X402PaymentError(
+            f"No supported payment scheme found. Server offered: {schemes}; "
+            f"client supports: [{SUPPORTED_SCHEME!r}]"
+        )
+
+    try:
+        return PaymentDetails(
+            resource_url=chosen["resource"],
+            pay_to=chosen["payTo"],
+            amount=chosen["maxAmountRequired"],
+            currency=chosen.get("currency", "USDC"),
+            network=chosen["network"],
+            deadline_seconds=int(chosen.get("requiredDeadlineSeconds", 300)),
+            description=chosen.get("description", ""),
+            reason=chosen.get("reason", ""),
+            extra=chosen.get("extra", {}),
+        )
+    except KeyError:
+        raise X402PaymentError("Missing required field in X-PAYMENT entry") from None
+
+
+class X402Binding:
+    """The reference :class:`~presidio_x402._types.PaymentProtocolBinding`.
+
+    Encapsulates how the x402 rail signals a payment requirement (HTTP 402 +
+    ``X-PAYMENT`` header) and how the signed token is transmitted (the same
+    header on the retried request).
+    """
+
+    name = "x402"
+    payment_required_status = 402
+    header_name = HEADER_PAYMENT
+
+    def payment_offer(self, status_code: int, headers: dict[str, str]) -> str | None:
+        """Return the raw payment-offer payload, or ``None`` if this response
+        does not require payment (or the offer is missing/malformed at the
+        transport level)."""
+        if status_code != self.payment_required_status:
+            return None
+        # Header lookup is case-insensitive at the httpx layer; callers pass
+        # the already-normalised mapping. A 402 without the header is treated
+        # as "no offer" — the gateway returns the response unmodified.
+        return headers.get(self.header_name)
+
+    def parse_payment_required(self, offer: str) -> PaymentDetails:
+        """Parse the rail's payment offer into rail-agnostic details.
+
+        Raises :class:`~presidio_x402.exceptions.X402PaymentError` on any
+        malformed offer (fail-closed; hardened per F-04/F1).
+        """
+        return parse_402_header(offer)
+
+    def token_headers(self, token: str) -> dict[str, str]:
+        """Headers carrying the signed payment token on the retried request."""
+        return {self.header_name: token}

--- a/src/presidio_x402/compliance_report.py
+++ b/src/presidio_x402/compliance_report.py
@@ -30,8 +30,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+# The chain key is read live from the audit_log module (not imported as a value
+# snapshot): the writer signs with `audit_log._CHAIN_KEY` at call time, so the
+# verifier must resolve the same attribute at verification time. A from-import
+# froze the key at import and silently desynced writer and verifier whenever
+# the module was reloaded with a different key — the chain check then failed on
+# untampered logs (found by the v0.5.0 partner conformance suite).
+from . import audit_log as _audit_log
 from ._types import AuditEvent
-from .audit_log import _CHAIN_KEY  # type: ignore[attr-defined]
 
 # ---------------------------------------------------------------------------
 # Entry parsing
@@ -148,7 +154,11 @@ class ComplianceReport:
                 )
             # Compute expected HMAC of this entry for the next entry
             entry_json = json.dumps(dict(raw), default=str)
-            prev_hmac = hmac.new(_CHAIN_KEY, entry_json.encode(), hashlib.sha256).hexdigest()
+            prev_hmac = hmac.new(
+                _audit_log._CHAIN_KEY,  # live module attribute — see import note
+                entry_json.encode(),
+                hashlib.sha256,
+            ).hexdigest()
 
     # ---------------------------------------------------------------------------
     # Analysis helpers

--- a/src/presidio_x402/conformance/__init__.py
+++ b/src/presidio_x402/conformance/__init__.py
@@ -1,0 +1,30 @@
+"""Partner-runnable conformance suite for presidio-hardened-x402 (OEM embed kit).
+
+Run against your installed environment with::
+
+    python -m presidio_x402.conformance
+
+The suite verifies — in-process, with no network access — that the installed
+library delivers the documented security guarantees end-to-end:
+
+1. The public API surface (everything in ``__all__``) imports.
+2. PII in payment metadata is redacted before the signer sees it.
+3. ``pii_action="block"`` fails closed on PII.
+4. Spending policy blocks an over-limit payment before signing.
+5. An identical payment is blocked as a replay; a signer failure rolls back
+   the budget + fingerprint (no lost funds accounting, no burned retry slot).
+6. The audit log is written and its HMAC chain verifies; a tampered log is
+   detected.
+7. The x402 binding parses spec-conformant 402 offers and rejects malformed
+   ones fail-closed.
+
+Exit code 0 = all checks pass; 1 = at least one failure (fail-closed: an
+unexpected exception in any check counts as failure). Intended for OEM
+partners to run in their own integration environment/CI.
+"""
+
+from __future__ import annotations
+
+from .runner import main, run_all
+
+__all__ = ["main", "run_all"]

--- a/src/presidio_x402/conformance/__main__.py
+++ b/src/presidio_x402/conformance/__main__.py
@@ -1,0 +1,5 @@
+"""``python -m presidio_x402.conformance`` entry point."""
+
+from .runner import main
+
+raise SystemExit(main())

--- a/src/presidio_x402/conformance/runner.py
+++ b/src/presidio_x402/conformance/runner.py
@@ -1,0 +1,261 @@
+"""Conformance checks — see package docstring. No network; httpx.MockTransport only."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import traceback
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+CHECKS: list[tuple[str, Callable[[], None]]] = []
+
+
+def check(name: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
+    def register(fn: Callable[[], None]) -> Callable[[], None]:
+        CHECKS.append((name, fn))
+        return fn
+
+    return register
+
+
+# ---------------------------------------------------------------------------
+# Helpers (no network: a scripted httpx.MockTransport plays the 402 server)
+# ---------------------------------------------------------------------------
+
+_OFFER = json.dumps(
+    {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base-sepolia",
+                "maxAmountRequired": "0.01",
+                "resource": "https://conformance.invalid/v1/data",
+                "description": "conformance probe for pii@example.com",
+                "payTo": "0x00000000000000000000000000000000c0ffee00",
+                "requiredDeadlineSeconds": 300,
+            }
+        ]
+    }
+)
+
+
+def _scripted_transport(responses: list[httpx.Response]) -> httpx.MockTransport:
+    queue = list(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not queue:
+            raise AssertionError("conformance transport exhausted")
+        return queue.pop(0)
+
+    return httpx.MockTransport(handler)
+
+
+def _client(responses: list[httpx.Response], **kwargs):
+    from presidio_x402 import HardenedX402Client
+    from presidio_x402._types import PaymentDetails, PaymentResponse
+
+    async def signer(details: PaymentDetails) -> PaymentResponse:
+        return PaymentResponse(token="conformance-token", details=details)  # noqa: S106
+
+    kwargs.setdefault("payment_signer", signer)
+    httpx_client = httpx.AsyncClient(transport=_scripted_transport(responses))
+    return HardenedX402Client(httpx_client=httpx_client, **kwargs)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _402(offer: str = _OFFER) -> httpx.Response:
+    return httpx.Response(402, headers={"X-PAYMENT": offer})
+
+
+def _ok() -> httpx.Response:
+    return httpx.Response(200, text="paid")
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+@check("public API surface importable")
+def check_api_surface() -> None:
+    import presidio_x402
+
+    missing = [name for name in presidio_x402.__all__ if not hasattr(presidio_x402, name)]
+    assert not missing, f"__all__ names missing from package: {missing}"
+
+
+@check("PII redacted before signer sees payment details")
+def check_pii_redaction() -> None:
+    from presidio_x402._types import PaymentDetails, PaymentResponse
+
+    seen: list[str] = []
+
+    async def capturing_signer(details: PaymentDetails) -> PaymentResponse:
+        seen.append(details.description)
+        return PaymentResponse(token="t", details=details)  # noqa: S106
+
+    async def flow() -> None:
+        client = _client([_402(), _ok()], payment_signer=capturing_signer)
+        async with client:
+            await client.get("https://conformance.invalid/v1/data")
+
+    _run(flow())
+    assert seen, "signer was never invoked"
+    assert "pii@example.com" not in seen[0], "raw PII reached the signer"
+
+
+@check("pii_action=block fails closed on PII")
+def check_pii_block() -> None:
+    from presidio_x402.exceptions import PIIBlockedError
+
+    async def flow() -> None:
+        client = _client([_402()], pii_action="block")
+        async with client:
+            try:
+                await client.get("https://conformance.invalid/v1/data")
+            except PIIBlockedError:
+                return
+            raise AssertionError("PII did not block the payment")
+
+    _run(flow())
+
+
+@check("spending policy blocks over-limit payment before signing")
+def check_policy_block() -> None:
+    from presidio_x402.exceptions import PolicyViolationError
+
+    async def flow() -> None:
+        client = _client([_402()], policy={"max_per_call_usd": 0.001})
+        async with client:
+            try:
+                await client.get("https://conformance.invalid/v1/data")
+            except PolicyViolationError:
+                return
+            raise AssertionError("policy did not block the payment")
+
+    _run(flow())
+
+
+@check("replay blocked; signer failure rolls back budget + fingerprint")
+def check_replay_and_rollback() -> None:
+    from presidio_x402._types import PaymentDetails, PaymentResponse
+    from presidio_x402.exceptions import ReplayDetectedError, X402PaymentError
+
+    async def replay_flow() -> None:
+        client = _client([_402(), _ok(), _402()])
+        async with client:
+            await client.get("https://conformance.invalid/v1/data")
+            try:
+                await client.get("https://conformance.invalid/v1/data")
+            except ReplayDetectedError:
+                return
+            raise AssertionError("identical payment was not detected as replay")
+
+    _run(replay_flow())
+
+    fail_once = {"n": 0}
+
+    async def flaky_signer(details: PaymentDetails) -> PaymentResponse:
+        fail_once["n"] += 1
+        if fail_once["n"] == 1:
+            raise RuntimeError("signer outage")
+        return PaymentResponse(token="t", details=details)  # noqa: S106
+
+    async def rollback_flow() -> None:
+        client = _client(
+            [_402(), _402(), _ok()],
+            payment_signer=flaky_signer,
+            policy={"daily_limit_usd": 0.01},
+        )
+        async with client:
+            try:
+                await client.get("https://conformance.invalid/v1/data")
+            except X402PaymentError:
+                pass
+            else:
+                raise AssertionError("signer failure did not surface as payment error")
+            # Budget and fingerprint must be free again — the retry succeeds.
+            await client.get("https://conformance.invalid/v1/data")
+
+    _run(rollback_flow())
+
+
+@check("audit log written; HMAC chain verifies; tampering detected")
+def check_audit_chain() -> None:
+    from presidio_x402 import ComplianceReport, FileAuditWriter
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "audit.jsonl"
+
+        async def flow() -> None:
+            client = _client([_402(), _ok()], audit_writer=FileAuditWriter(str(path)))
+            async with client:
+                await client.get("https://conformance.invalid/v1/data")
+
+        _run(flow())
+        assert path.exists() and path.stat().st_size > 0, "no audit records written"
+        report = ComplianceReport.from_jsonl(path)
+        assert report.chain_ok, f"audit chain failed on untampered log: {report.chain_warnings}"
+
+        # Tamper with the first record — the chain must flag it.
+        lines = path.read_text(encoding="utf-8").splitlines()
+        record = json.loads(lines[0])
+        record["amount_usd"] = 99999.0
+        lines[0] = json.dumps(record)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        tampered = ComplianceReport.from_jsonl(path)
+        assert not tampered.chain_ok, "tampered audit log passed chain verification"
+
+
+@check("x402 binding parses spec offers and rejects malformed offers fail-closed")
+def check_binding() -> None:
+    from presidio_x402 import X402Binding
+    from presidio_x402.exceptions import X402PaymentError
+
+    binding = X402Binding()
+    details = binding.parse_payment_required(_OFFER)
+    assert details.amount == "0.01" and details.network == "base-sepolia"
+    for bad in ("not json", "[]", '{"accepts": []}', '{"accepts": ["exact"]}'):
+        try:
+            binding.parse_payment_required(bad)
+        except X402PaymentError:
+            continue
+        raise AssertionError(f"malformed offer accepted: {bad!r}")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run_all() -> int:
+    """Run every conformance check. Returns the number of failures."""
+    import presidio_x402
+
+    print(f"presidio-hardened-x402 conformance suite — library {presidio_x402.__version__}")
+    failures = 0
+    for name, fn in CHECKS:
+        try:
+            fn()
+        except Exception:
+            failures += 1
+            print(f"FAIL  {name}")
+            traceback.print_exc()
+        else:
+            print(f"PASS  {name}")
+    print(f"\n{len(CHECKS) - failures}/{len(CHECKS)} checks passed")
+    return failures
+
+
+def main() -> int:
+    return 1 if run_all() else 0

--- a/src/presidio_x402/core.py
+++ b/src/presidio_x402/core.py
@@ -1,0 +1,377 @@
+"""ScreeningPipeline — the rail-agnostic screening core (v0.5.0, session-3 T2).
+
+The patent-relevant four-control sequence (PII filter → trusted-wallet check →
+policy engine → replay guard → MPA) extracted from the x402 gateway so that it
+operates on :class:`~presidio_x402._types.PaymentDetails` alone and contains no
+payment-protocol assumptions. Bindings (:mod:`presidio_x402.bindings`) translate
+rail-specific wire formats into ``PaymentDetails``; the pipeline and its
+security guarantees are reused unchanged across rails.
+
+Behavioural contract: this module was extracted verbatim from
+``gateway.HardenedX402Client`` — audit events, metric names, exception types,
+rollback semantics, and redaction behaviour are byte-identical to v0.4.0. The
+existing gateway test suite is the conformance proof.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import replace
+from typing import TYPE_CHECKING, Literal
+
+import httpx
+
+from .exceptions import (
+    MPADeniedError,
+    MPATimeoutError,
+    PIIBlockedError,
+    PolicyViolationError,
+    ReplayDetectedError,
+    X402PaymentError,
+)
+from .replay_guard import ReplayGuard, compute_fingerprint
+
+if TYPE_CHECKING:
+    from ._types import PaymentDetails
+    from .audit_log import AuditLog
+    from .metrics import MetricsCollector
+    from .mpa import MPAEngine
+    from .pii_filter import PIIFilter
+    from .policy_engine import PolicyEngine
+    from .screening_client import ScreeningClient
+
+logger = logging.getLogger("presidio_x402.core")
+
+# Max characters of an exception message retained in audit records. Exception
+# text frequently carries fragments of the offending input (JSON snippets,
+# signing-key material, wallet addresses) — truncation caps blast radius.
+SAFE_EXC_MESSAGE_MAX = 80
+
+_USD_PEGGED = frozenset({"USDC", "USDT", "DAI", "USDCE", "USDBC"})
+
+
+def safe_exc_message(exc: BaseException, max_len: int = SAFE_EXC_MESSAGE_MAX) -> str:
+    """Truncate an exception message before it can reach an audit record."""
+    msg = str(exc)
+    if len(msg) > max_len:
+        msg = msg[:max_len] + "...[truncated]"
+    return msg
+
+
+def resource_origin(url: str) -> str:
+    """Scheme + host[:port] of a resource URL (allowlist key)."""
+    parsed = httpx.URL(url)
+    return str(parsed.copy_with(path="", query=None, fragment=None)).rstrip("/")
+
+
+def amount_to_usd(amount: str, currency: str) -> float:
+    """Convert a payment amount string to USD.
+
+    Supports USD-pegged stablecoins only (USDC, USDT, DAI, USDCE, USDBC).
+    Non-stablecoin currencies raise :class:`X402PaymentError` because without a
+    price oracle the USD value cannot be determined, and silently understating it
+    would allow policy limits to be bypassed.
+    """
+    try:
+        value = float(amount)
+    except ValueError as exc:
+        raise X402PaymentError(f"Invalid payment amount {amount!r}: not a numeric value") from exc
+    if not math.isfinite(value) or value < 0:
+        raise X402PaymentError(
+            f"Invalid payment amount {amount!r}: must be a finite non-negative number. "
+            "Non-finite values (nan, inf, -inf) bypass IEEE 754 comparison-based limit checks "
+            "and are rejected to preserve policy enforcement integrity."
+        )
+    if currency.upper() not in _USD_PEGGED:
+        raise X402PaymentError(
+            f"Unsupported currency {currency!r} for policy enforcement. "
+            f"Supported stablecoins: {sorted(_USD_PEGGED)}. "
+            "For non-stablecoin payments configure a custom price oracle."
+        )
+    return value
+
+
+class ScreeningPipeline:
+    """Pre-execution screening: PII → wallet allowlist → policy → replay → MPA.
+
+    Rail-agnostic. Construct with the security components (typically done by a
+    binding client such as :class:`~presidio_x402.gateway.HardenedX402Client`)
+    and call :meth:`apply` with the parsed :class:`PaymentDetails` immediately
+    before the payment is signed. If signing subsequently fails, call
+    :meth:`rollback` with the returned fingerprint.
+    """
+
+    def __init__(
+        self,
+        *,
+        pii_filter: PIIFilter,
+        policy: PolicyEngine,
+        replay: ReplayGuard,
+        audit: AuditLog,
+        pii_action: Literal["redact", "block", "warn"] = "redact",
+        pii_entities: list[str] | None = None,
+        mpa_engine: MPAEngine | None = None,
+        metrics_collector: MetricsCollector | None = None,
+        trusted_wallets: dict[str, frozenset[str]] | None = None,
+        screening_client: ScreeningClient | None = None,
+        remote_screening: bool = False,
+    ) -> None:
+        if remote_screening and screening_client is None:
+            raise ValueError("remote_screening=True requires a screening_client instance")
+        self._pii_filter = pii_filter
+        self._pii_entities = pii_entities
+        self._pii_action = pii_action
+        self._policy = policy
+        self._replay = replay
+        self._audit = audit
+        self._mpa = mpa_engine
+        self._metrics = metrics_collector
+        self._trusted_wallets = trusted_wallets
+        self._screening_client = screening_client
+        self._remote_screening = remote_screening
+
+    def rollback(self, *, resource_url: str, amount_usd: float, fingerprint: str) -> None:
+        """Reverse the spend + replay fingerprint speculatively committed in
+        :meth:`apply`.
+
+        The policy spend and replay fingerprint are recorded *before* the payment
+        is signed (so the TOCTOU-critical check+record stays atomic under a
+        single lock — a guarantee that cannot span the async signer ``await``).
+        When the payment is subsequently denied (MPA) or fails to sign, this
+        compensating rollback keeps the spend ledger consistent with payments
+        that actually committed and frees the fingerprint for a legitimate retry
+        (F-03, 2026-06-03).
+        """
+        self._policy.refund(resource_url=resource_url, amount_usd=amount_usd)
+        self._replay.release(fingerprint)
+
+    async def apply(
+        self,
+        details: PaymentDetails,
+        *,
+        mpa_signatures: dict[str, str] | None = None,
+    ) -> tuple[PaymentDetails, str]:
+        """Apply PIIFilter → PolicyEngine → ReplayGuard → MPAEngine → AuditLog.
+
+        Returns a ``(details, fingerprint)`` tuple: the (possibly modified)
+        :class:`~presidio_x402._types.PaymentDetails` with PII redacted from
+        metadata fields if ``pii_action="redact"``, plus the replay fingerprint
+        recorded for this payment so the caller can roll it back if signing
+        fails.
+
+        Raises on policy violation, replay, PII block, or MPA denial/timeout.
+        On MPA denial/timeout the spend + replay commit is rolled back before
+        re-raising.
+        """
+        amount_usd = amount_to_usd(details.amount, details.currency)
+
+        # Preserve the original resource_url for replay-guard fingerprinting.
+        # In pii_action="redact" mode the URL gets rewritten with PII tokens
+        # masked; using the redacted URL for fingerprinting would collide
+        # distinct user-specific URLs (e.g. /user/alice@.../pay vs
+        # /user/bob@.../pay both reduce to /user/<EMAIL_ADDRESS>/pay) and
+        # produce false-positive ReplayDetectedError. Original URL is never
+        # passed downstream to signer / MPA — only used for the local HMAC.
+        original_resource_url = details.resource_url
+
+        # ------------------------------------------------------------------
+        # 1. PII Filter (local regex/NLP or remote screening service)
+        # ------------------------------------------------------------------
+        if self._remote_screening and self._screening_client is not None:
+            (
+                clean_url,
+                clean_desc,
+                clean_reason,
+                pii_entities,
+            ) = await self._screening_client.scan_payment_fields(
+                details.resource_url,
+                details.description,
+                details.reason,
+                entities=self._pii_entities,
+            )
+            # Defense-in-depth (F-06, 2026-06-03): the remote screener is the
+            # only scan of the three primary fields, so a mis-redacting, empty,
+            # or silently degraded response would pass PII through unredacted.
+            # Re-run the fast local regex filter over its output as a cheap
+            # backstop. On a correct remote response the fields are already
+            # masked, so this finds nothing; it only catches what the remote
+            # missed, and feeds those entities into the block/redact decision.
+            clean_url, url_ent = self._pii_filter.scan_and_redact(clean_url)
+            clean_desc, desc_ent = self._pii_filter.scan_and_redact(clean_desc)
+            clean_reason, reason_ent = self._pii_filter.scan_and_redact(clean_reason)
+            pii_entities = list(pii_entities) + url_ent + desc_ent + reason_ent
+        else:
+            clean_url, clean_desc, clean_reason, pii_entities = (
+                self._pii_filter.scan_payment_fields(
+                    details.resource_url, details.description, details.reason
+                )
+            )
+
+        # The remote screening API only covers the three primary string fields.
+        # The `extra` dict is arbitrary server-controlled JSON and must be
+        # scanned locally for defense-in-depth — this closes REQ-1 against
+        # malicious 402 servers that smuggle PII through the extra channel.
+        clean_extra, extra_entities = self._pii_filter.scan_dict(details.extra)
+        if extra_entities:
+            pii_entities = list(pii_entities) + list(extra_entities)
+
+        if pii_entities:
+            entity_types = [e.entity_type for e in pii_entities]
+            if self._pii_action == "block":
+                self._audit.emit(
+                    "PII_BLOCKED",
+                    resource_url=clean_url,
+                    amount_usd=amount_usd,
+                    network=details.network,
+                    outcome="blocked",
+                    pii_entities_found=entity_types,
+                )
+                if self._metrics:
+                    self._metrics.record_pii_detection(entity_types, "block")
+                    self._metrics.record_payment_blocked("pii", amount_usd)
+                raise PIIBlockedError(
+                    f"PII detected in payment metadata: {', '.join(sorted(set(entity_types)))}",
+                    entities=entity_types,
+                )
+            elif self._pii_action == "redact":
+                self._audit.emit(
+                    "PII_REDACTED",
+                    resource_url=clean_url,
+                    amount_usd=amount_usd,
+                    network=details.network,
+                    outcome="allowed",
+                    pii_entities_found=entity_types,
+                )
+                if self._metrics:
+                    self._metrics.record_pii_detection(entity_types, "redact")
+                # Replace metadata fields with redacted versions.
+                # resource_url is replaced AFTER replay-fingerprint computation
+                # earlier in this function so the original URL still drives
+                # deduplication; from this point on every downstream consumer
+                # (signer, MPA webhooks, audit log post-event) sees clean_url.
+                # The `extra` dict is also redacted in-place when PII is found
+                # in any of its string values (REQ-1 — closes F-A 2026-05-03).
+                details = replace(
+                    details,
+                    resource_url=clean_url,
+                    description=clean_desc,
+                    reason=clean_reason,
+                    extra=clean_extra if extra_entities else details.extra,
+                )
+            elif self._metrics:
+                # pii_action == "warn": log already happened in PIIFilter
+                self._metrics.record_pii_detection(entity_types, "warn")
+
+        # ------------------------------------------------------------------
+        # 2. Trusted-wallet allowlist (pay_to substitution defence)
+        # ------------------------------------------------------------------
+        if self._trusted_wallets is not None:
+            # Key the allowlist off the ORIGINAL (pre-redaction) origin. PII
+            # redaction can rewrite the host (IP literals via IP_ADDRESS,
+            # digit-laden DNS labels via US_SSN/PHONE_NUMBER), which would shift
+            # the origin string out of the allowlist, miss the lookup, and
+            # silently skip the pay_to check entirely. The host is a
+            # security-control key, not PII — this mirrors the replay
+            # fingerprint, which also keys off original_resource_url below
+            # (CWE-348 / F-02, 2026-06-03).
+            origin = resource_origin(original_resource_url)
+            allowed = self._trusted_wallets.get(origin)
+            if allowed is not None and details.pay_to.lower() not in allowed:
+                # The raw origin may contain a redactable host; keep it out of
+                # the persisted audit message and surface only the redacted URL.
+                self._audit.emit(
+                    "WALLET_BLOCKED",
+                    resource_url=clean_url,
+                    amount_usd=amount_usd,
+                    network=details.network,
+                    outcome="blocked",
+                    error_message=f"pay_to {details.pay_to!r} not in trusted wallet allowlist",
+                )
+                if self._metrics:
+                    self._metrics.record_payment_blocked("wallet", amount_usd)
+                raise X402PaymentError(
+                    f"pay_to wallet {details.pay_to!r} not in trusted allowlist"
+                )
+
+        # ------------------------------------------------------------------
+        # 3. Policy Engine
+        # ------------------------------------------------------------------
+        try:
+            self._policy.check_and_record(resource_url=details.resource_url, amount_usd=amount_usd)
+        except PolicyViolationError as exc:
+            self._audit.emit(
+                "POLICY_BLOCKED",
+                resource_url=clean_url,
+                amount_usd=amount_usd,
+                network=details.network,
+                outcome="blocked",
+                policy_limit_usd=exc.limit_usd,
+            )
+            if self._metrics:
+                self._metrics.record_policy_violation("limit_exceeded")
+                self._metrics.record_payment_blocked("policy", amount_usd)
+            raise
+
+        # ------------------------------------------------------------------
+        # 4. Replay Guard
+        # ------------------------------------------------------------------
+        fingerprint = compute_fingerprint(
+            resource_url=original_resource_url,  # ORIGINAL URL — see top of method
+            pay_to=details.pay_to,
+            amount=details.amount,
+            currency=details.currency,
+            deadline_seconds=details.deadline_seconds,
+        )
+        try:
+            self._replay.check_and_record(fingerprint)
+        except ReplayDetectedError:
+            self._audit.emit(
+                "REPLAY_BLOCKED",
+                resource_url=clean_url,
+                amount_usd=amount_usd,
+                network=details.network,
+                outcome="blocked",
+                replay_fingerprint=fingerprint[:16],
+            )
+            if self._metrics:
+                self._metrics.record_replay_detection()
+                self._metrics.record_payment_blocked("replay", amount_usd)
+            raise
+
+        # ------------------------------------------------------------------
+        # 5. Multi-Party Authorization (if configured)
+        # ------------------------------------------------------------------
+        if self._mpa is not None:
+            try:
+                await self._mpa.request_approval(
+                    details, amount_usd, provided_signatures=mpa_signatures
+                )
+                if self._metrics:
+                    self._metrics.record_mpa_event("approved")
+            except (MPADeniedError, MPATimeoutError) as exc:
+                # Roll back the spend + replay fingerprint committed at steps 3–4:
+                # an MPA-denied/timed-out payment was never signed, so it must not
+                # charge the budget or burn the fingerprint (which would block the
+                # legitimate crypto-mode retry that carries the countersignatures).
+                self.rollback(
+                    resource_url=details.resource_url,
+                    amount_usd=amount_usd,
+                    fingerprint=fingerprint,
+                )
+                outcome = "timeout" if isinstance(exc, MPATimeoutError) else "denied"
+                safe_msg, _ = self._pii_filter.scan_and_redact(safe_exc_message(exc))
+                self._audit.emit(
+                    "MPA_BLOCKED",
+                    resource_url=clean_url,
+                    amount_usd=amount_usd,
+                    network=details.network,
+                    outcome="blocked",
+                    error_message=safe_msg,
+                )
+                if self._metrics:
+                    self._metrics.record_mpa_event(outcome)
+                    self._metrics.record_payment_blocked(f"mpa_{outcome}", amount_usd)
+                raise
+
+        return details, fingerprint

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -3,6 +3,16 @@
 Implements the x402 payment flow directly over httpx, with all security controls
 applied before payment signing and submission.
 
+Since v0.5.0 the client is a thin composition of two rail-separated parts
+(session-3 T2 binding-layer refactor):
+
+- :class:`~presidio_x402.core.ScreeningPipeline` — the rail-agnostic screening
+  core (PII → trusted-wallet → policy → replay → MPA, with audit + rollback);
+- :class:`~presidio_x402.bindings.x402.X402Binding` — everything x402-specific
+  (402 status, ``X-PAYMENT`` header, accepts[] parsing).
+
+Behaviour is byte-identical to v0.4.0; all previous import paths keep working.
+
 Payment flow (per x402 spec):
   1. Client sends HTTP request to a resource URL
   2. Server responds with 402 Payment Required + ``X-PAYMENT`` header (JSON)
@@ -35,170 +45,60 @@ Usage::
 
 from __future__ import annotations
 
-import json
 import logging
-import math
-from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 
-from ._types import AuditWriter, PaymentDetails, PaymentResponse, PaymentSigner
 from .audit_log import AuditLog, NullAuditWriter
-from .exceptions import (
-    MPADeniedError,
-    MPATimeoutError,
-    PIIBlockedError,
-    PolicyViolationError,
-    ReplayDetectedError,
-    X402PaymentError,
+from .bindings.x402 import (
+    HEADER_PAYMENT,
+    PAYMENT_HEADER_MAX_BYTES,
+    SUPPORTED_SCHEME,
+    X402Binding,
+    parse_402_header,
 )
+from .core import (
+    SAFE_EXC_MESSAGE_MAX,
+    ScreeningPipeline,
+    amount_to_usd,
+    resource_origin,
+    safe_exc_message,
+)
+from .exceptions import X402PaymentError
+from .pii_filter import PIIFilter
+from .policy_engine import PolicyConfig, PolicyEngine
+from .replay_guard import ReplayGuard
 
 if TYPE_CHECKING:
+    from ._types import (
+        AuditWriter,
+        PaymentDetails,
+        PaymentProtocolBinding,
+        PaymentResponse,
+        PaymentSigner,
+    )
     from .metrics import MetricsCollector
     from .mpa import MPAEngine
     from .screening_client import ScreeningClient
-from .pii_filter import PIIFilter
-from .policy_engine import PolicyConfig, PolicyEngine
-from .replay_guard import ReplayGuard, compute_fingerprint
 
 logger = logging.getLogger("presidio_x402.gateway")
 
-# Header names per x402 spec
-_HEADER_PAYMENT = "X-PAYMENT"
-
-# Supported x402 scheme for v0.1.0
-_SUPPORTED_SCHEME = "exact"
-
-# Max characters of an exception message retained in audit records. Exception
-# text frequently carries fragments of the offending input (JSON snippets,
-# signing-key material, wallet addresses) — truncation caps blast radius.
-_SAFE_EXC_MESSAGE_MAX = 80
-
-# Max byte length of the raw X-PAYMENT header before JSON parsing. A malicious
-# 402 server could otherwise force the client to allocate arbitrary memory in
-# json.loads before any security control fires. 64 KiB is multiple orders of
-# magnitude above any legitimate x402 accepts payload.
-_PAYMENT_HEADER_MAX_BYTES = 65_536
-
-
-def _safe_exc_message(exc: BaseException, max_len: int = _SAFE_EXC_MESSAGE_MAX) -> str:
-    msg = str(exc)
-    if len(msg) > max_len:
-        msg = msg[:max_len] + "...[truncated]"
-    return msg
-
-
-def _resource_origin(url: str) -> str:
-    parsed = httpx.URL(url)
-    return str(parsed.copy_with(path="", query=None, fragment=None)).rstrip("/")
-
-
-def _parse_402_header(header_value: str) -> PaymentDetails:
-    """Parse the ``X-PAYMENT`` header from a 402 response.
-
-    Expected JSON structure (x402 spec v1)::
-
-        {
-          "accepts": [{
-            "scheme": "exact",
-            "network": "base-mainnet",
-            "maxAmountRequired": "0.01",
-            "resource": "https://...",
-            "description": "...",
-            "mimeType": "application/json",
-            "payTo": "0x...",
-            "requiredDeadlineSeconds": 300,
-            "extra": {}
-          }]
-        }
-    """
-    if len(header_value.encode("utf-8")) > _PAYMENT_HEADER_MAX_BYTES:
-        raise X402PaymentError(
-            f"X-PAYMENT header exceeds maximum length of {_PAYMENT_HEADER_MAX_BYTES} bytes"
-        )
-    try:
-        data = json.loads(header_value)
-    except (json.JSONDecodeError, ValueError, RecursionError) as exc:
-        # Also catch RecursionError: deeply nested JSON (small byte payload, under
-        # the size cap above) makes json.loads recurse to the interpreter limit;
-        # without this it would propagate uncaught and bypass the sanitised audit
-        # path (F-04, 2026-06-03). Never embed the raw JSON (which may carry
-        # wallet/PII fragments) in the message; the parse-error cause itself
-        # carries only position info, so it is kept on __cause__ for debugging.
-        raise X402PaymentError("Invalid X-PAYMENT header JSON") from exc
-
-    # The top level must be a JSON object. A valid-but-non-object payload (a
-    # bare array/number/string, e.g. a moderately nested list that parses before
-    # the recursion limit) would otherwise reach data.get() and raise an uncaught
-    # AttributeError outside the sanitised audit path (F-04, 2026-06-03).
-    if not isinstance(data, dict):
-        raise X402PaymentError("Invalid X-PAYMENT header JSON")
-
-    accepts = data.get("accepts", [])
-    if not accepts:
-        raise X402PaymentError("X-PAYMENT header contains no 'accepts' entries")
-
-    # Pick the first supported scheme. Each accepts[] entry must be a JSON object;
-    # a hostile server can send a primitive (e.g. {"accepts": ["exact"]} or [42]),
-    # and entry.get() on a non-dict would raise an uncaught AttributeError outside
-    # the sanitised audit path (F1, 2026-06-07). Skip non-dict entries.
-    chosen = None
-    for entry in accepts:
-        if isinstance(entry, dict) and entry.get("scheme") == _SUPPORTED_SCHEME:
-            chosen = entry
-            break
-    if chosen is None:
-        schemes = [e.get("scheme") for e in accepts if isinstance(e, dict)]
-        raise X402PaymentError(
-            f"No supported payment scheme found. Server offered: {schemes}; "
-            f"client supports: [{_SUPPORTED_SCHEME!r}]"
-        )
-
-    try:
-        return PaymentDetails(
-            resource_url=chosen["resource"],
-            pay_to=chosen["payTo"],
-            amount=chosen["maxAmountRequired"],
-            currency=chosen.get("currency", "USDC"),
-            network=chosen["network"],
-            deadline_seconds=int(chosen.get("requiredDeadlineSeconds", 300)),
-            description=chosen.get("description", ""),
-            reason=chosen.get("reason", ""),
-            extra=chosen.get("extra", {}),
-        )
-    except KeyError:
-        raise X402PaymentError("Missing required field in X-PAYMENT entry") from None
-
-
-_USD_PEGGED = frozenset({"USDC", "USDT", "DAI", "USDCE", "USDBC"})
-
-
-def _amount_to_usd(amount: str, currency: str) -> float:
-    """Convert a payment amount string to USD.
-
-    Supports USD-pegged stablecoins only (USDC, USDT, DAI, USDCE, USDBC).
-    Non-stablecoin currencies raise :class:`X402PaymentError` because without a
-    price oracle the USD value cannot be determined, and silently understating it
-    would allow policy limits to be bypassed.
-    """
-    try:
-        value = float(amount)
-    except ValueError as exc:
-        raise X402PaymentError(f"Invalid payment amount {amount!r}: not a numeric value") from exc
-    if not math.isfinite(value) or value < 0:
-        raise X402PaymentError(
-            f"Invalid payment amount {amount!r}: must be a finite non-negative number. "
-            "Non-finite values (nan, inf, -inf) bypass IEEE 754 comparison-based limit checks "
-            "and are rejected to preserve policy enforcement integrity."
-        )
-    if currency.upper() not in _USD_PEGGED:
-        raise X402PaymentError(
-            f"Unsupported currency {currency!r} for policy enforcement. "
-            f"Supported stablecoins: {sorted(_USD_PEGGED)}. "
-            "For non-stablecoin payments configure a custom price oracle."
-        )
-    return value
+# ---------------------------------------------------------------------------
+# Back-compat aliases (pre-v0.5.0 module layout). New code should import from
+# presidio_x402.bindings.x402 and presidio_x402.core instead. Kept so that the
+# v0.4.0 import surface — including underscore names used in downstream test
+# suites — survives the binding-layer refactor unchanged. Removal would be a
+# breaking change (SEMVER.md); earliest at v1.0.0.
+# ---------------------------------------------------------------------------
+_HEADER_PAYMENT = HEADER_PAYMENT
+_SUPPORTED_SCHEME = SUPPORTED_SCHEME
+_PAYMENT_HEADER_MAX_BYTES = PAYMENT_HEADER_MAX_BYTES
+_SAFE_EXC_MESSAGE_MAX = SAFE_EXC_MESSAGE_MAX
+_parse_402_header = parse_402_header
+_amount_to_usd = amount_to_usd
+_safe_exc_message = safe_exc_message
+_resource_origin = resource_origin
 
 
 class HardenedX402Client:
@@ -269,6 +169,12 @@ class HardenedX402Client:
         Toggle for the remote PII path. ``False`` (default) runs the local
         :class:`PIIFilter`; ``True`` requires ``screening_client`` to be set
         and forwards payment metadata to the remote service.
+    binding:
+        The :class:`~presidio_x402._types.PaymentProtocolBinding` translating
+        the payment rail's wire format. Defaults to
+        :class:`~presidio_x402.bindings.x402.X402Binding` (HTTP 402 +
+        ``X-PAYMENT``). Supply a custom binding to reuse the screening core on
+        a different payment rail.
     """
 
     def __init__(
@@ -289,6 +195,7 @@ class HardenedX402Client:
         trusted_wallets: dict[str, set[str]] | None = None,
         screening_client: ScreeningClient | None = None,
         remote_screening: bool = False,
+        binding: PaymentProtocolBinding | None = None,
     ) -> None:
         if remote_screening and screening_client is None:
             raise ValueError("remote_screening=True requires a screening_client instance")
@@ -305,6 +212,7 @@ class HardenedX402Client:
         self._httpx = httpx_client or httpx.AsyncClient(timeout=30.0)
         self._mpa = mpa_engine
         self._metrics = metrics_collector
+        self._binding = binding or X402Binding()
         # Store allowlisted wallet addresses lower-cased: EVM addresses are
         # case-insensitive (EIP-55 checksum casing is optional), so comparing
         # verbatim would reject a valid checksummed/lower-case variant and cause
@@ -317,6 +225,22 @@ class HardenedX402Client:
             }
             if trusted_wallets is not None
             else None
+        )
+        # The rail-agnostic screening core shares the component instances above:
+        # the client keeps direct references for back-compat introspection while
+        # the pipeline owns the control-sequence logic.
+        self._pipeline = ScreeningPipeline(
+            pii_filter=self._pii_filter,
+            policy=self._policy,
+            replay=self._replay,
+            audit=self._audit,
+            pii_action=pii_action,
+            pii_entities=pii_entities,
+            mpa_engine=mpa_engine,
+            metrics_collector=metrics_collector,
+            trusted_wallets=self._trusted_wallets,
+            screening_client=screening_client,
+            remote_screening=remote_screening,
         )
         logger.info("Presidio hardening applied — HardenedX402Client initialized")
 
@@ -343,29 +267,35 @@ class HardenedX402Client:
         return await self._request(method, url, **kwargs)
 
     # ------------------------------------------------------------------
-    # Internal: request + 402 handling
+    # Internal: request + payment-required handling (rail via binding)
     # ------------------------------------------------------------------
 
     async def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
-        """Send *method* request to *url*; handle 402 with security controls."""
+        """Send *method* request to *url*; handle payment-required responses
+        with the screening pipeline and the configured rail binding."""
         # Extract MPA crypto-mode countersignatures if provided (not passed to httpx)
         mpa_signatures: dict[str, str] | None = kwargs.pop("mpa_signatures", None)
 
         resp = await self._httpx.request(method, url, **kwargs)
 
-        if resp.status_code != 402:
+        if resp.status_code != self._binding.payment_required_status:
             return resp
 
-        payment_header = resp.headers.get(_HEADER_PAYMENT)
-        if not payment_header:
-            logger.warning("402 response missing X-PAYMENT header from %s", url)
+        offer = self._binding.payment_offer(resp.status_code, resp.headers)  # type: ignore[arg-type]
+        if not offer:
+            logger.warning(
+                "%s response missing %s header from %s",
+                self._binding.payment_required_status,
+                self._binding.header_name,
+                url,
+            )
             return resp
 
         try:
-            details = _parse_402_header(payment_header)
+            details = self._binding.parse_payment_required(offer)
         except X402PaymentError as exc:
             safe_url, _ = self._pii_filter.scan_and_redact(url)
-            safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
+            safe_msg, _ = self._pii_filter.scan_and_redact(safe_exc_message(exc))
             self._audit.emit(
                 "PAYMENT_ERROR",
                 resource_url=safe_url,
@@ -376,7 +306,7 @@ class HardenedX402Client:
 
         # Apply security controls; get (possibly modified) details + the replay
         # fingerprint back so a signing failure can roll the commit back.
-        secure_details, fingerprint = await self._apply_security_controls(
+        secure_details, fingerprint = await self._pipeline.apply(
             details, mpa_signatures=mpa_signatures
         )
 
@@ -388,16 +318,16 @@ class HardenedX402Client:
             # failure means no payment was made, so release them (F-03) —
             # otherwise a hostile server inducing repeated signer failures could
             # drain the accounting budget and block legitimate retries.
-            self._rollback_commit(
+            self._pipeline.rollback(
                 resource_url=secure_details.resource_url,
-                amount_usd=_amount_to_usd(secure_details.amount, secure_details.currency),
+                amount_usd=amount_to_usd(secure_details.amount, secure_details.currency),
                 fingerprint=fingerprint,
             )
-            safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
+            safe_msg, _ = self._pii_filter.scan_and_redact(safe_exc_message(exc))
             self._audit.emit(
                 "PAYMENT_ERROR",
                 resource_url=secure_details.resource_url,
-                amount_usd=_amount_to_usd(secure_details.amount, secure_details.currency),
+                amount_usd=amount_to_usd(secure_details.amount, secure_details.currency),
                 network=secure_details.network,
                 outcome="blocked",
                 error_message=safe_msg,
@@ -410,13 +340,13 @@ class HardenedX402Client:
             # the audit record above.
             raise X402PaymentError("Payment signing failed") from None
 
-        # Retry request with payment token
+        # Retry request with payment token (header channel per binding)
         headers = dict(kwargs.pop("headers", {}) or {})
-        headers[_HEADER_PAYMENT] = payment_response.token
+        headers.update(self._binding.token_headers(payment_response.token))
         kwargs["headers"] = headers
         resp = await self._httpx.request(method, url, **kwargs)
 
-        paid_usd = _amount_to_usd(secure_details.amount, secure_details.currency)
+        paid_usd = amount_to_usd(secure_details.amount, secure_details.currency)
         self._audit.emit(
             "PAYMENT_ALLOWED",
             resource_url=secure_details.resource_url,
@@ -427,251 +357,6 @@ class HardenedX402Client:
         if self._metrics:
             self._metrics.record_payment_allowed(paid_usd)
         return resp
-
-    def _rollback_commit(self, *, resource_url: str, amount_usd: float, fingerprint: str) -> None:
-        """Reverse the spend + replay fingerprint speculatively committed in
-        :meth:`_apply_security_controls`.
-
-        The policy spend and replay fingerprint are recorded *before* the payment
-        is signed (so the TOCTOU-critical check+record stays atomic under a
-        single lock — a guarantee that cannot span the async signer ``await``).
-        When the payment is subsequently denied (MPA) or fails to sign, this
-        compensating rollback keeps the spend ledger consistent with payments
-        that actually committed and frees the fingerprint for a legitimate retry
-        (F-03, 2026-06-03).
-        """
-        self._policy.refund(resource_url=resource_url, amount_usd=amount_usd)
-        self._replay.release(fingerprint)
-
-    async def _apply_security_controls(
-        self,
-        details: PaymentDetails,
-        *,
-        mpa_signatures: dict[str, str] | None = None,
-    ) -> tuple[PaymentDetails, str]:
-        """Apply PIIFilter → PolicyEngine → ReplayGuard → MPAEngine → AuditLog.
-
-        Returns a ``(details, fingerprint)`` tuple: the (possibly modified)
-        :class:`~presidio_x402._types.PaymentDetails` with PII redacted from
-        metadata fields if ``pii_action="redact"``, plus the replay fingerprint
-        recorded for this payment so the caller can roll it back if signing
-        fails.
-
-        Raises on policy violation, replay, PII block, or MPA denial/timeout.
-        On MPA denial/timeout the spend + replay commit is rolled back before
-        re-raising.
-        """
-        amount_usd = _amount_to_usd(details.amount, details.currency)
-
-        # Preserve the original resource_url for replay-guard fingerprinting.
-        # In pii_action="redact" mode the URL gets rewritten with PII tokens
-        # masked; using the redacted URL for fingerprinting would collide
-        # distinct user-specific URLs (e.g. /user/alice@.../pay vs
-        # /user/bob@.../pay both reduce to /user/<EMAIL_ADDRESS>/pay) and
-        # produce false-positive ReplayDetectedError. Original URL is never
-        # passed downstream to signer / MPA — only used for the local HMAC.
-        original_resource_url = details.resource_url
-
-        # ------------------------------------------------------------------
-        # 1. PII Filter (local regex/NLP or remote screening service)
-        # ------------------------------------------------------------------
-        if self._remote_screening and self._screening_client is not None:
-            (
-                clean_url,
-                clean_desc,
-                clean_reason,
-                pii_entities,
-            ) = await self._screening_client.scan_payment_fields(
-                details.resource_url,
-                details.description,
-                details.reason,
-                entities=self._pii_entities,
-            )
-            # Defense-in-depth (F-06, 2026-06-03): the remote screener is the
-            # only scan of the three primary fields, so a mis-redacting, empty,
-            # or silently degraded response would pass PII through unredacted.
-            # Re-run the fast local regex filter over its output as a cheap
-            # backstop. On a correct remote response the fields are already
-            # masked, so this finds nothing; it only catches what the remote
-            # missed, and feeds those entities into the block/redact decision.
-            clean_url, url_ent = self._pii_filter.scan_and_redact(clean_url)
-            clean_desc, desc_ent = self._pii_filter.scan_and_redact(clean_desc)
-            clean_reason, reason_ent = self._pii_filter.scan_and_redact(clean_reason)
-            pii_entities = list(pii_entities) + url_ent + desc_ent + reason_ent
-        else:
-            clean_url, clean_desc, clean_reason, pii_entities = (
-                self._pii_filter.scan_payment_fields(
-                    details.resource_url, details.description, details.reason
-                )
-            )
-
-        # The remote screening API only covers the three primary string fields.
-        # The `extra` dict is arbitrary server-controlled JSON and must be
-        # scanned locally for defense-in-depth — this closes REQ-1 against
-        # malicious 402 servers that smuggle PII through the extra channel.
-        clean_extra, extra_entities = self._pii_filter.scan_dict(details.extra)
-        if extra_entities:
-            pii_entities = list(pii_entities) + list(extra_entities)
-
-        if pii_entities:
-            entity_types = [e.entity_type for e in pii_entities]
-            if self._pii_action == "block":
-                self._audit.emit(
-                    "PII_BLOCKED",
-                    resource_url=clean_url,
-                    amount_usd=amount_usd,
-                    network=details.network,
-                    outcome="blocked",
-                    pii_entities_found=entity_types,
-                )
-                if self._metrics:
-                    self._metrics.record_pii_detection(entity_types, "block")
-                    self._metrics.record_payment_blocked("pii", amount_usd)
-                raise PIIBlockedError(
-                    f"PII detected in payment metadata: {', '.join(sorted(set(entity_types)))}",
-                    entities=entity_types,
-                )
-            elif self._pii_action == "redact":
-                self._audit.emit(
-                    "PII_REDACTED",
-                    resource_url=clean_url,
-                    amount_usd=amount_usd,
-                    network=details.network,
-                    outcome="allowed",
-                    pii_entities_found=entity_types,
-                )
-                if self._metrics:
-                    self._metrics.record_pii_detection(entity_types, "redact")
-                # Replace metadata fields with redacted versions.
-                # resource_url is replaced AFTER replay-fingerprint computation
-                # earlier in this function so the original URL still drives
-                # deduplication; from this point on every downstream consumer
-                # (signer, MPA webhooks, audit log post-event) sees clean_url.
-                # The `extra` dict is also redacted in-place when PII is found
-                # in any of its string values (REQ-1 — closes F-A 2026-05-03).
-                details = replace(
-                    details,
-                    resource_url=clean_url,
-                    description=clean_desc,
-                    reason=clean_reason,
-                    extra=clean_extra if extra_entities else details.extra,
-                )
-            elif self._metrics:
-                # pii_action == "warn": log already happened in PIIFilter
-                self._metrics.record_pii_detection(entity_types, "warn")
-
-        # ------------------------------------------------------------------
-        # 2. Trusted-wallet allowlist (pay_to substitution defence)
-        # ------------------------------------------------------------------
-        if self._trusted_wallets is not None:
-            # Key the allowlist off the ORIGINAL (pre-redaction) origin. PII
-            # redaction can rewrite the host (IP literals via IP_ADDRESS,
-            # digit-laden DNS labels via US_SSN/PHONE_NUMBER), which would shift
-            # the origin string out of the allowlist, miss the lookup, and
-            # silently skip the pay_to check entirely. The host is a
-            # security-control key, not PII — this mirrors the replay
-            # fingerprint, which also keys off original_resource_url below
-            # (CWE-348 / F-02, 2026-06-03).
-            origin = _resource_origin(original_resource_url)
-            allowed = self._trusted_wallets.get(origin)
-            if allowed is not None and details.pay_to.lower() not in allowed:
-                # The raw origin may contain a redactable host; keep it out of
-                # the persisted audit message and surface only the redacted URL.
-                self._audit.emit(
-                    "WALLET_BLOCKED",
-                    resource_url=clean_url,
-                    amount_usd=amount_usd,
-                    network=details.network,
-                    outcome="blocked",
-                    error_message=f"pay_to {details.pay_to!r} not in trusted wallet allowlist",
-                )
-                if self._metrics:
-                    self._metrics.record_payment_blocked("wallet", amount_usd)
-                raise X402PaymentError(
-                    f"pay_to wallet {details.pay_to!r} not in trusted allowlist"
-                )
-
-        # ------------------------------------------------------------------
-        # 3. Policy Engine
-        # ------------------------------------------------------------------
-        try:
-            self._policy.check_and_record(resource_url=details.resource_url, amount_usd=amount_usd)
-        except PolicyViolationError as exc:
-            self._audit.emit(
-                "POLICY_BLOCKED",
-                resource_url=clean_url,
-                amount_usd=amount_usd,
-                network=details.network,
-                outcome="blocked",
-                policy_limit_usd=exc.limit_usd,
-            )
-            if self._metrics:
-                self._metrics.record_policy_violation("limit_exceeded")
-                self._metrics.record_payment_blocked("policy", amount_usd)
-            raise
-
-        # ------------------------------------------------------------------
-        # 4. Replay Guard
-        # ------------------------------------------------------------------
-        fingerprint = compute_fingerprint(
-            resource_url=original_resource_url,  # ORIGINAL URL — see top of method
-            pay_to=details.pay_to,
-            amount=details.amount,
-            currency=details.currency,
-            deadline_seconds=details.deadline_seconds,
-        )
-        try:
-            self._replay.check_and_record(fingerprint)
-        except ReplayDetectedError:
-            self._audit.emit(
-                "REPLAY_BLOCKED",
-                resource_url=clean_url,
-                amount_usd=amount_usd,
-                network=details.network,
-                outcome="blocked",
-                replay_fingerprint=fingerprint[:16],
-            )
-            if self._metrics:
-                self._metrics.record_replay_detection()
-                self._metrics.record_payment_blocked("replay", amount_usd)
-            raise
-
-        # ------------------------------------------------------------------
-        # 5. Multi-Party Authorization (if configured)
-        # ------------------------------------------------------------------
-        if self._mpa is not None:
-            try:
-                await self._mpa.request_approval(
-                    details, amount_usd, provided_signatures=mpa_signatures
-                )
-                if self._metrics:
-                    self._metrics.record_mpa_event("approved")
-            except (MPADeniedError, MPATimeoutError) as exc:
-                # Roll back the spend + replay fingerprint committed at steps 3–4:
-                # an MPA-denied/timed-out payment was never signed, so it must not
-                # charge the budget or burn the fingerprint (which would block the
-                # legitimate crypto-mode retry that carries the countersignatures).
-                self._rollback_commit(
-                    resource_url=details.resource_url,
-                    amount_usd=amount_usd,
-                    fingerprint=fingerprint,
-                )
-                outcome = "timeout" if isinstance(exc, MPATimeoutError) else "denied"
-                safe_msg, _ = self._pii_filter.scan_and_redact(_safe_exc_message(exc))
-                self._audit.emit(
-                    "MPA_BLOCKED",
-                    resource_url=clean_url,
-                    amount_usd=amount_usd,
-                    network=details.network,
-                    outcome="blocked",
-                    error_message=safe_msg,
-                )
-                if self._metrics:
-                    self._metrics.record_mpa_event(outcome)
-                    self._metrics.record_payment_blocked(f"mpa_{outcome}", amount_usd)
-                raise
-
-        return details, fingerprint
 
     # ------------------------------------------------------------------
     # Context manager support

--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -342,6 +342,30 @@ class PIIFilter:
 
         return clean_url, clean_desc, clean_reason, all_entities
 
+    def scan_fields(self, fields: dict[str, str]) -> tuple[dict[str, str], list[EntityResult]]:
+        """Scan and redact an arbitrary mapping of named string fields.
+
+        Rail-agnostic generalisation of :meth:`scan_payment_fields` (v0.5.0
+        binding-layer refactor): bindings for rails whose metadata fields differ
+        from x402's ``(resource_url, description, reason)`` triple pass their
+        own field mapping. Returns ``(redacted_fields, all_entities)`` with the
+        same keys in the same order.
+        """
+        redacted: dict[str, str] = {}
+        all_entities: list[EntityResult] = []
+        for name, value in fields.items():
+            clean, entities = self.scan_and_redact(value)
+            redacted[name] = clean
+            all_entities.extend(entities)
+        if all_entities:
+            types = [e.entity_type for e in all_entities]
+            logger.warning(
+                "PII detected in payment metadata fields (%s): %s",
+                ", ".join(fields),
+                ", ".join(sorted(set(types))),
+            )
+        return redacted, all_entities
+
     def scan_dict(self, data: object) -> tuple[object, list[EntityResult]]:
         """Recursively scan and redact string values in arbitrary JSON-shaped data.
 

--- a/tests/test_bindings_core.py
+++ b/tests/test_bindings_core.py
@@ -1,0 +1,290 @@
+"""Tests for the v0.5.0 binding-layer refactor (session-3 T2).
+
+Proves the two architectural claims:
+1. Everything x402-specific lives in ``bindings.x402`` and satisfies the
+   ``PaymentProtocolBinding`` protocol.
+2. The screening core is rail-agnostic — a different rail (different status
+   code, different header, different offer format) reuses the full pipeline
+   unchanged, including redaction, policy, and replay guarantees.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from presidio_x402 import (
+    HardenedX402Client,
+    PaymentProtocolBinding,
+    ScreeningPipeline,
+    X402Binding,
+)
+from presidio_x402._types import PaymentDetails, PaymentResponse
+from presidio_x402.audit_log import AuditLog, NullAuditWriter
+from presidio_x402.exceptions import (
+    PolicyViolationError,
+    ReplayDetectedError,
+    X402PaymentError,
+)
+from presidio_x402.pii_filter import PIIFilter
+from presidio_x402.policy_engine import PolicyEngine
+from presidio_x402.replay_guard import ReplayGuard
+
+# ---------------------------------------------------------------------------
+# X402Binding
+# ---------------------------------------------------------------------------
+
+OFFER = json.dumps(
+    {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base-sepolia",
+                "maxAmountRequired": "0.01",
+                "resource": "https://api.example.com/v1/data",
+                "description": "API data access",
+                "payTo": "0xabcdef1234567890abcdef1234567890abcdef12",
+                "requiredDeadlineSeconds": 300,
+            }
+        ]
+    }
+)
+
+
+def test_x402_binding_satisfies_protocol():
+    assert isinstance(X402Binding(), PaymentProtocolBinding)
+
+
+def test_x402_binding_constants():
+    b = X402Binding()
+    assert b.name == "x402"
+    assert b.payment_required_status == 402
+    assert b.header_name == "X-PAYMENT"
+
+
+def test_payment_offer_extraction():
+    b = X402Binding()
+    assert b.payment_offer(200, {"X-PAYMENT": OFFER}) is None  # not payment-required
+    assert b.payment_offer(402, {}) is None  # missing header
+    assert b.payment_offer(402, {"X-PAYMENT": OFFER}) == OFFER
+
+
+def test_parse_payment_required_round_trip():
+    details = X402Binding().parse_payment_required(OFFER)
+    assert details.pay_to == "0xabcdef1234567890abcdef1234567890abcdef12"
+    assert details.amount == "0.01"
+    assert details.network == "base-sepolia"
+
+
+def test_parse_payment_required_fails_closed():
+    with pytest.raises(X402PaymentError):
+        X402Binding().parse_payment_required("not json")
+
+
+def test_token_headers():
+    assert X402Binding().token_headers("tok") == {"X-PAYMENT": "tok"}
+
+
+def test_back_compat_import_paths_survive_refactor():
+    """The pre-v0.5.0 gateway import surface still works (SEMVER.md)."""
+    from presidio_x402 import gateway
+
+    assert gateway._HEADER_PAYMENT == "X-PAYMENT"
+    assert gateway._SUPPORTED_SCHEME == "exact"
+    assert gateway._parse_402_header is not None
+    assert gateway._amount_to_usd("0.5", "USDC") == 0.5
+
+
+# ---------------------------------------------------------------------------
+# ScreeningPipeline standalone (no HTTP, no binding — rail-agnostic by construction)
+# ---------------------------------------------------------------------------
+
+
+def _details(**overrides) -> PaymentDetails:
+    base = {
+        "resource_url": "https://api.example.com/v1/data",
+        "pay_to": "0xabcdef1234567890abcdef1234567890abcdef12",
+        "amount": "0.01",
+        "currency": "USDC",
+        "network": "base-sepolia",
+        "deadline_seconds": 300,
+        "description": "",
+        "reason": "",
+    }
+    base.update(overrides)
+    return PaymentDetails(**base)
+
+
+def _pipeline(**overrides) -> ScreeningPipeline:
+    defaults = {
+        "pii_filter": PIIFilter(),
+        "policy": PolicyEngine(overrides.pop("policy_config", None)),
+        "replay": ReplayGuard(ttl=300),
+        "audit": AuditLog(NullAuditWriter()),
+    }
+    defaults.update(overrides)
+    return ScreeningPipeline(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_redacts_pii_without_any_rail():
+    pipeline = _pipeline()
+    details = _details(description="contact alice@example.com for access")
+    secure, fingerprint = await pipeline.apply(details)
+    assert "alice@example.com" not in secure.description
+    assert "<REDACTED>" in secure.description
+    assert len(fingerprint) == 64  # HMAC-SHA256 hex
+
+
+@pytest.mark.asyncio
+async def test_pipeline_policy_violation_blocks():
+    pipeline = _pipeline(policy_config={"max_per_call_usd": 0.001})
+    with pytest.raises(PolicyViolationError):
+        await pipeline.apply(_details())
+
+
+@pytest.mark.asyncio
+async def test_pipeline_replay_blocks_second_identical_payment():
+    pipeline = _pipeline()
+    await pipeline.apply(_details())
+    with pytest.raises(ReplayDetectedError):
+        await pipeline.apply(_details())
+
+
+@pytest.mark.asyncio
+async def test_pipeline_rollback_frees_budget_and_fingerprint():
+    pipeline = _pipeline(policy_config={"daily_limit_usd": 0.01})
+    secure, fingerprint = await pipeline.apply(_details())
+    pipeline.rollback(resource_url=secure.resource_url, amount_usd=0.01, fingerprint=fingerprint)
+    # After rollback the same payment passes again: budget refunded, slot freed.
+    await pipeline.apply(_details())
+
+
+# ---------------------------------------------------------------------------
+# Rail-agnosticism end-to-end: a non-x402 rail through the unchanged core
+# ---------------------------------------------------------------------------
+
+
+class FakeRailBinding:
+    """A hypothetical rail: HTTP 419 + ``X-FAKEPAY`` header, flat JSON offer."""
+
+    name = "fakerail"
+    payment_required_status = 419
+    header_name = "X-FAKEPAY"
+
+    def payment_offer(self, status_code: int, headers) -> str | None:
+        if status_code != self.payment_required_status:
+            return None
+        return headers.get(self.header_name)
+
+    def parse_payment_required(self, offer: str) -> PaymentDetails:
+        try:
+            data = json.loads(offer)
+            return PaymentDetails(
+                resource_url=data["url"],
+                pay_to=data["to"],
+                amount=data["amt"],
+                currency=data.get("ccy", "USDC"),
+                network=data.get("net", "fake-net"),
+                deadline_seconds=int(data.get("ttl", 300)),
+                description=data.get("desc", ""),
+            )
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            raise X402PaymentError("Invalid fakerail offer") from exc
+
+    def token_headers(self, token: str) -> dict[str, str]:
+        return {self.header_name: token}
+
+
+FAKE_OFFER = json.dumps(
+    {
+        "url": "https://api.fakerail.test/res",
+        "to": "0x1111111111111111111111111111111111111111",
+        "amt": "0.02",
+        "desc": "reach bob@example.com",
+    }
+)
+
+
+async def _mock_signer(details: PaymentDetails) -> PaymentResponse:
+    return PaymentResponse(token="fake-signed", details=details)  # noqa: S106
+
+
+def test_fake_rail_satisfies_protocol():
+    assert isinstance(FakeRailBinding(), PaymentProtocolBinding)
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_runs_on_a_different_rail():
+    """The complete client flow — detection, parsing, PII redaction, signing,
+    token retry — works on a rail that shares nothing with x402's wire format."""
+    signed_descriptions: list[str] = []
+
+    async def capturing_signer(details: PaymentDetails) -> PaymentResponse:
+        signed_descriptions.append(details.description)
+        return PaymentResponse(token="fake-signed", details=details)  # noqa: S106
+
+    captured_headers: dict[str, str] = {}
+
+    def _capture_retry(request: httpx.Request) -> httpx.Response:
+        captured_headers.update(dict(request.headers))
+        return httpx.Response(200, text="paid")
+
+    with respx.mock:
+        route = respx.get("https://api.fakerail.test/res")
+        route.side_effect = [
+            httpx.Response(419, headers={"X-FAKEPAY": FAKE_OFFER}),
+            _capture_retry,
+        ]
+        async with HardenedX402Client(
+            payment_signer=capturing_signer, binding=FakeRailBinding()
+        ) as client:
+            resp = await client.get("https://api.fakerail.test/res")
+
+    assert resp.status_code == 200
+    # The screening core ran unchanged: PII was redacted before signing.
+    assert signed_descriptions == ["reach <REDACTED>"]
+    # The token travelled on the fake rail's header, not X-PAYMENT.
+    assert captured_headers.get("x-fakepay") == "fake-signed"
+    assert "x-payment" not in {k.lower() for k in captured_headers}
+
+
+@pytest.mark.asyncio
+async def test_fake_rail_replay_blocked_like_x402():
+    """Replay protection is a core guarantee, independent of the rail."""
+    with respx.mock:
+        route = respx.get("https://api.fakerail.test/res")
+        route.side_effect = [
+            httpx.Response(419, headers={"X-FAKEPAY": FAKE_OFFER}),
+            httpx.Response(200, text="paid"),
+            httpx.Response(419, headers={"X-FAKEPAY": FAKE_OFFER}),
+        ]
+        async with HardenedX402Client(
+            payment_signer=_mock_signer, binding=FakeRailBinding()
+        ) as client:
+            await client.get("https://api.fakerail.test/res")
+            with pytest.raises(ReplayDetectedError):
+                await client.get("https://api.fakerail.test/res")
+
+
+# ---------------------------------------------------------------------------
+# PIIFilter.scan_fields (rail-agnostic field mapping)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_fields_arbitrary_mapping():
+    f = PIIFilter()
+    redacted, entities = f.scan_fields(
+        {"memo": "ssn 078-05-1120", "note": "clean", "ref": "call 030-1234567"}
+    )
+    assert list(redacted) == ["memo", "note", "ref"]
+    assert redacted["note"] == "clean"
+    assert "078-05-1120" not in redacted["memo"]
+    assert entities  # at least the SSN detected
+
+
+def test_scan_fields_empty_mapping():
+    assert PIIFilter().scan_fields({}) == ({}, [])

--- a/tests/test_conformance_suite.py
+++ b/tests/test_conformance_suite.py
@@ -1,0 +1,29 @@
+"""The partner conformance suite must pass against the development tree.
+
+This is the same suite OEM partners run via ``python -m presidio_x402.conformance``
+(SEMVER.md). Running it inside pytest keeps the runner itself covered and makes
+any conformance regression a test failure, not just a separate CI step.
+
+Note: the suite manages its own event loops (``asyncio.run`` per check), so this
+test is deliberately synchronous.
+"""
+
+from __future__ import annotations
+
+from presidio_x402.conformance import run_all
+from presidio_x402.conformance.runner import CHECKS, main
+
+
+def test_conformance_suite_passes():
+    assert run_all() == 0, "partner conformance suite reported failures"
+
+
+def test_conformance_suite_has_all_documented_checks():
+    # SEMVER.md and the package docstring promise 7 checks; keep them honest.
+    assert len(CHECKS) == 7
+    names = [name for name, _ in CHECKS]
+    assert len(set(names)) == len(names), "duplicate check names"
+
+
+def test_main_exit_contract():
+    assert main() == 0  # all green → exit code 0 (fail-closed: any failure → 1)

--- a/uv.lock
+++ b/uv.lock
@@ -2987,7 +2987,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- Rail-agnostic `ScreeningPipeline` core extracted verbatim from the gateway; everything x402-specific moved behind the `PaymentProtocolBinding` protocol (`bindings/x402`). Back-compat re-exports kept until v1.0.0.
- Partner conformance suite (`python -m presidio_x402.conformance`, 7 checks) wired into CI; SBOM (CycloneDX) job added; CDP/LangChain/CrewAI quickstarts + SEMVER.md.
- **BREAKING (crypto-mode MPA):** countersignatures are now freshness-bound (`<unix_ts>:<hmac_hex>`, default 300s window). Folds in the prior Unreleased MPA-freshness / sink-redaction / F1-F2 hardening. Also fixes `ComplianceReport` chain-key snapshot desync.

## Test plan
- [x] `ruff check` + `ruff format --check` clean on `src/`
- [x] Full pytest suite passes locally
- [x] Conformance suite 7/7 (`python -m presidio_x402.conformance`, reports lib 0.5.0)
- [ ] 5 required CI checks green (Py 3.10–3.13 + Lockfile drift)