### PR TITLE
security(deps): pin urllib3>=2.7.0 and pyjwt>=2.13.0 (audit 2026-06-14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ dependencies = [
     # floor is defense-in-depth so a fresh resolve cannot regress below the fix.
     # Family audit rec R3 (Grok 4.3, 2026-06-06); audit 2026-06-07.
     "idna>=3.15",
+    # Transitive of presidio-analyzer (-> requests -> urllib3); pin minimum to
+    # evict PYSEC-2026-141 and PYSEC-2026-142 (urllib3 < 2.7.0 vulnerable).
+    # Explicit floor is defense-in-depth so a fresh resolve cannot regress below
+    # the fix; requests allows urllib3<3,>=1.26 so 2.7.0 resolves cleanly against
+    # httpx>=0.27.0. Audit 2026-06-14 (F1).
+    "urllib3>=2.7.0",
 ]
 
 [project.optional-dependencies]
@@ -64,6 +70,11 @@ langchain = [
 ]
 crewai = [
     "crewai>=0.28.0",
+    # crewai pulls pyjwt (pyjwt<3,>=2.9.0). Pin minimum to 2.13.0 to evict 5 CVEs
+    # in 2.7.0 (PYSEC-2026-120 crit-header bypass, PYSEC-2025-183, PYSEC-2026-175,
+    # PYSEC-2026-177, PYSEC-2026-179). 2.13.0 satisfies crewai's <3 cap. Audit
+    # 2026-06-14 (F2).
+    "pyjwt>=2.13.0",
 ]
 prometheus = [
     "prometheus-client>=0.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2995,11 +2995,13 @@ dependencies = [
     { name = "idna" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
+    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
 crewai = [
     { name = "crewai" },
+    { name = "pyjwt" },
 ]
 dev = [
     { name = "fakeredis" },
@@ -3045,6 +3047,7 @@ requires-dist = [
     { name = "presidio-anonymizer", specifier = ">=2.2.0" },
     { name = "prometheus-client", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "prometheus-client", marker = "extra == 'prometheus'", specifier = ">=0.20.0" },
+    { name = "pyjwt", marker = "extra == 'crewai'", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -3052,6 +3055,7 @@ requires-dist = [
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["nlp", "evidence", "redis", "langchain", "crewai", "prometheus", "schema", "dev"]
 
@@ -3558,14 +3562,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Closes the two transitive dependency-CVE findings from Felix's weekly audit (2026-06-14). Both are the established defense-in-depth floor-pin pattern (cf. `idna>=3.15`, `cryptography>=46.0.6`).

- **F1 (MEDIUM):** `urllib3` 2.6.3 carries PYSEC-2026-141/142 (fix 2.7.0), transitive via `presidio-analyzer → requests → urllib3`. Added `urllib3>=2.7.0` to `dependencies`. `requests` allows `urllib3<3,>=1.26`, so it resolves cleanly.
- **F2 (LOW):** `pyjwt` enters **only** via the `[crewai]` extra (`crewai → pyjwt<3,>=2.9.0`); could resolve to 2.7.0 (5 CVEs incl. PYSEC-2026-120 crit-header bypass). Added `pyjwt>=2.13.0` to `[crewai]` (satisfies the `<3` cap).

`uv.lock` regenerated: `urllib3==2.7.0`, `pyjwt 2.12.1→2.13.0`.

These floors are independent of the MiCA/multi-tenant v0.6.0 work, so they merge ahead; they ride the v0.6.0 release.

## Test plan
- [x] `ruff check` + `ruff format --check` clean on `src/`
- [x] Full suite: 360 passed / 2 skipped / 0 failed
- [x] `uv lock --check` in sync (Lockfile-drift gate)
- [ ] 5 required CI checks green