### PR TITLE
feat: MiCA/EU evidence module (signed evidence-ref@1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-(nothing yet)
+### Added
+- **MiCA/EU evidence module** (`mica.py`, session-3 T3): emits Ed25519-signed
+  (or HMAC-SHA256) compliance-supporting evidence in the cross-repo
+  `presidio-hardened/evidence-ref@1` wire format over a verified audit window.
+  The obligation map is data with per-entry legal basis, verification status,
+  confidence, and deployment-flag conditions (MiCA Art. 68(8)/(9), DORA
+  Arts. 9/17, GDPR Art. 5(1)(c); opt-in MiCA Art. 92(1) PPAET input and DORA
+  Art. 9(4) MPA items). Honest-claims enforcement: attestations are emitted only
+  when the audit window evidences them; an explicit TFR Art. 14(4)
+  layer-separation record prevents redaction-vs-travel-rule overclaiming; AMLR
+  citations are absent until article-level verification (guarded by test).
+  Fail-closed throughout: broken audit chain, missing key, empty window, or
+  missing deployment flags refuse to sign. Research memo with per-claim
+  verification status: `docs/mica-obligations.md`. New optional extra
+  `[evidence]` (cryptography>=46.0.6); HMAC mode needs no extra. Public API:
+  `build_evidence`, `Obligation`, `OBLIGATION_MAP`, `EvidenceError`.
 
 ## [0.5.0] — 2026-06-12
 

--- a/docs/mica-obligations.md
+++ b/docs/mica-obligations.md
@@ -1,0 +1,51 @@
+# MiCA & adjacent EU obligations — research memo for the evidence module
+
+*Research date 2026-06-12 (web-verified against primary sources). This memo is the normative source for `presidio_x402/mica.py`'s `OBLIGATION_MAP`: do not change attestation wording or article citations in code without re-checking here, and do not change this memo without re-verifying against the cited sources. Verification tags: VERIFIED-PRIMARY = read on EUR-Lex or an official EU institution/authority page; VERIFIED-SECONDARY = reputable secondary source; UNVERIFIED = flagged, not citable in product claims.*
+
+## Framing rule (applies to every mapping)
+
+All obligations below are addressed to the **deployer** (CASP, PPAET, financial entity, data controller) — never to this library. Evidence records attest only what the middleware observed/did on traffic routed through it. No mapping supports a claim that the middleware "complies with" or "satisfies" any article.
+
+## 1. Timeline — the 1 July 2026 cliff
+
+MiCA applies from 30 December 2024 (Art. 149(2)); Titles III/IV (ARTs/EMTs) from 30 June 2024 (Art. 149(3)). Title V (CASPs) and Title VI (market abuse) therefore apply since 30 Dec 2024. **VERIFIED-PRIMARY** (ESMA Interactive Single Rulebook, Art. 149).
+
+Art. 143(3): CASPs operating lawfully before 30 Dec 2024 may continue **until 1 July 2026** or until authorisation is granted/refused, whichever is sooner; member states could shorten this. **VERIFIED-PRIMARY** (ESMA ISR, Art. 143). ESMA's statement of 17 April 2026 (ESMA75-113276571-1679): the transitional period "will officially expire across the EU on 1 July 2026"; after that, providing crypto-asset services to EU clients without a MiCA licence is a breach. **VERIFIED-PRIMARY.** Member-state variations per the official ESMA list: 6 months (LV, HU, NL, PL, SI, FI), 9 (SE), 12 (DE, IE, LT, AT, SK; EEA NO), 18/full (BG, CZ, DK, EE, GR, ES, FR, HR, IT, CY, LU, MT, RO). **VERIFIED-PRIMARY.** No amendment changing these dates was found — negative finding, **UNVERIFIED (absence-of-evidence)**; re-check before each release.
+
+Sales consequence: after 2026-07-01 the buyer profile is *authorised* CASPs (and PPAETs) needing evidence tooling — not grandfathered entities.
+
+## 2. CASP obligations the middleware can support
+
+- **Art. 68(9) record-keeping (strongest hook), VERIFIED-PRIMARY:** records of "all crypto-asset services, activities, orders, and transactions", sufficient for supervision, available to clients on request, kept 5 years (7 on request). Level 2: Delegated Regulation (EU) 2025/1140 specifies record content — existence VERIFIED-PRIMARY, **field-level content not yet read**: read before claiming record-content sufficiency (we deliberately claim "component of the record set" only).
+- **Art. 68(7)–(8) security, VERIFIED-PRIMARY:** delegated to DORA ("resilient and secure ICT systems as required by Regulation (EU) 2022/2554"; safeguard "availability, authenticity, integrity and confidentiality of data"). Map integrity attestations to DORA Art. 9(2) + MiCA Art. 68(8).
+- **Art. 70 safekeeping:** custody/segregation arrangements — at best a supporting-control narrative; **not mapped** (too weak).
+- **Art. 92(1) (Title VI), VERIFIED-PRIMARY:** "any person professionally arranging or executing transactions" (PPAET) must have arrangements to prevent/detect market abuse and report suspicions (STOR). Scope condition: assets admitted to trading (Art. 86(1)). Level 2: Delegated Regulation (EU) 2025/885 (VERIFIED-SECONDARY). Mapped as **opt-in, input-data claim only** (`ppaet` + `admitted_to_trading` flags); replay detection ≠ market-abuse detection.
+
+## 3. TFR (EU) 2023/1113 — the redaction tension
+
+All VERIFIED-PRIMARY (EUR-Lex CELEX 32023R1113). Applies since 30 Dec 2024 (Art. 40). Art. 14(1)–(2): originator/beneficiary name, DLT address, address/ID-number-or-DOB, LEI where available must accompany CASP transfers. Art. 14(8): the originator's CASP shall not allow initiation/execution before ensuring compliance. Art. 14(4): the information travels "in advance of, or simultaneously or concurrently with" the transfer and **need not be included in the transfer itself** (parallel secure messaging layer). Arts. 16(1)/17/19–22: beneficiary/intermediary CASP detection and missing-info procedures. Art. 26(1): 5-year retention.
+
+**Guardrails (encoded in the module):** (1) never claim redaction satisfies or supports TFR — stripping TFR-mandated fields from a CASP messaging flow would *cause* a breach; (2) the only TFR-adjacent attestation is layer separation: redaction applies to x402 payment metadata, which is not the travel-rule messaging channel (Art. 14(4)); (3) many x402 flows (self-hosted wallet → merchant, no CASP) are outside TFR entirely — no claim at all there.
+
+## 4. GDPR hook
+
+Art. 5(1)(c) data minimisation + Art. 5(2) accountability ("be able to demonstrate compliance") — the signed redaction record is demonstration material for the controller. **VERIFIED-SECONDARY** (faithful full-text mirror). Supporting: Arts. 25, 32 (not quoted; UNVERIFIED wording). Caveat: minimisation is purpose-relative — data required by TFR/AML is necessary by law (see §3).
+
+## 5. AML package — deferred
+
+AMLR (EU) 2024/1624 applies from **10 July 2027**; AMLD6 transposition by 10 July 2027; AMLA direct supervision from 2028. **VERIFIED-SECONDARY** (dates); **article-level CASP monitoring content UNVERIFIED** (only recitals retrieved from EUR-Lex). Consequence, enforced by test: `OBLIGATION_MAP` contains **no** AMLR citations until the OJ articles are verified. Revisit ahead of 2027-07-10 — screening evidence becomes more valuable then.
+
+## 6. DORA (EU) 2022/2554
+
+Applies to authorised CASPs as financial entities (Art. 2(1)(f)) since **17 January 2025**. **VERIFIED-PRIMARY.** (Whether a grandfathered, not-yet-authorised CASP is caught before authorisation is an UNVERIFIED supervisory-practice nuance.) Mapped articles: **Art. 9(2)** (availability/authenticity/integrity/confidentiality of data — the audit chain's integrity property), **Art. 9(4)(c)–(d)** (access control, strong authentication — MPA, opt-in flag `mpa_enabled`), **Art. 17(2)–(3)(b)** (record/track/log/categorise ICT incidents — blocked-event logging; Art. 17 text VERIFIED-SECONDARY). Related level 2 exists (DR 2024/1772, DR 2025/301, IR 2025/302) — not mapped.
+
+## Open items before any customer-facing use
+
+1. Read Delegated Regulation (EU) 2025/1140 field requirements (record content) — upgrade or annotate the Art. 68(9) mapping.
+2. Read Delegated Regulation (EU) 2025/885 before any PPAET-targeted sale.
+3. Re-verify "no amendment to MiCA dates" (negative finding) at each release.
+4. Verify AMLR article content against the OJ text before 2027 positioning.
+
+## Primary sources
+
+ESMA ISR MiCA Arts. 68, 70, 86, 92, 143, 149 (esma.europa.eu/publications-and-data/interactive-single-rulebook/mica/…); ESMA statement 2026-04-17 ESMA75-113276571-1679; ESMA grandfathering-periods list (Art. 143(3)); EUR-Lex CELEX 32023R1113 (TFR); EUR-Lex CELEX 32022R2554 (DORA) + ESMA DORA page; OJ L 2025/1140. Secondary: StreamLex (DORA Art. 17), gdpr-info.eu (GDPR Art. 5), CSSF/NautaDutilh (AML package dates), Regulation Tomorrow/Ganado (DR 2025/885).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ dependencies = [
 nlp = [
     "spacy>=3.7.0",
 ]
+evidence = [
+    # Ed25519 signing for the MiCA/EU evidence module (mica.py). Floor matches
+    # the _KNOWN_VULNERABLE minimum-safe version in __init__.py.
+    "cryptography>=46.0.6",
+]
 redis = [
     "redis>=5.0.0",
 ]

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -47,6 +47,7 @@ from .exceptions import (
 from .gateway import HardenedX402Client
 from .log_redaction import RedactingFilter, SecretRedactor, install_log_redaction
 from .metrics import MetricsCollector
+from .mica import OBLIGATION_MAP, EvidenceError, Obligation, build_evidence
 from .mpa import MPAApproverConfig, MPAConfig, MPAEngine, build_countersignature
 from .pii_filter import PIIFilter
 from .policy_engine import PolicyConfig, PolicyEngine
@@ -63,6 +64,11 @@ __all__ = [
     "ScreeningPipeline",
     "PaymentProtocolBinding",
     "X402Binding",
+    # MiCA/EU signed evidence (evidence-ref@1 wire format)
+    "build_evidence",
+    "Obligation",
+    "OBLIGATION_MAP",
+    "EvidenceError",
     # Multi-party authorization
     "MPAConfig",
     "MPAApproverConfig",

--- a/src/presidio_x402/mica.py
+++ b/src/presidio_x402/mica.py
@@ -1,0 +1,418 @@
+"""MiCA/EU evidence module — signed compliance-supporting evidence (session-3 T3).
+
+Maps what the screening middleware **actually does** (audit-chained payment
+records, integrity protection, security-event logging, PII redaction) to the EU
+obligations its *deployer* may need to demonstrate, and emits that mapping as
+Ed25519-signed evidence records in the cross-repo
+``presidio-hardened/evidence-ref@1`` wire format (the same format produced by
+presidio-hardened-ai and verified by presidio-hardened-ikigov-assess).
+
+Honest-claims doctrine (research memo: ``docs/mica-obligations.md``):
+
+- Every obligation cited is addressed to the **deployer** (CASP, PPAET,
+  financial entity, data controller) — never to this library. An evidence
+  record attests only what the middleware observed/did on traffic routed
+  through it; it is *supporting* material for the deployer's demonstration,
+  not a compliance claim.
+- The obligation map is **data**, not code: each entry carries its legal basis,
+  per-claim verification status, a confidence grade, and the conditions under
+  which it may be emitted. Entries below ``default_emit=True`` are the
+  conservative core; conditional entries require explicit deployment flags.
+- **TFR guardrail:** Regulation (EU) 2023/1113 *requires* originator/beneficiary
+  personal data to accompany CASP-handled transfers (Arts. 14(1)–(2), 14(8)).
+  PII redaction therefore must never be presented as TFR-supporting. The only
+  TFR-adjacent attestation this module emits is a *layer-separation* statement:
+  redaction was applied to x402 payment metadata, which is not the CASP
+  travel-rule messaging channel (Art. 14(4)).
+- AMLR (EU) 2024/1624 (applies 2027-07-10) mappings are deliberately absent:
+  article-level content was not primary-source-verified at authoring time.
+
+Wire format (must byte-match the family golden vector): detached signature =
+``alg(canonical_json({"content_hash": ..., "signer": ...}))`` where
+``canonical_json`` is ``json.dumps(sort_keys=True, separators=(",", ":"),
+ensure_ascii=False)`` and ``content_hash`` is SHA-256 over the canonical
+encoding of the attested content. Ed25519 needs the ``[evidence]`` extra
+(``pip install presidio-hardened-x402[evidence]``); HMAC-SHA256 works with the
+standard library.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmaclib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from .exceptions import X402Error
+
+if TYPE_CHECKING:
+    from .compliance_report import ComplianceReport
+
+EVIDENCE_SCHEMA_ID = "presidio-hardened/evidence-ref@1"
+DEFAULT_SIGNER = "presidio-hardened-x402"
+
+SIGNING_ALGORITHMS = ("ed25519", "hmac-sha256")
+
+
+class EvidenceError(X402Error):
+    """Raised on invalid evidence configuration or signing failure (fail-closed)."""
+
+
+# ---------------------------------------------------------------------------
+# Canonical encoding + signing (family wire format)
+# ---------------------------------------------------------------------------
+
+
+def canonical_bytes(payload: object) -> bytes:
+    """Deterministic canonical JSON — must byte-match every family producer."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def sha256_hex(payload: object) -> str:
+    return hashlib.sha256(canonical_bytes(payload)).hexdigest()
+
+
+def _require_crypto():
+    try:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise EvidenceError(
+            "Ed25519 evidence signing needs the optional extra: "
+            "pip install 'presidio-hardened-x402[evidence]'"
+        ) from exc
+    return ed25519
+
+
+def sign_evidence(
+    content_hash: str,
+    signer: str,
+    *,
+    algorithm: str = "ed25519",
+    key: str = "",
+) -> str:
+    """Detached signature over ``canonical({content_hash, signer})`` (hex).
+
+    ``key`` is the Ed25519 private key as 64 lowercase hex chars, or the HMAC
+    secret (UTF-8) for ``hmac-sha256``. Fail-closed: unknown algorithm or
+    missing/malformed key raises :class:`EvidenceError`.
+    """
+    if not key:
+        raise EvidenceError("evidence signing requires a key (fail-closed; no unsigned output)")
+    message = canonical_bytes({"content_hash": content_hash, "signer": signer})
+    if algorithm == "ed25519":
+        ed25519 = _require_crypto()
+        try:
+            sk = ed25519.Ed25519PrivateKey.from_private_bytes(bytes.fromhex(key))
+        except ValueError as exc:
+            raise EvidenceError("Ed25519 private key must be 64 lowercase hex chars") from exc
+        return sk.sign(message).hex()
+    if algorithm == "hmac-sha256":
+        return hmaclib.new(key.encode("utf-8"), message, hashlib.sha256).hexdigest()
+    raise EvidenceError(f"unknown signing algorithm {algorithm!r} (use ed25519 | hmac-sha256)")
+
+
+# ---------------------------------------------------------------------------
+# Obligation map — DATA, founder-reviewable. Verification statuses refer to the
+# 2026-06-12 research memo (docs/mica-obligations.md); do not edit attestation
+# wording without re-checking the cited source.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Obligation:
+    item_id: str
+    regulation: str
+    article: str
+    attests: str
+    confidence: str  # "high" | "medium-high" | "medium" | "low-medium" | "low"
+    verification: str  # "VERIFIED-PRIMARY" | "VERIFIED-SECONDARY"
+    default_emit: bool
+    requires: tuple[str, ...] = field(default_factory=tuple)
+    """Deployment flags that must all be set for this item to be emitted."""
+
+    notes: str = ""
+
+
+OBLIGATION_MAP: tuple[Obligation, ...] = (
+    Obligation(
+        item_id="MICA-68-9-RECORDS",
+        regulation="Regulation (EU) 2023/1114 (MiCA)",
+        article="Art. 68(9); Delegated Regulation (EU) 2025/1140",
+        attests=(
+            "A tamper-evident, individually identifiable record of each payment "
+            "order/attempt processed through the middleware exists (timestamp, "
+            "decision, outcome), suitable as a component of a CASP's Art. 68(9) "
+            "record set for flows routed through the middleware."
+        ),
+        confidence="medium-high",
+        verification="VERIFIED-PRIMARY",
+        default_emit=True,
+        notes=(
+            "Component claim only — record-content sufficiency against RTS (EU) "
+            "2025/1140 field requirements is the deployer's assessment."
+        ),
+    ),
+    Obligation(
+        item_id="MICA-68-8-INTEGRITY",
+        regulation="Regulation (EU) 2023/1114 (MiCA) / Regulation (EU) 2022/2554 (DORA)",
+        article="MiCA Art. 68(8) 2nd subpara; DORA Art. 9(2)",
+        attests=(
+            "Audit log authenticity and integrity are cryptographically protected "
+            "(HMAC-chained records; tampering is detectable on verification)."
+        ),
+        confidence="medium",
+        verification="VERIFIED-PRIMARY",
+        default_emit=True,
+    ),
+    Obligation(
+        item_id="DORA-17-2-SECURITY-EVENTS",
+        regulation="Regulation (EU) 2022/2554 (DORA)",
+        article="Art. 17(2), 17(3)(b)",
+        attests=(
+            "Anomalous payment events (replay/duplicate detections, policy blocks, "
+            "PII blocks) were detected, logged and categorised, and are available "
+            "as inputs to the deployer's ICT incident-management process."
+        ),
+        confidence="medium",
+        verification="VERIFIED-SECONDARY",
+        default_emit=True,
+    ),
+    Obligation(
+        item_id="GDPR-5-1C-MINIMISATION",
+        regulation="Regulation (EU) 2016/679 (GDPR)",
+        article="Art. 5(1)(c) with Art. 5(2) accountability",
+        attests=(
+            "Payment metadata was scanned pre-signature; fields matching PII "
+            "patterns were redacted before transmission — demonstration material "
+            "for the controller's data-minimisation accountability."
+        ),
+        confidence="medium",
+        verification="VERIFIED-SECONDARY",
+        default_emit=True,
+        notes="Emitted only when redaction events are present in the audit window.",
+    ),
+    Obligation(
+        item_id="TFR-14-4-LAYER-SEPARATION",
+        regulation="Regulation (EU) 2023/1113 (TFR)",
+        article="Art. 14(4) (constraint context: Arts. 14(1)-(2), 14(8))",
+        attests=(
+            "PII redaction was applied exclusively to x402 payment metadata, which "
+            "is not the CASP-to-CASP travel-rule messaging channel (TFR Art. 14(4): "
+            "required information need not be included in the transfer itself). "
+            "This record makes no claim that redaction supports TFR compliance; "
+            "TFR-mandated originator/beneficiary data flows are the deployer's "
+            "responsibility on their own channel."
+        ),
+        confidence="high",
+        verification="VERIFIED-PRIMARY",
+        default_emit=True,
+        notes="Negative/clarifying attestation — exists to prevent overclaiming.",
+    ),
+    Obligation(
+        item_id="MICA-92-1-PPAET-INPUT",
+        regulation="Regulation (EU) 2023/1114 (MiCA)",
+        article="Art. 92(1) (scope: Art. 86(1)); Delegated Regulation (EU) 2025/885",
+        attests=(
+            "Orders flagged as duplicates/replays were blocked and recorded with "
+            "timestamps, providing input data the deployer (a person professionally "
+            "arranging or executing transactions) may use within its market-abuse "
+            "detection arrangements and STOR substantiation."
+        ),
+        confidence="low-medium",
+        verification="VERIFIED-PRIMARY",
+        default_emit=False,
+        requires=("ppaet", "admitted_to_trading"),
+        notes="Replay detection is not market-abuse detection; input claim only.",
+    ),
+    Obligation(
+        item_id="DORA-9-4-ACCESS-CONTROL",
+        regulation="Regulation (EU) 2022/2554 (DORA)",
+        article="Art. 9(4)(c)-(d)",
+        attests=(
+            "High-value payments required and received n-of-m approvals from "
+            "distinct authorised parties before signing (freshness-bound "
+            "countersignatures), as a technical access-control measure."
+        ),
+        confidence="low-medium",
+        verification="VERIFIED-PRIMARY",
+        default_emit=False,
+        requires=("mpa_enabled",),
+    ),
+)
+
+_OBLIGATIONS_BY_ID = {o.item_id: o for o in OBLIGATION_MAP}
+
+
+# ---------------------------------------------------------------------------
+# Evidence emission
+# ---------------------------------------------------------------------------
+
+_REDACTION_EVENTS = frozenset({"PII_REDACTED", "PII_BLOCKED"})
+_SECURITY_EVENTS = frozenset({"REPLAY_BLOCKED", "POLICY_BLOCKED", "PII_BLOCKED", "MPA_BLOCKED"})
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _audit_summary(report: ComplianceReport) -> dict[str, object]:
+    """Deterministic, PII-free summary of the audit window — the attested content."""
+    counts: dict[str, int] = {}
+    timestamps: list[str] = []
+    for ev in report.events:
+        counts[ev.event_type] = counts.get(ev.event_type, 0) + 1
+        timestamps.append(ev.timestamp.isoformat() if ev.timestamp else "")
+    return {
+        "event_counts": dict(sorted(counts.items())),
+        "n_events": len(report.events),
+        "chain_ok": bool(report.chain_ok),
+        "window_first": min(timestamps) if timestamps else "",
+        "window_last": max(timestamps) if timestamps else "",
+    }
+
+
+def applicable_obligations(
+    report: ComplianceReport,
+    *,
+    deployment_flags: frozenset[str] = frozenset(),
+    include: list[str] | None = None,
+) -> list[Obligation]:
+    """Select obligation items honestly supported by this audit window.
+
+    Default-emit items are included when their evidentiary precondition holds in
+    the data (e.g. GDPR minimisation only if redaction events exist). Conditional
+    items additionally need every flag in ``requires`` present in
+    ``deployment_flags`` — deployment facts the middleware cannot observe and the
+    deployer must assert. ``include`` restricts to an explicit subset of ids.
+    """
+    counts: dict[str, int] = {}
+    for ev in report.events:
+        counts[ev.event_type] = counts.get(ev.event_type, 0) + 1
+
+    if not counts:
+        # An empty window supports no attestation at all — even the record-keeping
+        # claim would be vacuous ("records of nothing exist").
+        return []
+
+    selected: list[Obligation] = []
+    for ob in OBLIGATION_MAP:
+        if include is not None and ob.item_id not in include:
+            continue
+        if ob.requires and not all(flag in deployment_flags for flag in ob.requires):
+            if include is not None:
+                raise EvidenceError(
+                    f"obligation {ob.item_id} requires deployment flags "
+                    f"{sorted(ob.requires)} (fail-closed: not emitted without them)"
+                )
+            continue
+        if not ob.requires and not ob.default_emit and include is None:
+            continue
+        # Data preconditions: never attest to behaviour the window doesn't show.
+        if ob.item_id in ("GDPR-5-1C-MINIMISATION", "TFR-14-4-LAYER-SEPARATION") and not any(
+            counts.get(e) for e in _REDACTION_EVENTS
+        ):
+            continue
+        if ob.item_id == "DORA-17-2-SECURITY-EVENTS" and not any(
+            counts.get(e) for e in _SECURITY_EVENTS
+        ):
+            continue
+        if ob.item_id == "MICA-92-1-PPAET-INPUT" and not counts.get("REPLAY_BLOCKED"):
+            continue
+        if ob.item_id == "DORA-9-4-ACCESS-CONTROL" and not (
+            counts.get("MPA_BLOCKED") or "mpa_enabled" in deployment_flags
+        ):
+            continue
+        selected.append(ob)
+    return selected
+
+
+def build_evidence(
+    report: ComplianceReport,
+    *,
+    signing_key: str,
+    algorithm: str = "ed25519",
+    signer: str = DEFAULT_SIGNER,
+    source_version: str | None = None,
+    use_case: str = "x402-payment-screening",
+    deployment_flags: frozenset[str] | set[str] = frozenset(),
+    include: list[str] | None = None,
+    ledger_ref: str | None = None,
+) -> dict[str, object]:
+    """Build a signed ``presidio-hardened/evidence-ref@1`` envelope.
+
+    One evidence ref per applicable obligation. All refs in one envelope share
+    the same attested content (the PII-free audit-window summary) and therefore
+    the same ``content_hash``; what differs is the obligation (``item_id``) the
+    deployer cites it under. The full obligation text travels alongside in
+    ``obligations`` so a human reviewer sees exactly what is — and is not —
+    being claimed.
+
+    Fail-closed: refuses to sign when the audit chain does not verify, when no
+    key is supplied, or when an explicitly requested obligation lacks its
+    deployment flags.
+    """
+    from . import __version__
+
+    if not report.chain_ok:
+        raise EvidenceError(
+            "audit chain failed verification — refusing to sign evidence over a "
+            f"non-verifying window (fail-closed): {report.chain_warnings}"
+        )
+
+    flags = frozenset(deployment_flags)
+    obligations = applicable_obligations(report, deployment_flags=flags, include=include)
+    if not obligations:
+        raise EvidenceError("no obligation is honestly supported by this audit window")
+
+    content = _audit_summary(report)
+    content_hash = sha256_hex(content)
+    signature = sign_evidence(content_hash, signer, algorithm=algorithm, key=signing_key)
+    version = source_version or __version__
+    claimed_at = _utcnow_iso()
+    ref_ledger = ledger_ref or f"x402-audit:chain/{content['n_events']}"
+
+    refs = [
+        {
+            "item_id": ob.item_id,
+            "source": signer,
+            "source_version": version,
+            "ledger_ref": ref_ledger,
+            "content_hash": content_hash,
+            "signer": signer,
+            "signature": signature,
+            "claimed_at": claimed_at,
+        }
+        for ob in obligations
+    ]
+    return {
+        "schema": EVIDENCE_SCHEMA_ID,
+        "use_case": use_case,
+        "source": signer,
+        "source_version": version,
+        "generated_at": claimed_at,
+        "evidence": refs,
+        # Non-contract companion data (ignored by evidence-ref@1 verifiers):
+        "attested_content": content,
+        "signing_algorithm": algorithm,
+        "obligations": [
+            {
+                "item_id": ob.item_id,
+                "regulation": ob.regulation,
+                "article": ob.article,
+                "attests": ob.attests,
+                "confidence": ob.confidence,
+                "verification": ob.verification,
+                "notes": ob.notes,
+            }
+            for ob in obligations
+        ],
+        "disclaimer": (
+            "Supporting evidence only. Obligations cited are addressed to the "
+            "deploying entity; this record attests solely to middleware-observed "
+            "behaviour on traffic routed through it and makes no compliance claim."
+        ),
+    }

--- a/src/presidio_x402/mica.py
+++ b/src/presidio_x402/mica.py
@@ -244,8 +244,6 @@ OBLIGATION_MAP: tuple[Obligation, ...] = (
     ),
 )
 
-_OBLIGATIONS_BY_ID = {o.item_id: o for o in OBLIGATION_MAP}
-
 
 # ---------------------------------------------------------------------------
 # Evidence emission

--- a/tests/test_mica.py
+++ b/tests/test_mica.py
@@ -1,0 +1,233 @@
+"""Tests for the MiCA/EU evidence module (session-3 T3).
+
+Covers: the cross-repo evidence-ref@1 wire format (golden vector byte-identical
+to presidio-hardened-ai / ikigov-assess), honest-claims selection logic
+(obligations only emitted when the audit window supports them and deployment
+flags assert what the middleware cannot observe), and fail-closed behaviour.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from presidio_x402._types import AuditEvent
+from presidio_x402.compliance_report import ComplianceReport
+from presidio_x402.mica import (
+    OBLIGATION_MAP,
+    EvidenceError,
+    applicable_obligations,
+    build_evidence,
+    canonical_bytes,
+    sha256_hex,
+    sign_evidence,
+)
+
+# ---------------------------------------------------------------------------
+# Cross-repo golden vector — pins the wire format. Byte-identical to the
+# vectors committed in presidio-hardened-ai tests/test_ed25519.py and
+# ikigov-assess tests/test_evidence.py. Do not change within evidence-ref@1.
+# ---------------------------------------------------------------------------
+
+GOLD_PRIV = "01" * 32
+GOLD_PUB = "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+GOLD_CH = "abc123def456"
+GOLD_SIGNER = "presidio-hardened-ai"
+GOLD_SIG = (
+    "a0dc8599958734457f194ebce15c60ec097754b59897ab5dc758f73abadafe36"
+    "97874049d9f7736de4e3a9cc28b2fb4d76b15d8bce7fa0b26c8434bebbba590a"
+)
+GOLD_HMAC_KEY = "shared-key"
+GOLD_HMAC_SIG = "2e7af6d2882dd53847dcf3032e1fe36e58c5a879c224ea97b505b3e3b626b87a"
+
+
+def test_golden_vector_ed25519_byte_identical():
+    assert sign_evidence(GOLD_CH, GOLD_SIGNER, algorithm="ed25519", key=GOLD_PRIV) == GOLD_SIG
+
+
+def test_golden_vector_hmac_byte_identical():
+    sig = sign_evidence(GOLD_CH, GOLD_SIGNER, algorithm="hmac-sha256", key=GOLD_HMAC_KEY)
+    assert sig == GOLD_HMAC_SIG
+
+
+def test_canonical_profile_matches_family():
+    payload = {"b": "2", "a": "1", "u": "ß"}
+    assert canonical_bytes(payload) == '{"a":"1","b":"2","u":"ß"}'.encode()
+
+
+def test_signing_fails_closed():
+    with pytest.raises(EvidenceError):
+        sign_evidence(GOLD_CH, GOLD_SIGNER, key="")  # no key
+    with pytest.raises(EvidenceError):
+        sign_evidence(GOLD_CH, GOLD_SIGNER, algorithm="rsa-pss", key=GOLD_PRIV)
+    with pytest.raises(EvidenceError):
+        sign_evidence(GOLD_CH, GOLD_SIGNER, algorithm="ed25519", key="zz" * 32)
+
+
+# ---------------------------------------------------------------------------
+# Audit-window fixtures
+# ---------------------------------------------------------------------------
+
+
+def _event(event_type: str, ts: str = "2026-06-12T10:00:00+00:00") -> AuditEvent:
+    return AuditEvent(
+        timestamp=datetime.fromisoformat(ts).astimezone(timezone.utc),
+        event_type=event_type,
+        resource_url="https://api.example.com/v1/data",
+        amount_usd=0.01,
+        network="base-sepolia",
+        agent_id="test-agent",
+        outcome="blocked" if event_type.endswith("BLOCKED") else "allowed",
+    )
+
+
+def _report(*event_types: str) -> ComplianceReport:
+    return ComplianceReport.from_events([_event(t) for t in event_types])
+
+
+FULL_WINDOW = (
+    "PAYMENT_ALLOWED",
+    "PII_REDACTED",
+    "REPLAY_BLOCKED",
+    "POLICY_BLOCKED",
+)
+
+
+# ---------------------------------------------------------------------------
+# Honest-claims selection
+# ---------------------------------------------------------------------------
+
+
+def test_default_selection_on_full_window():
+    ids = {o.item_id for o in applicable_obligations(_report(*FULL_WINDOW))}
+    assert ids == {
+        "MICA-68-9-RECORDS",
+        "MICA-68-8-INTEGRITY",
+        "DORA-17-2-SECURITY-EVENTS",
+        "GDPR-5-1C-MINIMISATION",
+        "TFR-14-4-LAYER-SEPARATION",
+    }
+
+
+def test_no_redaction_no_gdpr_and_no_tfr_claims():
+    ids = {o.item_id for o in applicable_obligations(_report("PAYMENT_ALLOWED"))}
+    assert "GDPR-5-1C-MINIMISATION" not in ids
+    assert "TFR-14-4-LAYER-SEPARATION" not in ids
+    assert "DORA-17-2-SECURITY-EVENTS" not in ids  # no security events either
+    assert "MICA-68-9-RECORDS" in ids  # records exist regardless
+
+
+def test_ppaet_item_needs_flags_and_replay_data():
+    report = _report(*FULL_WINDOW)
+    # Data present but flags absent → not emitted.
+    assert "MICA-92-1-PPAET-INPUT" not in {o.item_id for o in applicable_obligations(report)}
+    # Flags present and replay data present → emitted.
+    flagged = applicable_obligations(
+        report, deployment_flags=frozenset({"ppaet", "admitted_to_trading"})
+    )
+    assert "MICA-92-1-PPAET-INPUT" in {o.item_id for o in flagged}
+    # Flags present but NO replay data → still not emitted (honest-claims).
+    no_replay = applicable_obligations(
+        _report("PAYMENT_ALLOWED", "PII_REDACTED"),
+        deployment_flags=frozenset({"ppaet", "admitted_to_trading"}),
+    )
+    assert "MICA-92-1-PPAET-INPUT" not in {o.item_id for o in no_replay}
+
+
+def test_explicit_include_without_flags_fails_closed():
+    with pytest.raises(EvidenceError):
+        applicable_obligations(_report(*FULL_WINDOW), include=["MICA-92-1-PPAET-INPUT"])
+
+
+def test_no_amlr_mappings_until_verified():
+    # AMLR (EU) 2024/1624 article content was UNVERIFIED at authoring time —
+    # the map must not cite it (docs/mica-obligations.md guardrail).
+    assert not any("2024/1624" in o.regulation for o in OBLIGATION_MAP)
+
+
+def test_obligation_map_hygiene():
+    ids = [o.item_id for o in OBLIGATION_MAP]
+    assert len(set(ids)) == len(ids)
+    for ob in OBLIGATION_MAP:
+        assert ob.verification in ("VERIFIED-PRIMARY", "VERIFIED-SECONDARY")
+        assert ob.attests and ob.article and ob.regulation
+        # The TFR entry must stay a negative/clarifying attestation.
+        if ob.item_id.startswith("TFR-"):
+            assert "no claim that redaction supports TFR compliance" in ob.attests
+
+
+# ---------------------------------------------------------------------------
+# Envelope building — evidence-ref@1 contract
+# ---------------------------------------------------------------------------
+
+CONTRACT_FIELDS = {
+    "item_id",
+    "source",
+    "source_version",
+    "ledger_ref",
+    "content_hash",
+    "signer",
+    "signature",
+    "claimed_at",
+}
+
+
+def test_envelope_matches_evidence_ref_contract():
+    env = build_evidence(_report(*FULL_WINDOW), signing_key=GOLD_PRIV)
+    assert env["schema"] == "presidio-hardened/evidence-ref@1"
+    assert env["evidence"], "envelope must contain refs"
+    for ref in env["evidence"]:
+        assert set(ref) == CONTRACT_FIELDS
+        for value in ref.values():
+            assert isinstance(value, str) and value and len(value) <= 512
+        assert ref["content_hash"] == sha256_hex(env["attested_content"])
+
+
+def test_envelope_signature_verifies_with_family_verifier():
+    """The emitted signature must verify under the exact consumer-side check
+    used by ikigov-assess (Ed25519 over canonical {content_hash, signer})."""
+    pytest.importorskip("cryptography")
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    env = build_evidence(_report(*FULL_WINDOW), signing_key=GOLD_PRIV)
+    ref = env["evidence"][0]
+    sk = ed25519.Ed25519PrivateKey.from_private_bytes(bytes.fromhex(GOLD_PRIV))
+    pk = sk.public_key()
+    message = canonical_bytes({"content_hash": ref["content_hash"], "signer": ref["signer"]})
+    pk.verify(bytes.fromhex(ref["signature"]), message)  # raises on failure
+
+
+def test_attested_content_is_pii_free_summary():
+    env = build_evidence(_report(*FULL_WINDOW), signing_key=GOLD_PRIV)
+    content = env["attested_content"]
+    assert set(content) == {"event_counts", "n_events", "chain_ok", "window_first", "window_last"}
+    assert content["n_events"] == len(FULL_WINDOW)
+    # No URLs, agent ids, or amounts — counts and window bounds only.
+    assert "resource_url" not in str(content)
+
+
+def test_envelope_carries_human_reviewable_obligations_and_disclaimer():
+    env = build_evidence(_report(*FULL_WINDOW), signing_key=GOLD_PRIV)
+    assert len(env["obligations"]) == len(env["evidence"])
+    assert "makes no compliance claim" in env["disclaimer"]
+    for ob in env["obligations"]:
+        assert ob["verification"] in ("VERIFIED-PRIMARY", "VERIFIED-SECONDARY")
+
+
+def test_build_evidence_fails_closed_on_broken_chain():
+    report = _report(*FULL_WINDOW)
+    report.chain_ok = False
+    with pytest.raises(EvidenceError):
+        build_evidence(report, signing_key=GOLD_PRIV)
+
+
+def test_build_evidence_fails_closed_on_empty_support():
+    with pytest.raises(EvidenceError):
+        build_evidence(ComplianceReport.from_events([]), signing_key=GOLD_PRIV)
+
+
+def test_hmac_mode_works_without_crypto_extra():
+    env = build_evidence(_report(*FULL_WINDOW), signing_key="shared-key", algorithm="hmac-sha256")
+    assert env["signing_algorithm"] == "hmac-sha256"
+    assert all(len(ref["signature"]) == 64 for ref in env["evidence"])  # HMAC-SHA256 hex

--- a/uv.lock
+++ b/uv.lock
@@ -3011,6 +3011,9 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
 ]
+evidence = [
+    { name = "cryptography" },
+]
 langchain = [
     { name = "langchain-core" },
 ]
@@ -3031,6 +3034,7 @@ schema = [
 requires-dist = [
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.28.0" },
     { name = "cryptography", specifier = ">=46.0.6" },
+    { name = "cryptography", marker = "extra == 'evidence'", specifier = ">=46.0.6" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.23" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "idna", specifier = ">=3.15" },
@@ -3049,7 +3053,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7.0" },
 ]
-provides-extras = ["nlp", "redis", "langchain", "crewai", "prometheus", "schema", "dev"]
+provides-extras = ["nlp", "evidence", "redis", "langchain", "crewai", "prometheus", "schema", "dev"]
 
 [[package]]
 name = "prometheus-client"


### PR DESCRIPTION
## Summary
- New `mica.py` module (session-3 T3): emits Ed25519-signed (or HMAC-SHA256) compliance-supporting evidence in the cross-repo `presidio-hardened/evidence-ref@1` wire format over a verified audit window.
- Obligation map as data with per-entry legal basis + verification status (MiCA 68(8)/(9), DORA 9/17, GDPR 5(1)(c); opt-in MiCA 92(1) PPAET + DORA 9(4) MPA). Honest-claims enforcement; fail-closed on broken chain / missing key / empty window / missing flags.
- New optional `[evidence]` extra (`cryptography>=46.0.6`); HMAC mode needs no extra. Public API: `build_evidence`, `Obligation`, `OBLIGATION_MAP`, `EvidenceError`.

Purely additive (semver minor). No existing behaviour changed.

## Test plan
- [x] `ruff check` + `ruff format --check` clean on `src/`
- [x] `tests/test_mica.py` passes (17 tests); full suite 360 passed / 2 skipped / 0 failed
- [x] Conformance suite 7/7
- [x] Cross-repo golden vector / ikigov consumer check (per commit)
- [ ] 5 required CI checks green