### PR TITLE
ci: PyPI Trusted Publishing workflow (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+# Trusted Publisher (OIDC, no stored secrets) + PEP 740 attestations.
+# Triggered by a signed v* tag. The publish job runs in the `release`
+# environment, which carries a required-reviewer founder gate.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Check metadata
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write # OIDC token for PyPI Trusted Publishing + sigstore
+      attestations: write # PEP 740 provenance attestations
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` — PyPI Trusted Publishing via OIDC (no stored secrets), triggered by signed `v*` tags.
- Build job: sdist+wheel via `python -m build` + `twine check`. Publish job runs in the founder-gated `release` environment and uploads with PEP 740 attestations.
- Verbatim copy of the family-wide template (presidio-hardened-requests/fastapi/flask/opcua/crypto-channel/vuln-scanner, set up 2026-06-11).

## Test plan
- [x] Workflow byte-identical to the canonical sibling template
- [x] `release` environment created with founder (vstantch) required-reviewer gate
- [ ] CI green on this PR
- [ ] After merge: PyPI Trusted Publisher configured on pypi.org, then re-trigger `v0.5.0` tag to publish