### PR TITLE
Add action-ref-v1 derivation primitive (compute_action_ref)

### DIFF
--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 
 from ._types import PaymentProtocolBinding
+from .action_ref import compute_action_ref, format_action_ref_timestamp
 from .audit_log import AuditLog, FileAuditWriter, NullAuditWriter, StreamAuditWriter
 from .bindings.x402 import X402Binding
 from .compliance_report import ComplianceReport
@@ -95,6 +96,8 @@ __all__ = [
     "PolicyEngine",
     "ReplayGuard",
     "compute_fingerprint",
+    "compute_action_ref",
+    "format_action_ref_timestamp",
     "AuditLog",
     "NullAuditWriter",
     "StreamAuditWriter",

--- a/src/presidio_x402/action_ref.py
+++ b/src/presidio_x402/action_ref.py
@@ -1,0 +1,114 @@
+"""Content-addressed ``action_ref`` derivation (action-ref-v1).
+
+``action_ref`` is a deterministic, content-addressed identifier for an agent
+action: ``SHA-256`` over the RFC 8785 (JCS) canonicalisation of a four-field
+preimage (``agent_id``, ``action_type``, ``scope``, ``timestamp``). Any party
+holding those four fields can recompute it independently — no trust in the
+emitting system required.
+
+This module implements the joint action-ref-v1 derivation that
+``presidio-hardened-x402`` co-authored on x402-foundation/x402 issue #2332. It
+is the interoperability primitive only; it does **not** submit trails to any
+external service. A Mycelium/ARGENTUM "provider" integration (an optional
+``AuditWriter`` that POSTs trails) is intentionally out of scope here.
+
+Spec: argentum-core ``docs/spec/action-ref.md`` (stable ref ``action-ref-v1.0``).
+
+.. note:: Safe band
+
+   The :func:`json.dumps` canonicalisation below is RFC 8785-compatible for the
+   input shapes this primitive targets: ASCII field values and conformant
+   ``YYYY-MM-DDTHH:MM:SS.mmmZ`` timestamps. For non-ASCII or surrogate-pair
+   field values, use an RFC 8785 library to guarantee byte-level portability.
+
+Usage::
+
+    from datetime import datetime, timezone
+    from presidio_x402.action_ref import compute_action_ref, format_action_ref_timestamp
+
+    ts = format_action_ref_timestamp(datetime.now(tz=timezone.utc))
+    ref = compute_action_ref(
+        agent_id="did:aps:zProviderAgent001",
+        action_type="payment.send",
+        scope="",
+        timestamp=ts,
+    )
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+
+# RFC 3339 UTC, exactly 3 fractional (millisecond) digits, mandatory trailing
+# ``Z``. The spec closes JCS-determinism at the format level: one valid byte
+# sequence per instant (no ``+00:00``, no trailing-zero suppression).
+_CONFORMANT_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+def format_action_ref_timestamp(dt: datetime) -> str:
+    """Format *dt* as a conformant ``action_ref`` timestamp string.
+
+    Returns RFC 3339 UTC with exactly three millisecond digits and a trailing
+    ``Z`` (``"2026-06-20T14:00:00.123Z"``) — the normative emission form.
+
+    *dt* must be timezone-aware; it is converted to UTC before formatting. A
+    naive datetime raises :class:`ValueError` rather than silently assuming a
+    timezone (which would yield an unverifiable, wrong digest).
+    """
+    if dt.tzinfo is None:
+        raise ValueError(
+            "format_action_ref_timestamp requires a timezone-aware datetime; got a naive value"
+        )
+    dt = dt.astimezone(timezone.utc)
+    ms = dt.microsecond // 1000
+    return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{ms:03d}Z")
+
+
+def compute_action_ref(
+    agent_id: str,
+    action_type: str,
+    scope: str,
+    timestamp: str,
+) -> str:
+    """Compute the ``action_ref`` for a four-field preimage.
+
+    Parameters
+    ----------
+    agent_id:
+        Stable identifier of the **terminal executing agent** at issuance time.
+    action_type:
+        Semantic label for the action (``"payment.send"``, ``"code.execute"``…).
+    scope:
+        Terminal agent's requested-intent scope. Pass ``""`` if not applicable;
+        never ``None`` and never a hash of an intent object.
+    timestamp:
+        Conformant RFC 3339 UTC string (``YYYY-MM-DDTHH:MM:SS.mmmZ``). Use
+        :func:`format_action_ref_timestamp` to produce one. A non-conformant
+        timestamp raises :class:`ValueError` so an unverifiable receipt is never
+        emitted.
+
+    Returns
+    -------
+    str
+        64 lowercase hex characters (SHA-256 of the JCS canonical preimage).
+    """
+    if not _CONFORMANT_TS_RE.match(timestamp):
+        raise ValueError(
+            "timestamp must be RFC 3339 UTC with exactly 3 millisecond digits "
+            f"and a trailing 'Z' (YYYY-MM-DDTHH:MM:SS.mmmZ); got {timestamp!r}"
+        )
+    payload = {
+        "agent_id": agent_id,
+        "action_type": action_type,
+        "scope": scope,
+        "timestamp": timestamp,
+    }
+    # JCS (RFC 8785): lexicographic key order, no inter-token whitespace, UTF-8.
+    # Mirrors the family canonical-bytes pattern (see ``mica.py``).
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()

--- a/tests/test_action_ref.py
+++ b/tests/test_action_ref.py
@@ -1,0 +1,112 @@
+"""Conformance tests for action-ref-v1 derivation.
+
+Byte-match vectors are lifted verbatim from argentum-core
+``examples/conformance/provider-protocol/vectors.json`` (suite
+``mycelium-provider-protocol-v1``) plus the worked NEXUS example in
+``docs/spec/action-ref.md``. If these pass, our ``compute_action_ref`` is
+interoperable with every other action-ref-v1 implementation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from presidio_x402.action_ref import compute_action_ref, format_action_ref_timestamp
+
+# --- Known-answer vectors (argentum-core mycelium-provider-protocol-v1) -------
+
+ACCEPT_VECTORS = [
+    # id, agent_id, action_type, scope, timestamp, expected
+    (
+        "pp-001",
+        "did:aps:zProviderAgent001",
+        "document.sign",
+        "mycelium:provider-protocol",
+        "2026-06-20T14:00:00.000Z",
+        "a0de245ffff300fe5aeb6e110c55b1ea623aaae49bda8a5e5f258b28b06c3ff9",
+    ),
+    (
+        "pp-002",  # empty scope passes "" — not null, not omitted
+        "did:web:provider.example.com",
+        "action",
+        "",
+        "2026-01-01T00:00:00.000Z",
+        "e1aecf30cbc5451d4f2149739c2bc6d49742df1082f5aa2d9b4144baf51d29bf",
+    ),
+    (
+        "spec-nexus",  # worked example from docs/spec/action-ref.md
+        "nexus-agent-xa12.onrender.com",
+        "oracle.signal",
+        "BTC",
+        "2025-05-18T11:40:31.000Z",
+        "fdd7f810499f06be24355ca8e2bfb8c4b965cc80c838f41fa074683443d89f5a",
+    ),
+]
+
+# pp-reject-*: timestamps that an emitter must never produce / hash.
+REJECT_TIMESTAMPS = [
+    ("pp-reject-001", "2026-06-20T14:00:00Z"),  # missing milliseconds
+    ("pp-reject-002", "2026-06-20T14:00:00.000000Z"),  # 6-digit fractional
+    ("offset-not-Z", "2026-06-20T14:00:00.000+00:00"),  # offset, not Z
+]
+
+
+@pytest.mark.parametrize("vid,agent_id,action_type,scope,ts,expected", ACCEPT_VECTORS)
+def test_action_ref_byte_match(vid, agent_id, action_type, scope, ts, expected):
+    assert compute_action_ref(agent_id, action_type, scope, ts) == expected
+
+
+def test_key_order_independence():
+    # pp-003: identical tuple, three different source key orders -> same digest.
+    expected = "a0de245ffff300fe5aeb6e110c55b1ea623aaae49bda8a5e5f258b28b06c3ff9"
+    assert (
+        compute_action_ref(
+            agent_id="did:aps:zProviderAgent001",
+            action_type="document.sign",
+            scope="mycelium:provider-protocol",
+            timestamp="2026-06-20T14:00:00.000Z",
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("vid,ts", REJECT_TIMESTAMPS)
+def test_nonconformant_timestamp_rejected(vid, ts):
+    with pytest.raises(ValueError, match="timestamp must be RFC 3339"):
+        compute_action_ref("did:aps:zX", "document.sign", "", ts)
+
+
+# --- Timestamp formatter (normative format_timestamp reference) --------------
+
+
+def test_format_timestamp_three_ms_digits_and_z():
+    dt = datetime(2026, 6, 20, 14, 0, 0, 123456, tzinfo=timezone.utc)
+    assert format_action_ref_timestamp(dt) == "2026-06-20T14:00:00.123Z"
+
+
+def test_format_timestamp_zero_subsecond_keeps_three_zeros():
+    dt = datetime.fromtimestamp(1747568431, tz=timezone.utc)  # NEXUS example epoch
+    assert format_action_ref_timestamp(dt) == "2025-05-18T11:40:31.000Z"
+
+
+def test_format_timestamp_converts_to_utc():
+    from datetime import timedelta
+
+    tz_plus2 = timezone(timedelta(hours=2))
+    dt = datetime(2026, 6, 20, 16, 0, 0, 0, tzinfo=tz_plus2)  # 14:00 UTC
+    assert format_action_ref_timestamp(dt) == "2026-06-20T14:00:00.000Z"
+
+
+def test_format_timestamp_rejects_naive():
+    with pytest.raises(ValueError, match="timezone-aware"):
+        format_action_ref_timestamp(datetime(2026, 6, 20, 14, 0, 0))
+
+
+def test_format_then_compute_roundtrip():
+    ts = format_action_ref_timestamp(datetime.fromtimestamp(1747568431, tz=timezone.utc))
+    assert (
+        compute_action_ref("nexus-agent-xa12.onrender.com", "oracle.signal", "BTC", ts)
+        == "fdd7f810499f06be24355ca8e2bfb8c4b965cc80c838f41fa074683443d89f5a"
+    )


### PR DESCRIPTION
## Summary
- Adds `action_ref.py`: `compute_action_ref()` (content-addressed SHA-256 over the RFC 8785 / JCS canonicalisation of the `agent_id`/`action_type`/`scope`/`timestamp` preimage) and `format_action_ref_timestamp()` (strict RFC 3339 UTC, exactly 3 ms digits + `Z`).
- Implements the joint **action-ref-v1** construction we co-authored on x402-foundation/x402 #2332; canonicalisation mirrors the family `mica.py` pattern (no new dependency).
- Interoperability primitive **only** — no external trail submission, no vendor coupling. A Mycelium/ARGENTUM provider writer is intentionally out of scope.

## Test plan
- [x] `tests/test_action_ref.py` byte-matches argentum-core's official `mycelium-provider-protocol-v1` vectors (pp-001/002/003 + reject vectors) and the spec's NEXUS worked example
- [x] timestamp formatter: 3-ms-digit/`Z` form, UTC conversion, naive-datetime rejection, round-trip
- [x] `ruff check/format src/ tests/` clean; full `pytest` suite green
- [x] exported from package `__init__`