### PR TITLE
Release v0.7.0 SLO payment broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,23 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Verify uv.lock is up to date with pyproject.toml
         run: uv lock --locked
+
+  security-audit:
+    name: Dependency Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Run pip-audit over release extras
+        run: >
+          uv run
+          --extra audit
+          --extra evidence
+          --extra redis
+          --extra audit-s3
+          --extra langchain
+          --extra prometheus
+          --extra otel
+          --extra schema
+          pip-audit --progress-spinner=off --skip-editable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,11 +84,13 @@ jobs:
       - name: Publish GitHub release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" dist/* sbom.cdx.json --clobber
+          if gh release view "$GITHUB_REF_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/* sbom.cdx.json --repo "$GH_REPO" --clobber
           else
             gh release create "$GITHUB_REF_NAME" dist/* sbom.cdx.json \
+              --repo "$GH_REPO" \
               --verify-tag \
               --title "$GITHUB_REF_NAME" \
               --notes "Release $GITHUB_REF_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 No unreleased changes.
 
+## [0.7.0] — 2026-06-21
+
+Market-based SLO enforcement (library). The agent becomes an economic actor that
+pays for capacity upgrades when infrastructure degrades — but only on a
+cryptographically **verified** degradation signal. The empirical evaluation,
+cs.DC preprint, and a real/mock capacity provider are tracked separately on the
+publication track and are not part of this library release.
+
+### Added
+- **`slo_broker.py`** — `SLOPaymentBroker`: wraps `HardenedX402Client`; on a
+  verified `SLOTrigger` applies cooldown + tier escalation + per-event/daily caps,
+  buys capacity via a pluggable `CapacityProvider` (default `X402CapacityProvider`),
+  and emits `SLO_PAYMENT_TRIGGERED` / `SLO_PAYMENT_BLOCKED` audit events. Decisions
+  are serialized (`asyncio.Lock`) so concurrent triggers cannot both pass cooldown.
+- **`slo_policy.py`** — `SLOPaymentPolicy(PolicyConfig)`: `latency_threshold_ms`,
+  `max_per_slo_event_usd`, `cooldown_seconds`, `max_daily_slo_usd`,
+  `tier_escalation_rules`. As a `PolicyConfig` subclass, SLO spend also counts
+  against the ordinary budgets (shared ledger).
+- **`arch_translucency_adapter.py`** — `ArchTranslucencyAdapter` + `SLOTrigger`:
+  fail-closed gate that accepts a degradation signal only when content↔hash and
+  signature↔trusted-signer both verify (`mica.verify_ref`), with an optional signer
+  allow-list and an overridable `field_map`.
+- **Provisioning PII entities** — opt-in `WORKLOAD_CLASS`, `DATA_CLASSIFICATION`,
+  `QUERY_PATTERN` (`PROVISIONING_ENTITIES`) redact workload context before it reaches
+  a third-party compute provider. Default PII behaviour is unchanged.
+
+### Security
+- **T-SLO-1 (spending drain):** the SLO trigger is an *authorization, not a metric* —
+  a spoofed or misconfigured degradation signal cannot trigger a payment because it
+  carries no valid signature. Cooldown + caps are defence-in-depth.
+- **T-SLO-2 (workload-metadata leakage):** provisioning PII entities (above).
+- **T-SLO-3 (vendor lock-in):** pluggable `CapacityProvider` registry.
+- **Third-party audit remediation:** production-tree conformance checks no longer use
+  bare `assert`, CI now runs `pip-audit` across release extras, and the v0.7.0 audit
+  remediation record is included in the source tree.
+
+### Notes
+- Validated end-to-end against the real `presidio-hardened-arch-translucency`
+  evidence producer + signing-bridge sidecar (degrade → sign → verify → pay; wrong
+  key rejected). The public wire contract remains pinned by the vendored
+  `evidence-ref@1` vectors and the v0.7.0 audit remediation record.
+
 ## [0.6.0] — 2026-06-21
 
 The production-hardening and evidence-substrate release. v0.6.0 closes the

--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -363,7 +363,7 @@ deferred and remains open outside the v0.6.0 release scope.
 
 ---
 
-## v0.7.0 Requirements (SLO Payment Broker) — re-slotted from v0.6.0 on 2026-06-12
+## v0.7.0 Requirements (SLO Payment Broker) — **library core delivered 2026-06-21**
 
 This version fills a second white spot: **market-based SLO enforcement**. Current
 autoscaling is reactive and rule-based. This milestone makes the agent an economic actor
@@ -373,32 +373,44 @@ x402 micropayments.
 ### Integration target
 
 `presidio-hardened-arch-translucency` provides the SLO observability signal (latency
-percentiles, quality metrics). `presidio-hardened-x402` acts as the SLO payment broker:
-it receives degradation events, applies `SLOPaymentPolicy`, and triggers x402 payments
-for capacity upgrades — all with the same PII redaction and spending governance already
-built in v0.1.0.
+percentiles, quality metrics) as **Ed25519-signed `evidence-ref@1` envelopes** (the same
+substrate x402 verifies via `mica`). `presidio-hardened-x402` acts as the SLO payment
+broker: it receives degradation events, **verifies the signed trigger fail-closed**, applies
+`SLOPaymentPolicy`, and triggers x402 payments for capacity upgrades — all with the same
+PII redaction and spending governance built in v0.1.0.
 
-### New components
+**Design upgrade — authorization, not metric.** The broker moves money, so a degradation
+signal is treated as an *authorization* and must be a signed evidence-ref from a trusted
+arch-translucency signer, verified before any payment. This makes spoofed/misconfigured
+degradation a verification failure (no payment) rather than something a cooldown races to
+contain. This is why v0.6.0 evidence Phase-A (the `mica` verifier) was a hard prerequisite.
 
-- **`slo_broker.py`** — `SLOPaymentBroker`: wraps `HardenedX402Client`; listens to SLO
-  degradation events; applies cooldown and tier escalation logic; triggers capacity upgrade
-  payments; records `SLO_PAYMENT_TRIGGERED` and `SLO_PAYMENT_BLOCKED` audit events.
+### New components — Delivered
 
-- **`slo_policy.py`** — `SLOPaymentPolicy`: extends `PolicyConfig` with:
-  - `latency_threshold_ms`: p99 latency above which a payment is triggered
-  - `max_per_slo_event_usd`: per-event spending cap
-  - `cooldown_seconds`: minimum gap between consecutive SLO payments (prevents drain)
-  - `max_daily_slo_usd`: daily SLO spending cap (shares ledger with `PolicyEngine`)
-  - `tier_escalation_rules`: step-up pricing for repeated degradation events
+- [x] **`slo_broker.py`** — `SLOPaymentBroker`: wraps `HardenedX402Client`; on a verified
+  `SLOTrigger` applies cooldown + tier escalation + per-event/daily caps; buys capacity via
+  a pluggable `CapacityProvider` (default `X402CapacityProvider`); records
+  `SLO_PAYMENT_TRIGGERED` / `SLO_PAYMENT_BLOCKED` audit events. Decision serialized
+  (`asyncio.Lock`) so concurrent triggers can't both pass the cooldown.
 
-- **`arch_translucency_adapter.py`** — consumes `presidio-hardened-arch-translucency`
-  metrics feed; translates degradation events into `SLOTrigger` objects consumed by
-  `SLOPaymentBroker`.
+- [x] **`slo_policy.py`** — `SLOPaymentPolicy(PolicyConfig)`: `latency_threshold_ms`,
+  `max_per_slo_event_usd`, `cooldown_seconds`, `max_daily_slo_usd`, `tier_escalation_rules`.
+  Being a `PolicyConfig` subclass, SLO spend also counts against the ordinary budgets (shared
+  ledger); the SLO caps are an independent second layer.
 
-- **Extended PII filter**: provisioning-specific entity types (`WORKLOAD_CLASS`,
-  `DATA_CLASSIFICATION`, `QUERY_PATTERN`) added to the `PIIFilter` entity registry.
-  Infrastructure provisioning requests carry sensitive workload context that must not
-  reach third-party compute providers.
+- [x] **`arch_translucency_adapter.py`** — `ArchTranslucencyAdapter` + `SLOTrigger`:
+  fail-closed gate that accepts a degradation signal only when (1) `sha256(content)` matches
+  the ref's `content_hash`, (2) the signature verifies against a trusted signer
+  (`mica.verify_ref`), and optionally (3) the signer is on an allow-list. Feed transport
+  injectable; attested-content field names overridable via `field_map`.
+
+- [x] **Extended PII filter**: opt-in provisioning entity types (`WORKLOAD_CLASS`,
+  `DATA_CLASSIFICATION`, `QUERY_PATTERN`) — kept out of the default active set so existing PII
+  behaviour is unchanged; selectable via `entities=` / `PROVISIONING_ENTITIES`. Redacts
+  workload context before it reaches a third-party compute provider.
+
+**Test coverage:** `test_slo_policy.py`, `test_arch_translucency_adapter.py`,
+`test_slo_broker.py`, `test_pii_provisioning.py` (29 tests). Full suite 476 passed / 9 skipped.
 
 ### Scoping decisions for v0.7.0
 
@@ -416,11 +428,11 @@ built in v0.1.0.
 
 ### New threat model entries
 
-| Threat | Mitigation |
-|--------|-----------|
-| SLO-triggered spending drain (adversarial or misconfigured degradation signals) | `SLOPaymentPolicy` cooldown + `max_daily_slo_usd` cap |
-| Workload metadata leakage in provisioning requests | Extended PIIFilter covers provisioning-specific entity types |
-| Vendor lock-in via payment coupling | Pluggable provider registry in `SLOPaymentBroker` |
+| ID | Threat | Primary mitigation | Defense-in-depth |
+|----|--------|--------------------|------------------|
+| **T-SLO-1** | SLO-triggered spending drain — adversarial or misconfigured infrastructure floods the agent with degraded signals to provoke runaway capacity payments | **Signed-trigger verification**: only a fail-closed-verified `evidence-ref` from a trusted arch-translucency signer can trigger a payment (`ArchTranslucencyAdapter` + `mica.verify_ref`) | `SLOPaymentPolicy` cooldown, `max_per_slo_event_usd`, `max_daily_slo_usd`, and step-up `tier_escalation_rules` |
+| **T-SLO-2** | Workload-metadata leakage — provisioning requests carry query types, data classifications, and access patterns that must not reach third-party compute providers | Extended `PIIFilter` provisioning entities (`WORKLOAD_CLASS`, `DATA_CLASSIFICATION`, `QUERY_PATTERN`) redact workload context before transmission | Opt-in, so no false-positive regression on ordinary payment metadata |
+| **T-SLO-3** | Vendor lock-in via payment coupling — agent becomes economically dependent on one capacity provider | Pluggable `CapacityProvider` registry in `SLOPaymentBroker` | — |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![CI](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml/badge.svg)](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml)
 
-> v0.6.0 — production hardening: multi-tenant replay namespaces, enterprise audit sinks, SLSA/OIDC release provenance, signed evidence-ref verification, OpenTelemetry spans, policy hot-reload, startup key gates, and human-pentest retest closure; plus the v0.5 OEM embed kit and the core PII/policy/replay/audit controls.
+> v0.7.0 — market-based SLO enforcement: signed arch-translucency degradation evidence becomes a verified x402 capacity-payment trigger, with cooldowns, spend caps, provisioning redaction, and pluggable capacity providers.
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -327,6 +327,69 @@ SOC 2 TSC mapping, GDPR obligations, and deployment patterns.
 
 ---
 
+## SLO Payment Broker (v0.7.0)
+
+Market-based SLO enforcement: when infrastructure degrades, the agent autonomously pays for
+a capacity upgrade via x402 micropayments instead of relying on pre-provisioned autoscaling.
+The broker acts only on a **verified** degradation signal — a signed
+`evidence-ref@1` from a trusted `presidio-hardened-arch-translucency` signer — so a spoofed or
+misconfigured signal cannot trigger a payment (authorization, not metric).
+
+```python
+from presidio_x402 import (
+    HardenedX402Client, SLOPaymentBroker, SLOPaymentPolicy,
+    X402CapacityProvider, ArchTranslucencyAdapter,
+)
+
+# arch-translucency's signed degradation feed → verified trigger (fail-closed).
+adapter = ArchTranslucencyAdapter(
+    {"presidio-hardened-arch-translucency": {"alg": "ed25519", "public_key": ARCH_PUB}},
+    expected_signers=["presidio-hardened-arch-translucency"],
+)
+client = HardenedX402Client(payment_signer=signer)
+broker = SLOPaymentBroker(
+    client=client,
+    slo_policy=SLOPaymentPolicy(
+        cooldown_seconds=300,            # anti-drain
+        max_per_slo_event_usd=0.50,
+        max_daily_slo_usd=10.00,
+        tier_escalation_rules=(1.0, 2.0, 4.0),  # step-up pricing for repeated degradation
+    ),
+    provider=X402CapacityProvider("compute", "https://compute.example/v1/capacity", client),
+    base_event_usd=0.10,
+)
+
+for trigger in adapter.build_triggers(signed_envelope):  # verified or skipped
+    await broker.handle_trigger(trigger)   # → paid / blocked / skipped, with audit event
+```
+
+The signing key lives in a separate bridge sidecar (arch-translucency stays key-less); x402
+holds only the public key. The wire contract is pinned by the `evidence-ref@1`
+golden-vector tests shared with arch-translucency.
+
+### Provisioning Metadata Redaction
+
+Capacity-upgrade requests can reveal workload type, data classification, or access pattern.
+Those heuristics are intentionally opt-in so ordinary payment metadata keeps the v0.6
+false-positive profile.
+
+```python
+from presidio_x402 import PIIFilter, PROVISIONING_ENTITIES
+
+filt = PIIFilter(
+    entities=list(PROVISIONING_ENTITIES),
+    redaction_template="<{entity_type}>",
+)
+
+clean, entities = filt.scan_and_redact(
+    "ml training workload over CONFIDENTIAL data: SELECT email FROM customers"
+)
+# clean:
+# "<WORKLOAD_CLASS> workload over <DATA_CLASSIFICATION> data: <QUERY_PATTERN>"
+```
+
+---
+
 ## Exceptions
 
 | Exception | Raised when |
@@ -362,9 +425,9 @@ All exceptions are importable from `presidio_x402`.
 | v0.3.0 | **Multi-party authorization** (`mpa.py`: n-of-m, webhook + crypto modes) · **Policy-as-code** JSON Schema (IETF draft candidate) · **Prometheus metrics** exporter · Kubernetes Helm chart + Docker image · SOC2 reference architecture |
 | v0.4.0 | **Screening API launch** — hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu) free tier (regex mode, 100 req/day) · `ScreeningClient` + `remote_screening=True` mode · per-origin `pay_to` allowlist (chain-06 mitigation) · audit-cycle hardening (F-A/B 2026-05-03, F-C/D/E 2026-05-10, F1/F2/F3 2026-05-17); see [`CHANGELOG.md`](CHANGELOG.md) |
 | v0.5.0 | **OEM embed kit** — rail-agnostic `ScreeningPipeline` core + `bindings/x402` layer (`PaymentProtocolBinding` protocol, hedge against rail fragmentation: ACP/Tempo, AP2) · [SEMVER.md](SEMVER.md) stability guarantees · partner conformance suite (`python -m presidio_x402.conformance`) · CDP/LangChain/CrewAI quickstarts · SBOM in CI · freshness-bound MPA countersignatures (F-8) |
-| **v0.6.0** | **Production hardening + evidence substrate** — multi-tenant replay namespaces · enterprise audit sinks (S3 / Splunk / Datadog) · signed `evidence-ref@1` verification · SLSA/OIDC release provenance · digest-pinned Docker base + hash-pinned spaCy model · latency SLO and all-matrix coverage CI gates · OTel spans · policy hot-reload · startup key gates · human-pentest retest closure — **latest release** |
+| v0.6.0 | **Production hardening + evidence substrate** — multi-tenant replay namespaces · enterprise audit sinks (S3 / Splunk / Datadog) · signed `evidence-ref@1` verification · SLSA/OIDC release provenance · digest-pinned Docker base + hash-pinned spaCy model · latency SLO and all-matrix coverage CI gates · OTel spans · policy hot-reload · startup key gates · human-pentest retest closure |
+| **v0.7.0** | **SLO payment broker (library)** — x402 micropayments as runtime infrastructure bids: `SLOPaymentBroker` + `SLOPaymentPolicy` + evidence-anchored `ArchTranslucencyAdapter` + provisioning PII entities; cross-repo validated against `presidio-hardened-arch-translucency`. cs.DC preprint + empirical eval tracked separately — **latest release** |
 | Unreleased on `main` | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
-| v0.7.0 | **SLO payment broker** — x402 micropayments as runtime infrastructure bids; `presidio-hardened-arch-translucency` integration |
 
 See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 

--- a/SECURITY-AUDIT-2026-06-21-v0.7.0.md
+++ b/SECURITY-AUDIT-2026-06-21-v0.7.0.md
@@ -1,0 +1,32 @@
+# Third-Party Functional/Security Audit Remediation — v0.7.0
+
+Date: 2026-06-21
+
+Source report: `/Users/vstantch/projects/presidio-third-party-audits/third-party-functional-security-audit-presidio-hardened-x402-v0.7.0-20260621-211439.md`
+
+Scope: `presidio-hardened-x402` v0.7.0 public library in `tools/`, including the SLO payment broker, arch-translucency evidence adapter, provisioning PII entities, release workflow, and screening/API regression context.
+
+Verdict from third-party report: functional pass; security maintained and enhanced. No Critical or High findings. Notes were low or informational.
+
+## Findings Assessed
+
+| Severity | Finding | Assessment | Remediation |
+|---|---|---|---|
+| Low | Ruff S101 findings in `src/presidio_x402/conformance/runner.py` | Valid. The conformance suite lives under `src/`, so bare `assert` statements were noisy even though this is a partner test harness. | Replaced bare `assert` statements with explicit `ConformanceFailure` checks while preserving fail-closed partner-suite behavior. |
+| Low | Clean `pip-audit` should be part of the v0.7.0 artifact gate | Valid. Prior gates had dependency controls, but the v0.7.0 extras path should be explicit in CI. | Added an `audit` extra and a CI dependency-audit job that runs `pip-audit` over the release extras: `evidence`, `redis`, `audit-s3`, `langchain`, `prometheus`, `otel`, and `schema`. |
+| Info | Production keys must be configured | Operational requirement, not a code defect. | Left production startup warnings intact; `SECURITY.md` documents `PRESIDIO_X402_CHAIN_KEY` and `PRESIDIO_X402_FINGERPRINT_KEY`. |
+| Info | Evidence bridge deployment should use secure key custody and hardened runtime | Operational requirement for the internal sidecar. | Public library remains key-less. The bridge is kept outside the public package; sidecar deployment hardening is tracked in the internal monorepo. |
+| Info | Provisioning entities and SLO policy should be visible in user docs | Valid release-documentation gap. | README now includes the SLO broker flow and a provisioning metadata redaction snippet using `PROVISIONING_ENTITIES`. |
+
+## Release Gate
+
+Before tagging v0.7.0, run:
+
+```bash
+.venv/bin/python -m ruff check .
+.venv/bin/python -m ruff format --check .
+/Users/vstantch/.local/bin/uv lock --check
+/Users/vstantch/.local/bin/uv run --extra audit --extra evidence --extra redis --extra audit-s3 --extra langchain --extra prometheus --extra otel --extra schema pip-audit --progress-spinner=off --skip-editable
+.venv/bin/python -m pytest tests/ -x -q --tb=short
+.venv/bin/python -m presidio_x402.conformance
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.6.x   | ✓ (latest release) |
+| 0.7.x   | ✓ (latest release) |
+| 0.6.x   | ✓ |
 | 0.5.x   | ✓ |
 | 0.4.x   | ✓ |
 | 0.3.x   | security fixes only |
@@ -65,6 +66,7 @@ active unless you enable them.
 | OpenTelemetry spans | Opt-in | Install `[otel]` and configure an exporter; disabled is a no-op |
 | Remote audit sinks | Opt-in | Use `MultiAuditWriter` with `S3AuditWriter`, `SplunkAuditWriter`, or `DatadogAuditWriter` |
 | Evidence signing / verification | Opt-in | Use `build_evidence()` / `verify_ref()` with a deployment trust store |
+| SLO payment broker (v0.7.0) | Opt-in | `SLOPaymentBroker` pays only on a **verified** signed degradation trigger (`ArchTranslucencyAdapter` → `verify_ref`); cooldown + per-event/daily caps + escalation as defence-in-depth |
 
 Header/secret redaction at the logging sink ships in v0.5.0 (family audit rec
 R2): `install_log_redaction()` runs at package import and scrubs API keys,
@@ -88,11 +90,21 @@ See `PRESIDIO-REQ.md` for the full threat model and security design rationale.
 | Forged MPA webhook response | Crypto mode verifies HMAC-SHA256 countersignatures against shared secrets |
 | Unobservable security control activations | Prometheus metrics expose every PII detection, policy block, replay, and MPA event |
 
+### v0.7.0 additions (SLO payment broker)
+
+| Threat | Mitigation |
+|--------|-----------|
+| T-SLO-1 — SLO-triggered spending drain (spoofed/misconfigured degradation signals) | Trigger is an *authorization, not a metric*: only a fail-closed-verified signed `evidence-ref` from a trusted arch-translucency signer can trigger a payment; cooldown + per-event/daily caps + step-up escalation are defence-in-depth |
+| T-SLO-2 — Workload-metadata leakage to a compute provider | Opt-in provisioning PII entities (`WORKLOAD_CLASS`, `DATA_CLASSIFICATION`, `QUERY_PATTERN`) redact workload context before transmission |
+| T-SLO-3 — Vendor lock-in via payment coupling | Pluggable `CapacityProvider` registry |
+
 ## Dependency Security
 
 - Dependencies are pinned to minimum-safe versions
 - `dependabot.yml` is configured for automated dependency updates
 - CodeQL analysis is run on every push and pull request
+- CI runs `pip-audit` against release extras (`evidence`, `redis`, `audit-s3`,
+  `langchain`, `prometheus`, `otel`, `schema`) before merge
 - Critical security updates are backported to the current supported version
 
 ## Known Limitations
@@ -112,3 +124,8 @@ See `PRESIDIO-REQ.md` for the full threat model and security design rationale.
 This repository is developed under the Presidio hardened-family SDLC. The public report
 — scope, standards mapping, threat-model gates, and supply-chain controls — is at
 <https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.
+
+## Manual Security Audit History
+
+- [`SECURITY-AUDIT-2026-06-21-v0.7.0.md`](SECURITY-AUDIT-2026-06-21-v0.7.0.md) —
+  v0.7.0 third-party functional/security audit remediation status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.6.0"
+version = "0.7.0"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"
@@ -65,6 +65,9 @@ audit-s3 = [
     # Enterprise S3AuditWriter (audit_sinks.py). Splunk/Datadog sinks reuse the
     # core httpx dependency; only S3 needs boto3.
     "boto3>=1.34",
+]
+audit = [
+    "pip-audit>=2.7.0",
 ]
 langchain = [
     # >=1.3.3 closes CVE-2026-44843 (GHSA-pjwx-r37v-7724) — unsafe broad-allowlist

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -28,6 +28,7 @@ import logging
 
 from ._types import PaymentProtocolBinding
 from .action_ref import compute_action_ref, format_action_ref_timestamp
+from .arch_translucency_adapter import ArchTranslucencyAdapter, SLOTrigger
 from .audit_log import AuditLog, FileAuditWriter, NullAuditWriter, StreamAuditWriter
 from .bindings.x402 import X402Binding
 from .compliance_report import ComplianceReport
@@ -50,12 +51,20 @@ from .log_redaction import RedactingFilter, SecretRedactor, install_log_redactio
 from .metrics import MetricsCollector
 from .mica import OBLIGATION_MAP, EvidenceError, Obligation, build_evidence
 from .mpa import MPAApproverConfig, MPAConfig, MPAEngine, build_countersignature
-from .pii_filter import PIIFilter
+from .pii_filter import PROVISIONING_ENTITIES, PIIFilter
 from .policy_engine import PolicyConfig, PolicyEngine
 from .replay_guard import ReplayGuard, compute_fingerprint
 from .screening_client import ScreeningClient
+from .slo_broker import (
+    CapacityProvider,
+    SLOPaymentBroker,
+    SLOPaymentDecision,
+    UpgradeReceipt,
+    X402CapacityProvider,
+)
+from .slo_policy import SLOPaymentPolicy
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __all__ = [
     # Primary public API
     "HardenedX402Client",
@@ -106,6 +115,16 @@ __all__ = [
     "install_log_redaction",
     "RedactingFilter",
     "SecretRedactor",
+    # Market-based SLO enforcement (v0.7.0)
+    "SLOPaymentBroker",
+    "SLOPaymentPolicy",
+    "SLOPaymentDecision",
+    "SLOTrigger",
+    "ArchTranslucencyAdapter",
+    "CapacityProvider",
+    "X402CapacityProvider",
+    "UpgradeReceipt",
+    "PROVISIONING_ENTITIES",
 ]
 
 logger = logging.getLogger("presidio_x402")

--- a/src/presidio_x402/arch_translucency_adapter.py
+++ b/src/presidio_x402/arch_translucency_adapter.py
@@ -1,0 +1,182 @@
+"""Adapter: arch-translucency degradation signals → verified SLO triggers (v0.7.0).
+
+The :class:`~presidio_x402.slo_broker.SLOPaymentBroker` *moves money* on degradation
+events, so a trigger must be an **authorization, not a metric**. ``presidio-hardened-
+arch-translucency`` already emits Ed25519-signed evidence in the cross-repo
+``presidio-hardened/evidence-ref@1`` wire format (the same substrate x402 verifies in
+:mod:`presidio_x402.mica`). This adapter accepts a degradation signal only when:
+
+1. the attested content's SHA-256 matches the ref's ``content_hash`` (content ↔ hash), and
+2. the ref's detached signature verifies against a **trusted arch-translucency signer**
+   in the trust store (hash+signer ↔ signature), and
+3. (optionally) the signer is on an allow-list of expected arch-translucency signers.
+
+All three are fail-closed: any failure yields **no** :class:`SLOTrigger`, so the broker
+never pays on a forged, tampered, or untrusted signal. Verification mechanics are
+contract-stable; only the *field names* read out of the attested content
+(``slo``/``value``/``threshold``/``window``) are coupled to arch-translucency's payload
+shape and are overridable via ``field_map``.
+
+Feed transport is injectable: construct :class:`SLOTrigger` objects from envelopes you
+pull however arch-translucency exposes them (HTTP poll, push, file tail). This keeps x402
+decoupled from arch-translucency's internal API surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from .mica import load_trust_store, parse_document, sha256_hex, verify_ref
+
+logger = logging.getLogger("presidio_x402.arch_translucency_adapter")
+
+# Default arch-translucency signer id (override via expected_signers if different).
+DEFAULT_ARCH_SIGNER = "presidio-hardened-arch-translucency"
+
+# Attested-content field names. Overridable to match arch-translucency's payload.
+_DEFAULT_FIELD_MAP = {
+    "slo": "slo",
+    "value": "value",
+    "threshold": "threshold",
+    "window": "window",
+    "observed_at": "observed_at",
+}
+
+
+@dataclass(frozen=True)
+class SLOTrigger:
+    """A *verified* SLO degradation event. Only the adapter constructs these, and
+    only after fail-closed signature + content-hash checks, so possessing one is
+    proof the broker may act on it."""
+
+    slo: str
+    value: int
+    threshold: int
+    window: str
+    signer: str
+    content_hash: str
+    observed_at: str
+
+    @property
+    def degraded(self) -> bool:
+        """True when the observed metric breaches the SLO's own threshold."""
+        return self.value > self.threshold
+
+
+class SLOTriggerError(ValueError):
+    """Raised by strict parsing when an envelope cannot be turned into a trigger."""
+
+
+class ArchTranslucencyAdapter:
+    """Verifies arch-translucency evidence envelopes into :class:`SLOTrigger` objects.
+
+    Parameters
+    ----------
+    trust:
+        Trust store (mapping or JSON text) of arch-translucency signers, in the
+        ``trust-store@1`` shape consumed by :func:`presidio_x402.mica.load_trust_store`.
+    expected_signers:
+        Optional allow-list; when set, a ref whose signer is not listed is rejected
+        even if its signature would verify under some other entry.
+    field_map:
+        Override attested-content field names if arch-translucency labels them
+        differently from the defaults (``slo``/``value``/``threshold``/``window``).
+    """
+
+    def __init__(
+        self,
+        trust: Mapping[str, object] | str,
+        *,
+        expected_signers: Iterable[str] | None = None,
+        field_map: Mapping[str, str] | None = None,
+    ) -> None:
+        self._trust = load_trust_store(trust)
+        self._expected = set(expected_signers) if expected_signers is not None else None
+        self._fields = {**_DEFAULT_FIELD_MAP, **(dict(field_map) if field_map else {})}
+        self.rejected = 0
+
+    def build_triggers(self, envelope: Mapping[str, object]) -> list[SLOTrigger]:
+        """Verify one evidence envelope and return its trigger(s) (fail-closed).
+
+        Bad/forged/untrusted items are skipped and counted in ``self.rejected``;
+        the method never raises on a verification failure (so a malicious feed item
+        produces no trigger rather than an exception that could mask others). Use
+        :meth:`build_trigger_strict` when you want a raise.
+        """
+        try:
+            refs = parse_document(envelope)
+        except Exception:
+            logger.warning("arch-translucency envelope failed structural parse; skipping")
+            self.rejected += 1
+            return []
+
+        content = envelope.get("attested_content")
+        if not isinstance(content, Mapping):
+            logger.warning("envelope missing attested_content mapping; skipping")
+            self.rejected += len(refs) or 1
+            return []
+
+        # Content ↔ hash: recompute and pin before trusting any field of it.
+        try:
+            content_digest = sha256_hex(content)
+        except Exception:
+            logger.warning("attested_content not canonicalizable; skipping")
+            self.rejected += len(refs) or 1
+            return []
+
+        triggers: list[SLOTrigger] = []
+        for ref in refs:
+            if ref.content_hash != content_digest:
+                logger.warning("content_hash mismatch (content tampered); rejecting ref")
+                self.rejected += 1
+                continue
+            if self._expected is not None and ref.signer not in self._expected:
+                logger.warning("signer %r not in expected arch signers; rejecting", ref.signer)
+                self.rejected += 1
+                continue
+            if not verify_ref(ref, self._trust):
+                logger.warning("signature did not verify for signer %r; rejecting", ref.signer)
+                self.rejected += 1
+                continue
+            trigger = self._content_to_trigger(content, ref.signer, ref.content_hash)
+            if trigger is None:
+                self.rejected += 1
+                continue
+            triggers.append(trigger)
+        return triggers
+
+    def build_trigger_strict(self, envelope: Mapping[str, object]) -> SLOTrigger:
+        """Like :meth:`build_triggers` but raises :class:`SLOTriggerError` on any
+        failure and requires exactly one trigger. Handy for request/response feeds."""
+        triggers = self.build_triggers(envelope)
+        if len(triggers) != 1:
+            raise SLOTriggerError(
+                f"expected exactly one verified trigger, got {len(triggers)} "
+                "(unverified, tampered, untrusted, or multi-ref envelope)"
+            )
+        return triggers[0]
+
+    def _content_to_trigger(
+        self, content: Mapping[str, object], signer: str, content_hash: str
+    ) -> SLOTrigger | None:
+        f = self._fields
+        try:
+            slo = str(content[f["slo"]])
+            value = int(content[f["value"]])
+            threshold = int(content[f["threshold"]])
+            window = str(content[f["window"]])
+        except (KeyError, TypeError, ValueError):
+            logger.warning("attested_content missing/invalid SLO fields; rejecting")
+            return None
+        observed_at = str(content.get(f["observed_at"], ""))
+        return SLOTrigger(
+            slo=slo,
+            value=value,
+            threshold=threshold,
+            window=window,
+            signer=signer,
+            content_hash=content_hash,
+            observed_at=observed_at,
+        )

--- a/src/presidio_x402/conformance/runner.py
+++ b/src/presidio_x402/conformance/runner.py
@@ -17,6 +17,15 @@ if TYPE_CHECKING:
 CHECKS: list[tuple[str, Callable[[], None]]] = []
 
 
+class ConformanceFailureError(AssertionError):
+    """Raised when a partner conformance invariant fails."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ConformanceFailureError(message)
+
+
 def check(name: str) -> Callable[[Callable[[], None]], Callable[[], None]]:
     def register(fn: Callable[[], None]) -> Callable[[], None]:
         CHECKS.append((name, fn))
@@ -91,7 +100,7 @@ def check_api_surface() -> None:
     import presidio_x402
 
     missing = [name for name in presidio_x402.__all__ if not hasattr(presidio_x402, name)]
-    assert not missing, f"__all__ names missing from package: {missing}"
+    _require(not missing, f"__all__ names missing from package: {missing}")
 
 
 @check("PII redacted before signer sees payment details")
@@ -110,8 +119,8 @@ def check_pii_redaction() -> None:
             await client.get("https://conformance.invalid/v1/data")
 
     _run(flow())
-    assert seen, "signer was never invoked"
-    assert "pii@example.com" not in seen[0], "raw PII reached the signer"
+    _require(bool(seen), "signer was never invoked")
+    _require("pii@example.com" not in seen[0], "raw PII reached the signer")
 
 
 @check("pii_action=block fails closed on PII")
@@ -203,9 +212,12 @@ def check_audit_chain() -> None:
                 await client.get("https://conformance.invalid/v1/data")
 
         _run(flow())
-        assert path.exists() and path.stat().st_size > 0, "no audit records written"
+        _require(path.exists() and path.stat().st_size > 0, "no audit records written")
         report = ComplianceReport.from_jsonl(path)
-        assert report.chain_ok, f"audit chain failed on untampered log: {report.chain_warnings}"
+        _require(
+            report.chain_ok,
+            f"audit chain failed on untampered log: {report.chain_warnings}",
+        )
 
         # Tamper with the first record — the chain must flag it.
         lines = path.read_text(encoding="utf-8").splitlines()
@@ -214,7 +226,7 @@ def check_audit_chain() -> None:
         lines[0] = json.dumps(record)
         path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         tampered = ComplianceReport.from_jsonl(path)
-        assert not tampered.chain_ok, "tampered audit log passed chain verification"
+        _require(not tampered.chain_ok, "tampered audit log passed chain verification")
 
 
 @check("x402 binding parses spec offers and rejects malformed offers fail-closed")
@@ -224,7 +236,10 @@ def check_binding() -> None:
 
     binding = X402Binding()
     details = binding.parse_payment_required(_OFFER)
-    assert details.amount == "0.01" and details.network == "base-sepolia"
+    _require(
+        details.amount == "0.01" and details.network == "base-sepolia",
+        "valid x402 offer parsed to unexpected payment details",
+    )
     for bad in ("not json", "[]", '{"accepts": []}', '{"accepts": ["exact"]}'):
         try:
             binding.parse_payment_required(bad)

--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -167,6 +167,57 @@ _REGEX_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ),
 ]
 
+# ---------------------------------------------------------------------------
+# Provisioning-metadata entity types (v0.7.0, SLO payment broker).
+#
+# Infrastructure capacity-upgrade requests carry sensitive *workload context* —
+# what the agent runs, how its data is classified, what it queries — which must
+# not leak to a third-party compute provider when the SLO broker pays for an
+# upgrade. These are heuristic, higher-false-positive patterns, so they are
+# **opt-in**: not in the default active set, only matched when a caller selects
+# them via ``entities=`` (e.g. ``PIIFilter(entities=list(PROVISIONING_ENTITIES))``).
+# ---------------------------------------------------------------------------
+PROVISIONING_ENTITIES: tuple[str, ...] = (
+    "WORKLOAD_CLASS",
+    "DATA_CLASSIFICATION",
+    "QUERY_PATTERN",
+)
+
+_PROVISIONING_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    # Data-classification banners — the markers you least want a compute provider
+    # to see attached to a workload.
+    (
+        "DATA_CLASSIFICATION",
+        re.compile(
+            r"\b(?:TOP[\s\-]?SECRET|SECRET|CONFIDENTIAL|RESTRICTED|CLASSIFIED|"
+            r"CUI|PII|PHI|PCI(?:[\s\-]?DSS)?|INTERNAL[\s\-]?ONLY)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # Workload descriptors that reveal what the agent is actually running.
+    (
+        "WORKLOAD_CLASS",
+        re.compile(
+            r"\b(?:ml[\s\-]?training|model[\s\-]?(?:training|inference)|"
+            r"fraud[\s\-]?detection|risk[\s\-]?scoring|key[\s\-]?management|"
+            r"kyc|aml|genomics?|biometrics?)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # Query/access-pattern fragments (SQL verb bounded to a nearby clause keyword;
+    # the {0,120} bound prevents catastrophic backtracking on hostile input).
+    (
+        "QUERY_PATTERN",
+        re.compile(
+            r"\b(?:SELECT|INSERT|UPDATE|DELETE)\b[^\n]{0,120}?\b(?:FROM|INTO|SET|WHERE)\b",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+# Lookup pool for opt-in selection: structural defaults + provisioning entities.
+_ALL_PATTERNS: list[tuple[str, re.Pattern[str]]] = _REGEX_PATTERNS + _PROVISIONING_PATTERNS
+
 
 @dataclass
 class EntityResult:
@@ -229,9 +280,13 @@ class PIIFilter:
             ) from exc
 
     def _active_patterns(self) -> list[tuple[str, re.Pattern[str]]]:
+        # Default (entities=None) keeps the structural set only — provisioning
+        # entities are opt-in to avoid false positives on ordinary metadata. When
+        # a caller names entities, select from the full pool so they can enable
+        # WORKLOAD_CLASS / DATA_CLASSIFICATION / QUERY_PATTERN explicitly.
         if self.entities is None:
             return _REGEX_PATTERNS
-        return [(name, pat) for name, pat in _REGEX_PATTERNS if name in self.entities]
+        return [(name, pat) for name, pat in _ALL_PATTERNS if name in self.entities]
 
     def scan_and_redact(self, text: str) -> tuple[str, list[EntityResult]]:
         """Scan *text* for PII, redact matches, and return ``(redacted_text, results)``.

--- a/src/presidio_x402/slo_broker.py
+++ b/src/presidio_x402/slo_broker.py
@@ -1,0 +1,228 @@
+"""Market-based SLO enforcement — the SLO payment broker (v0.7.0).
+
+When infrastructure degrades, the agent autonomously pays for a capacity upgrade via
+x402 micropayments instead of relying on pre-provisioned autoscaling. The broker is an
+economic actor that *bids for the infrastructure quality it needs, only when it needs it*.
+
+It wraps a :class:`~presidio_x402.gateway.HardenedX402Client`, so capacity payments inherit
+the full pre-execution pipeline (PII redaction, spending policy, replay guard, audit) — and
+adds three SLO-specific controls layered on top:
+
+* **Authorization, not metric.** It acts only on a *verified* :class:`~presidio_x402.
+  arch_translucency_adapter.SLOTrigger` (a signature-checked arch-translucency degradation
+  event). Forged/untrusted signals never reach the broker — that gate lives in the adapter.
+* **Anti-drain.** :class:`~presidio_x402.slo_policy.SLOPaymentPolicy` enforces a cooldown,
+  a per-event cap, a daily SLO cap (its own ledger), and step-up pricing for *consecutive*
+  degradations, so a flapping or adversarial backend can't bleed the budget.
+* **Anti-lock-in.** Capacity is bought through a pluggable :class:`CapacityProvider`, so the
+  agent is not economically welded to a single provider.
+
+Every decision emits an audit event (``SLO_PAYMENT_TRIGGERED`` / ``SLO_PAYMENT_BLOCKED``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from .audit_log import AuditLog, NullAuditWriter
+from .exceptions import PolicyViolationError, X402Error
+from .policy_engine import _decimal_usd, _SpendLedger
+from .slo_policy import SLOPaymentPolicy, validate_slo_policy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ._types import AuditWriter
+    from .arch_translucency_adapter import SLOTrigger
+    from .gateway import HardenedX402Client
+
+logger = logging.getLogger("presidio_x402.slo_broker")
+
+
+class SLOBrokerError(X402Error):
+    """Raised on broker misconfiguration (fail-closed at construction)."""
+
+
+@dataclass(frozen=True)
+class UpgradeReceipt:
+    """Result of a capacity-provider purchase attempt."""
+
+    provider: str
+    endpoint: str
+    amount_usd: float
+    ok: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class SLOPaymentDecision:
+    """Outcome of handling one trigger."""
+
+    action: str  # "paid" | "blocked" | "skipped"
+    reason: str
+    amount_usd: float
+    receipt: UpgradeReceipt | None = None
+
+
+class CapacityProvider(Protocol):
+    """A provider the agent can pay to upgrade capacity. Implementations must not
+    spend more than ``max_usd`` and should surface the actual charge in the receipt."""
+
+    name: str
+
+    async def purchase_upgrade(self, trigger: SLOTrigger, *, max_usd: float) -> UpgradeReceipt:
+        raise NotImplementedError
+
+
+class X402CapacityProvider:
+    """Default provider: pays an x402 capacity-upgrade endpoint via the wrapped client.
+
+    The endpoint is expected to answer with HTTP 402 and a payment offer; the
+    :class:`~presidio_x402.gateway.HardenedX402Client` settles it (subject to its own
+    policy/PII/replay controls), so this provider mainly binds an endpoint to the agent.
+    """
+
+    def __init__(self, name: str, endpoint: str, client: HardenedX402Client) -> None:
+        self.name = name
+        self._endpoint = endpoint
+        self._client = client
+
+    async def purchase_upgrade(self, trigger: SLOTrigger, *, max_usd: float) -> UpgradeReceipt:
+        payload = {
+            "slo": trigger.slo,
+            "observed": trigger.value,
+            "threshold": trigger.threshold,
+            "max_usd": max_usd,
+        }
+        resp = await self._client.post(self._endpoint, json=payload)
+        ok = resp.status_code < 400
+        # The agent authorized at most max_usd; the gateway enforces the real cap.
+        return UpgradeReceipt(
+            provider=self.name,
+            endpoint=self._endpoint,
+            amount_usd=max_usd if ok else 0.0,
+            ok=ok,
+            detail=f"HTTP {resp.status_code}",
+        )
+
+
+class SLOPaymentBroker:
+    """Decides and executes SLO-triggered capacity payments.
+
+    Parameters
+    ----------
+    client:
+        The wrapped :class:`~presidio_x402.gateway.HardenedX402Client` (shared spending
+        ledger / audit pipeline).
+    slo_policy:
+        :class:`~presidio_x402.slo_policy.SLOPaymentPolicy` (validated at construction).
+    provider:
+        A :class:`CapacityProvider` to buy upgrades from.
+    base_event_usd:
+        Base price for one capacity upgrade, before escalation/caps.
+    audit_writer:
+        Optional sink for the broker's ``SLO_PAYMENT_*`` audit events.
+    clock:
+        Monotonic clock for cooldown (injectable for tests). Defaults to
+        :func:`time.monotonic`.
+    """
+
+    def __init__(
+        self,
+        client: HardenedX402Client,
+        *,
+        slo_policy: SLOPaymentPolicy,
+        provider: CapacityProvider,
+        base_event_usd: float,
+        audit_writer: AuditWriter | None = None,
+        agent_id: str | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        validate_slo_policy(slo_policy)
+        _decimal_usd(base_event_usd, "base_event_usd")
+        self._client = client
+        self._policy = slo_policy
+        self._provider = provider
+        self._base_usd = base_event_usd
+        self._audit = AuditLog(audit_writer or NullAuditWriter(), agent_id=agent_id)
+        self._clock = clock
+        self._slo_ledger = _SpendLedger(slo_policy.window_seconds)
+        self._last_payment_ts: float | None = None
+        self._consecutive = 0
+        self._lock = asyncio.Lock()
+
+    async def handle_trigger(self, trigger: SLOTrigger) -> SLOPaymentDecision:
+        """Decide and (if authorized) execute a capacity payment for one verified
+        trigger. Serialized so concurrent triggers cannot both pass the cooldown."""
+        async with self._lock:
+            if not trigger.degraded:
+                # Recovery: reset the consecutive-escalation counter.
+                self._consecutive = 0
+                return SLOPaymentDecision("skipped", "not degraded", 0.0)
+
+            now = self._clock()
+            if (
+                self._last_payment_ts is not None
+                and (now - self._last_payment_ts) < self._policy.cooldown_seconds
+            ):
+                return self._blocked(trigger, "cooldown active", 0.0)
+
+            amount = self._base_usd * self._policy.escalation_multiplier(self._consecutive)
+            if self._policy.max_per_slo_event_usd is not None:
+                amount = min(amount, self._policy.max_per_slo_event_usd)
+            amount_dec = _decimal_usd(amount, "slo_amount")
+
+            if self._policy.max_daily_slo_usd is not None:
+                cap = _decimal_usd(self._policy.max_daily_slo_usd, "max_daily_slo_usd")
+                if self._slo_ledger.would_exceed(amount_dec, cap):
+                    return self._blocked(trigger, "daily SLO cap reached", amount)
+
+            try:
+                receipt = await self._provider.purchase_upgrade(trigger, max_usd=amount)
+            except PolicyViolationError as exc:
+                return self._blocked(trigger, f"client policy blocked: {exc}", amount)
+            except Exception as exc:  # provider/network failure → no payment recorded
+                logger.exception("capacity provider failed")
+                return self._blocked(trigger, f"provider error: {exc}", amount)
+
+            if not receipt.ok:
+                return self._blocked(trigger, f"provider declined: {receipt.detail}", amount)
+
+            charged = receipt.amount_usd
+            self._slo_ledger.record(_decimal_usd(charged, "charged_usd"))
+            self._last_payment_ts = now
+            self._consecutive += 1
+            self._emit("SLO_PAYMENT_TRIGGERED", trigger, charged, "allowed")
+            logger.info(
+                "SLO payment: %s degraded (%d>%d) → $%.4f via %s",
+                trigger.slo,
+                trigger.value,
+                trigger.threshold,
+                charged,
+                receipt.provider,
+            )
+            return SLOPaymentDecision("paid", "ok", charged, receipt)
+
+    def _blocked(self, trigger: SLOTrigger, reason: str, amount: float) -> SLOPaymentDecision:
+        self._emit("SLO_PAYMENT_BLOCKED", trigger, amount, "blocked", error=reason)
+        logger.warning("SLO payment blocked (%s) for %s", reason, trigger.slo)
+        return SLOPaymentDecision("blocked", reason, amount)
+
+    def _emit(
+        self, event_type: str, trigger: SLOTrigger, amount: float, outcome: str, *, error: str = ""
+    ) -> None:
+        self._audit.emit(
+            event_type,
+            resource_url=f"slo://{trigger.signer}/{trigger.slo}",
+            amount_usd=amount,
+            outcome=outcome,
+            error_message=error or None,
+        )
+
+    @property
+    def consecutive_degradations(self) -> int:
+        return self._consecutive

--- a/src/presidio_x402/slo_policy.py
+++ b/src/presidio_x402/slo_policy.py
@@ -1,0 +1,83 @@
+"""SLO-payment spending policy (v0.7.0).
+
+:class:`SLOPaymentPolicy` extends :class:`~presidio_x402.policy_engine.PolicyConfig`
+with limits specific to *market-based SLO enforcement* — the agent paying for
+capacity upgrades when infrastructure degrades. Because it **is** a ``PolicyConfig``,
+it drops into a :class:`~presidio_x402.policy_engine.PolicyEngine` unchanged, so SLO
+capacity payments are also counted against the ordinary per-call / daily / per-endpoint
+budgets (one shared ledger). The SLO-specific caps below are a second, independent layer
+the :class:`~presidio_x402.slo_broker.SLOPaymentBroker` enforces *before* it pays — the
+primary mitigation for the "SLO-triggered spending drain" threat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .policy_engine import PolicyConfig, _decimal_usd
+
+
+@dataclass
+class SLOPaymentPolicy(PolicyConfig):
+    """Spending policy for SLO-triggered capacity payments."""
+
+    latency_threshold_ms: float = 200.0
+    """Self-measurement threshold: p99 latency above which the broker's own
+    ``get()`` path treats a request as degraded. Signed triggers from
+    arch-translucency carry their own threshold and are authoritative on the
+    event path; this governs the broker-measured path."""
+
+    max_per_slo_event_usd: float | None = None
+    """Hard cap on a single capacity-upgrade payment."""
+
+    cooldown_seconds: int = 300
+    """Minimum gap between consecutive SLO payments — the anti-drain control."""
+
+    max_daily_slo_usd: float | None = None
+    """Cap on SLO spend within ``window_seconds`` (separate from the general
+    ``daily_limit_usd``, which also still applies via the shared ledger)."""
+
+    tier_escalation_rules: tuple[float, ...] = ()
+    """Step-up multipliers for *consecutive* degradation events, applied to the
+    base event price. ``()`` → flat pricing (multiplier 1.0). Example
+    ``(1.0, 2.0, 4.0)`` charges 1×, 2×, then 4× for the 1st/2nd/3rd+ consecutive
+    degradation, so a flapping backend gets economically expensive fast."""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> SLOPaymentPolicy:
+        base = PolicyConfig.from_dict(data)
+        return cls(
+            max_per_call_usd=base.max_per_call_usd,
+            daily_limit_usd=base.daily_limit_usd,
+            per_endpoint=base.per_endpoint,
+            window_seconds=base.window_seconds,
+            agent_id=base.agent_id,
+            latency_threshold_ms=data.get("latency_threshold_ms", 200.0),
+            max_per_slo_event_usd=data.get("max_per_slo_event_usd"),
+            cooldown_seconds=data.get("cooldown_seconds", 300),
+            max_daily_slo_usd=data.get("max_daily_slo_usd"),
+            tier_escalation_rules=tuple(data.get("tier_escalation_rules", ())),
+        )
+
+    def escalation_multiplier(self, consecutive_index: int) -> float:
+        """Multiplier for the ``consecutive_index``-th consecutive degradation
+        (0-based), clamped to the last rule. Empty rules → ``1.0``."""
+        if not self.tier_escalation_rules:
+            return 1.0
+        i = max(0, min(consecutive_index, len(self.tier_escalation_rules) - 1))
+        return self.tier_escalation_rules[i]
+
+
+def validate_slo_policy(policy: SLOPaymentPolicy) -> None:
+    """Fail-closed config validation (raises ``ValueError`` on any bad limit)."""
+    if policy.latency_threshold_ms <= 0:
+        raise ValueError("latency_threshold_ms must be > 0")
+    if policy.cooldown_seconds < 0:
+        raise ValueError("cooldown_seconds must be >= 0")
+    if policy.max_per_slo_event_usd is not None:
+        _decimal_usd(policy.max_per_slo_event_usd, "max_per_slo_event_usd")
+    if policy.max_daily_slo_usd is not None:
+        _decimal_usd(policy.max_daily_slo_usd, "max_daily_slo_usd")
+    for i, multiplier in enumerate(policy.tier_escalation_rules):
+        if multiplier <= 0:
+            raise ValueError(f"tier_escalation_rules[{i}] must be > 0")

--- a/tests/test_arch_translucency_adapter.py
+++ b/tests/test_arch_translucency_adapter.py
@@ -1,0 +1,132 @@
+"""Tests for the arch-translucency adapter — the fail-closed verification gate
+that turns a signed degradation envelope into a trusted SLOTrigger (v0.7.0)."""
+
+from __future__ import annotations
+
+import pytest
+
+from presidio_x402.arch_translucency_adapter import (
+    DEFAULT_ARCH_SIGNER,
+    ArchTranslucencyAdapter,
+    SLOTriggerError,
+)
+from presidio_x402.mica import sha256_hex, sign_evidence
+
+ARCH_PRIV = "03" * 32
+OTHER_PRIV = "04" * 32
+
+
+def _ed25519_pub(priv_hex: str) -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    sk = ed25519.Ed25519PrivateKey.from_private_bytes(bytes.fromhex(priv_hex))
+    return (
+        sk.public_key()
+        .public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+        .hex()
+    )
+
+
+def _envelope(content: dict, *, signer: str, key: str, **ref_override) -> dict:
+    ch = sha256_hex(content)
+    sig = sign_evidence(ch, signer, algorithm="ed25519", key=key)
+    ref = {
+        "item_id": "SLO-DEGRADED",
+        "source": signer,
+        "source_version": "0.16.0",
+        "ledger_ref": "arch-translucency:slo/1",
+        "content_hash": ch,
+        "signer": signer,
+        "signature": sig,
+        "claimed_at": "2026-06-21T10:00:00+00:00",
+    }
+    ref.update(ref_override)
+    return {
+        "schema": "presidio-hardened/evidence-ref@1",
+        "evidence": [ref],
+        "attested_content": content,
+    }
+
+
+def _content(value: int = 420, threshold: int = 200) -> dict:
+    return {"slo": "p99_latency_ms", "value": value, "threshold": threshold, "window": "5m"}
+
+
+def _adapter(**kw) -> ArchTranslucencyAdapter:
+    pytest.importorskip("cryptography")
+    trust = {DEFAULT_ARCH_SIGNER: {"alg": "ed25519", "public_key": _ed25519_pub(ARCH_PRIV)}}
+    return ArchTranslucencyAdapter(trust, **kw)
+
+
+def test_valid_signed_envelope_yields_degraded_trigger():
+    adapter = _adapter()
+    env = _envelope(_content(420, 200), signer=DEFAULT_ARCH_SIGNER, key=ARCH_PRIV)
+    triggers = adapter.build_triggers(env)
+    assert len(triggers) == 1
+    t = triggers[0]
+    assert t.slo == "p99_latency_ms" and t.value == 420 and t.threshold == 200
+    assert t.degraded is True
+    assert t.signer == DEFAULT_ARCH_SIGNER
+    assert adapter.rejected == 0
+
+
+def test_non_degraded_envelope_is_verified_but_not_degraded():
+    adapter = _adapter()
+    env = _envelope(_content(120, 200), signer=DEFAULT_ARCH_SIGNER, key=ARCH_PRIV)
+    t = adapter.build_trigger_strict(env)
+    assert t.degraded is False  # verified, but no breach → broker will skip
+
+
+def test_tampered_content_fails_closed():
+    adapter = _adapter()
+    env = _envelope(_content(420, 200), signer=DEFAULT_ARCH_SIGNER, key=ARCH_PRIV)
+    # Mutate the content after signing → content_hash no longer matches.
+    env["attested_content"]["value"] = 9999
+    assert adapter.build_triggers(env) == []
+    assert adapter.rejected == 1
+
+
+def test_untrusted_signer_fails_closed():
+    adapter = _adapter()
+    # Signed by a key the trust store doesn't know.
+    env = _envelope(_content(), signer=DEFAULT_ARCH_SIGNER, key=OTHER_PRIV)
+    assert adapter.build_triggers(env) == []
+
+
+def test_expected_signers_allowlist_excludes_other_signer():
+    pytest.importorskip("cryptography")
+    # Trust store knows two signers, but adapter only expects the arch one.
+    trust = {
+        DEFAULT_ARCH_SIGNER: {"alg": "ed25519", "public_key": _ed25519_pub(ARCH_PRIV)},
+        "rogue": {"alg": "ed25519", "public_key": _ed25519_pub(OTHER_PRIV)},
+    }
+    adapter = ArchTranslucencyAdapter(trust, expected_signers=[DEFAULT_ARCH_SIGNER])
+    env = _envelope(_content(), signer="rogue", key=OTHER_PRIV)
+    assert adapter.build_triggers(env) == []
+
+
+def test_missing_attested_content_fails_closed():
+    adapter = _adapter()
+    env = _envelope(_content(), signer=DEFAULT_ARCH_SIGNER, key=ARCH_PRIV)
+    del env["attested_content"]
+    assert adapter.build_triggers(env) == []
+
+
+def test_strict_raises_when_no_verified_trigger():
+    adapter = _adapter()
+    env = _envelope(_content(), signer=DEFAULT_ARCH_SIGNER, key=OTHER_PRIV)
+    with pytest.raises(SLOTriggerError):
+        adapter.build_trigger_strict(env)
+
+
+def test_field_map_override():
+    pytest.importorskip("cryptography")
+    trust = {DEFAULT_ARCH_SIGNER: {"alg": "ed25519", "public_key": _ed25519_pub(ARCH_PRIV)}}
+    adapter = ArchTranslucencyAdapter(
+        trust, field_map={"value": "observed_ms", "threshold": "budget_ms"}
+    )
+    content = {"slo": "p99", "observed_ms": 500, "budget_ms": 200, "window": "1m"}
+    env = _envelope(content, signer=DEFAULT_ARCH_SIGNER, key=ARCH_PRIV)
+    t = adapter.build_trigger_strict(env)
+    assert t.value == 500 and t.threshold == 200 and t.degraded is True

--- a/tests/test_pii_provisioning.py
+++ b/tests/test_pii_provisioning.py
@@ -1,0 +1,58 @@
+"""Tests for the v0.7.0 provisioning-metadata PII entities.
+
+These are opt-in (kept out of the default active set) so the SLO broker can redact
+workload context before it reaches a third-party compute provider, without changing
+default PII behaviour for existing callers.
+"""
+
+from __future__ import annotations
+
+from presidio_x402.pii_filter import PROVISIONING_ENTITIES, PIIFilter
+
+
+def _types(filt: PIIFilter, text: str) -> set[str]:
+    _, entities = filt.scan_and_redact(text)
+    return {e.entity_type for e in entities}
+
+
+def test_provisioning_entities_are_off_by_default():
+    # Default filter must not flag provisioning markers (back-compat).
+    default = PIIFilter()
+    found = _types(default, "run ml-training on CONFIDENTIAL data: SELECT x FROM accounts")
+    assert "WORKLOAD_CLASS" not in found
+    assert "DATA_CLASSIFICATION" not in found
+    assert "QUERY_PATTERN" not in found
+
+
+def test_data_classification_redacted_when_opted_in():
+    filt = PIIFilter(entities=["DATA_CLASSIFICATION"])
+    redacted, entities = filt.scan_and_redact("tier=CONFIDENTIAL workload")
+    assert any(e.entity_type == "DATA_CLASSIFICATION" for e in entities)
+    assert "CONFIDENTIAL" not in redacted
+
+
+def test_workload_class_redacted_when_opted_in():
+    assert "WORKLOAD_CLASS" in _types(
+        PIIFilter(entities=["WORKLOAD_CLASS"]), "job: ml-training nightly"
+    )
+
+
+def test_query_pattern_redacted_when_opted_in():
+    assert "QUERY_PATTERN" in _types(
+        PIIFilter(entities=["QUERY_PATTERN"]),
+        "SELECT ssn, balance FROM customers WHERE region='eu'",
+    )
+
+
+def test_provisioning_and_structural_compose():
+    filt = PIIFilter(entities=["EMAIL_ADDRESS", "DATA_CLASSIFICATION"])
+    redacted, entities = filt.scan_and_redact("owner alice@example.com tier SECRET")
+    kinds = {e.entity_type for e in entities}
+    assert kinds == {"EMAIL_ADDRESS", "DATA_CLASSIFICATION"}
+    assert "alice@example.com" not in redacted and "SECRET" not in redacted
+
+
+def test_full_provisioning_set_selectable_via_constant():
+    filt = PIIFilter(entities=list(PROVISIONING_ENTITIES))
+    found = _types(filt, "ml-training over RESTRICTED rows: DELETE FROM logs WHERE old")
+    assert {"WORKLOAD_CLASS", "DATA_CLASSIFICATION", "QUERY_PATTERN"} <= found

--- a/tests/test_slo_broker.py
+++ b/tests/test_slo_broker.py
@@ -1,0 +1,185 @@
+"""Tests for SLOPaymentBroker — the evidence-gated SLO payment decision engine (v0.7.0)."""
+
+from __future__ import annotations
+
+import pytest
+
+from presidio_x402.arch_translucency_adapter import SLOTrigger
+from presidio_x402.exceptions import PolicyViolationError
+from presidio_x402.slo_broker import SLOPaymentBroker, UpgradeReceipt
+from presidio_x402.slo_policy import SLOPaymentPolicy
+
+ARCH = "presidio-hardened-arch-translucency"
+
+
+def _trigger(value: int = 420, threshold: int = 200) -> SLOTrigger:
+    return SLOTrigger(
+        slo="p99_latency_ms",
+        value=value,
+        threshold=threshold,
+        window="5m",
+        signer=ARCH,
+        content_hash="ab" * 16,
+        observed_at="2026-06-21T10:00:00+00:00",
+    )
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class _FakeProvider:
+    name = "fake"
+
+    def __init__(
+        self, ok: bool = True, charge: float | None = None, raises: Exception | None = None
+    ):
+        self.ok = ok
+        self.charge = charge
+        self.raises = raises
+        self.calls: list[float] = []
+
+    async def purchase_upgrade(self, trigger, *, max_usd: float) -> UpgradeReceipt:
+        self.calls.append(max_usd)
+        if self.raises is not None:
+            raise self.raises
+        amount = self.charge if self.charge is not None else max_usd
+        return UpgradeReceipt("fake", "https://compute.io/up", amount, self.ok, "detail")
+
+
+class _CapWriter:
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def write(self, event) -> None:
+        self.events.append(event)
+
+    def flush(self) -> None:
+        pass
+
+
+def _broker(policy=None, provider=None, base=0.10, clock=None, audit=None):
+    return SLOPaymentBroker(
+        client=object(),  # only the default provider touches the client; we inject our own
+        slo_policy=policy or SLOPaymentPolicy(),
+        provider=provider or _FakeProvider(),
+        base_event_usd=base,
+        audit_writer=audit,
+        clock=clock or _Clock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pays_on_degraded_trigger():
+    prov, cap = _FakeProvider(), _CapWriter()
+    broker = _broker(provider=prov, audit=cap)
+    decision = await broker.handle_trigger(_trigger())
+    assert decision.action == "paid"
+    assert decision.amount_usd == pytest.approx(0.10)
+    assert prov.calls == [pytest.approx(0.10)]
+    assert any(e.event_type == "SLO_PAYMENT_TRIGGERED" for e in cap.events)
+
+
+@pytest.mark.asyncio
+async def test_skips_non_degraded_trigger():
+    prov = _FakeProvider()
+    broker = _broker(provider=prov)
+    decision = await broker.handle_trigger(_trigger(value=100, threshold=200))
+    assert decision.action == "skipped"
+    assert prov.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cooldown_blocks_then_allows():
+    clock = _Clock()
+    pol = SLOPaymentPolicy(cooldown_seconds=300)
+    prov, cap = _FakeProvider(), _CapWriter()
+    broker = _broker(policy=pol, provider=prov, clock=clock, audit=cap)
+
+    assert (await broker.handle_trigger(_trigger())).action == "paid"
+    second = await broker.handle_trigger(_trigger())
+    assert second.action == "blocked" and "cooldown" in second.reason
+    assert any(e.event_type == "SLO_PAYMENT_BLOCKED" for e in cap.events)
+
+    clock.advance(301)
+    assert (await broker.handle_trigger(_trigger())).action == "paid"
+    assert len(prov.calls) == 2  # the blocked attempt never reached the provider
+
+
+@pytest.mark.asyncio
+async def test_tier_escalation_steps_up_price():
+    clock = _Clock()
+    pol = SLOPaymentPolicy(cooldown_seconds=300, tier_escalation_rules=(1.0, 2.0, 4.0))
+    prov = _FakeProvider()
+    broker = _broker(policy=pol, provider=prov, base=0.10, clock=clock)
+    for _ in range(3):
+        await broker.handle_trigger(_trigger())
+        clock.advance(301)
+    assert prov.calls == [pytest.approx(0.10), pytest.approx(0.20), pytest.approx(0.40)]
+
+
+@pytest.mark.asyncio
+async def test_per_event_cap_clamps_escalated_amount():
+    clock = _Clock()
+    pol = SLOPaymentPolicy(
+        cooldown_seconds=300, tier_escalation_rules=(1.0, 10.0), max_per_slo_event_usd=0.15
+    )
+    prov = _FakeProvider()
+    broker = _broker(policy=pol, provider=prov, base=0.10, clock=clock)
+    await broker.handle_trigger(_trigger())  # 0.10
+    clock.advance(301)
+    await broker.handle_trigger(_trigger())  # escalated 1.00 → capped 0.15
+    assert prov.calls == [pytest.approx(0.10), pytest.approx(0.15)]
+
+
+@pytest.mark.asyncio
+async def test_daily_slo_cap_blocks_when_exceeded():
+    pol = SLOPaymentPolicy(cooldown_seconds=0, max_daily_slo_usd=0.25)
+    prov = _FakeProvider()
+    broker = _broker(policy=pol, provider=prov, base=0.10)
+    assert (await broker.handle_trigger(_trigger())).action == "paid"  # 0.10
+    assert (await broker.handle_trigger(_trigger())).action == "paid"  # 0.20
+    third = await broker.handle_trigger(_trigger())  # 0.30 > 0.25
+    assert third.action == "blocked" and "daily SLO cap" in third.reason
+
+
+@pytest.mark.asyncio
+async def test_provider_decline_is_not_recorded():
+    pol = SLOPaymentPolicy(cooldown_seconds=0, max_daily_slo_usd=0.25)
+    prov = _FakeProvider(ok=False)
+    broker = _broker(policy=pol, provider=prov, base=0.10)
+    decision = await broker.handle_trigger(_trigger())
+    assert decision.action == "blocked" and "declined" in decision.reason
+    # A declined attempt must not consume the daily SLO budget.
+    prov.ok = True
+    assert (await broker.handle_trigger(_trigger())).action == "paid"
+
+
+@pytest.mark.asyncio
+async def test_client_policy_violation_blocks():
+    prov = _FakeProvider(raises=PolicyViolationError("over limit", amount_usd=1.0, limit_usd=0.5))
+    broker = _broker(provider=prov)
+    decision = await broker.handle_trigger(_trigger())
+    assert decision.action == "blocked" and "client policy" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_recovery_resets_escalation():
+    clock = _Clock()
+    pol = SLOPaymentPolicy(cooldown_seconds=300, tier_escalation_rules=(1.0, 2.0, 4.0))
+    prov = _FakeProvider()
+    broker = _broker(policy=pol, provider=prov, base=0.10, clock=clock)
+    await broker.handle_trigger(_trigger())  # 0.10, consecutive→1
+    clock.advance(301)
+    await broker.handle_trigger(_trigger(value=100))  # recovery → reset consecutive
+    assert broker.consecutive_degradations == 0
+    clock.advance(301)
+    await broker.handle_trigger(_trigger())  # back to base 0.10, not escalated
+    assert prov.calls == [pytest.approx(0.10), pytest.approx(0.10)]

--- a/tests/test_slo_broker_integration.py
+++ b/tests/test_slo_broker_integration.py
@@ -1,0 +1,103 @@
+"""Thin 402 integration test for the SLO broker (v0.7.0).
+
+Where ``test_slo_broker.py`` injects a fake provider, this exercises the one seam the
+unit tests stub: ``X402CapacityProvider`` driving a **real** ``HardenedX402Client``
+through an actual 402 → pay → 200 flow (respx-mocked endpoint). It proves the broker's
+default provider correctly settles a capacity payment and that the gateway's own
+controls run on it — the genuine code-risk in the broker→client→402-rail path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from presidio_x402._types import PaymentDetails, PaymentResponse
+from presidio_x402.arch_translucency_adapter import SLOTrigger
+from presidio_x402.audit_log import NullAuditWriter
+from presidio_x402.gateway import HardenedX402Client
+from presidio_x402.slo_broker import SLOPaymentBroker, X402CapacityProvider
+from presidio_x402.slo_policy import SLOPaymentPolicy
+
+CAPACITY_URL = "https://compute.local/v1/capacity"
+
+CAPACITY_OFFER = json.dumps(
+    {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base-sepolia",
+                "maxAmountRequired": "0.01",
+                "resource": CAPACITY_URL,
+                "description": "capacity upgrade",
+                "reason": "slo",
+                "mimeType": "application/json",
+                "payTo": "0xabcdef1234567890abcdef1234567890abcdef12",
+                "requiredDeadlineSeconds": 300,
+                "extra": {},
+            }
+        ]
+    }
+)
+
+
+async def _signer(details: PaymentDetails) -> PaymentResponse:
+    return PaymentResponse(token="signed-capacity-token", details=details)  # noqa: S106
+
+
+def _trigger() -> SLOTrigger:
+    return SLOTrigger(
+        slo="p99_latency_ms",
+        value=420,
+        threshold=200,
+        window="5m",
+        signer="presidio-hardened-arch-translucency",
+        content_hash="ab" * 16,
+        observed_at="2026-06-21T10:00:00+00:00",
+    )
+
+
+def _broker(client: HardenedX402Client) -> SLOPaymentBroker:
+    return SLOPaymentBroker(
+        client=client,
+        slo_policy=SLOPaymentPolicy(max_per_call_usd=0.05),
+        provider=X402CapacityProvider("compute-local", CAPACITY_URL, client),
+        base_event_usd=0.01,
+    )
+
+
+@pytest.mark.asyncio
+async def test_degrade_to_paid_drives_real_402_flow():
+    captured: dict[str, str] = {}
+
+    def _retry(request: httpx.Request) -> httpx.Response:
+        captured.update({k.lower(): v for k, v in request.headers.items()})
+        return httpx.Response(200, text="upgraded")
+
+    with respx.mock:
+        route = respx.post(CAPACITY_URL)
+        route.side_effect = [
+            httpx.Response(402, headers={"X-PAYMENT": CAPACITY_OFFER}),
+            _retry,
+        ]
+        async with HardenedX402Client(payment_signer=_signer, audit_writer=NullAuditWriter()) as c:
+            decision = await _broker(c).handle_trigger(_trigger())
+
+    assert decision.action == "paid"
+    assert decision.receipt is not None and decision.receipt.ok
+    # The capacity payment really went through the gateway's 402 settle + retry.
+    assert captured.get("x-payment") == "signed-capacity-token"
+
+
+@pytest.mark.asyncio
+async def test_provider_error_blocks_without_payment():
+    with respx.mock:
+        respx.post(CAPACITY_URL).mock(return_value=httpx.Response(500, text="provider down"))
+        async with HardenedX402Client(payment_signer=_signer, audit_writer=NullAuditWriter()) as c:
+            decision = await _broker(c).handle_trigger(_trigger())
+
+    # 5xx (no 402 offer) → no payment, provider declines, broker blocks fail-closed.
+    assert decision.action == "blocked"

--- a/tests/test_slo_policy.py
+++ b/tests/test_slo_policy.py
@@ -1,0 +1,66 @@
+"""Tests for SLOPaymentPolicy (v0.7.0)."""
+
+from __future__ import annotations
+
+import pytest
+
+from presidio_x402.policy_engine import PolicyConfig, PolicyEngine
+from presidio_x402.slo_policy import SLOPaymentPolicy, validate_slo_policy
+
+
+def test_is_a_policyconfig_and_drops_into_engine():
+    # Being a PolicyConfig subclass, it must configure a PolicyEngine unchanged so
+    # SLO spend shares the ordinary ledger.
+    pol = SLOPaymentPolicy(max_per_call_usd=0.50, daily_limit_usd=5.0)
+    assert isinstance(pol, PolicyConfig)
+    engine = PolicyEngine(pol)
+    engine.check_and_record(resource_url="https://compute.io/up", amount_usd=0.10)
+
+
+def test_from_dict_round_trips_base_and_slo_fields():
+    pol = SLOPaymentPolicy.from_dict(
+        {
+            "max_per_call_usd": 0.5,
+            "daily_limit_usd": 10.0,
+            "latency_threshold_ms": 150,
+            "max_per_slo_event_usd": 0.25,
+            "cooldown_seconds": 60,
+            "max_daily_slo_usd": 2.0,
+            "tier_escalation_rules": [1.0, 2.0, 4.0],
+        }
+    )
+    assert pol.max_per_call_usd == 0.5
+    assert pol.latency_threshold_ms == 150
+    assert pol.tier_escalation_rules == (1.0, 2.0, 4.0)
+
+
+def test_escalation_multiplier_clamps_to_last_rule():
+    pol = SLOPaymentPolicy(tier_escalation_rules=(1.0, 2.0, 4.0))
+    assert [pol.escalation_multiplier(i) for i in range(5)] == [1.0, 2.0, 4.0, 4.0, 4.0]
+
+
+def test_escalation_default_is_flat():
+    assert SLOPaymentPolicy().escalation_multiplier(7) == 1.0
+
+
+def test_validate_rejects_bad_limits():
+    with pytest.raises(ValueError):
+        validate_slo_policy(SLOPaymentPolicy(latency_threshold_ms=0))
+    with pytest.raises(ValueError):
+        validate_slo_policy(SLOPaymentPolicy(cooldown_seconds=-1))
+    with pytest.raises(ValueError):
+        validate_slo_policy(SLOPaymentPolicy(max_per_slo_event_usd=-0.1))
+    with pytest.raises(ValueError):
+        validate_slo_policy(SLOPaymentPolicy(tier_escalation_rules=(1.0, 0.0)))
+
+
+def test_validate_accepts_sane_policy():
+    validate_slo_policy(
+        SLOPaymentPolicy(
+            latency_threshold_ms=200,
+            cooldown_seconds=300,
+            max_per_slo_event_usd=0.5,
+            max_daily_slo_usd=10.0,
+            tier_escalation_rules=(1.0, 1.5),
+        )
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,15 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.34"
 source = { registry = "https://pypi.org/simple" }
@@ -140,6 +149,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3c/0d/559cdceb9f6acea6b91404970b7973e28a4434fa8a70eb1416b0af478d86/botocore-1.43.34.tar.gz", hash = "sha256:ccc973cf30c6445b30afe5760f6dc949a80f1f862cb23d9c45747f2c814ece77", size = 15591382, upload-time = "2026-06-19T19:33:28.561Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/ea/dc5aab38e2b3f63380810465fab92c836e9e8bce458eba4a8a896f25e1d2/botocore-1.43.34-py3-none-any.whl", hash = "sha256:238a0269f33c5914b9343900b44767e783b3e8b6dcb6e065eac8b4495601c5df", size = 15277590, upload-time = "2026-06-19T19:33:24.562Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -568,6 +595,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
+]
+
+[[package]]
 name = "cymem"
 version = "2.0.13"
 source = { registry = "https://pypi.org/simple" }
@@ -629,6 +672,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/01/ffe51729a8f961a437920560659073e47f575d4627445216c1177ecd4a41/cymem-2.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:666ce6146bc61b9318aa70d91ce33f126b6344a25cf0b925621baed0c161e9cc", size = 290465, upload-time = "2025-11-14T14:58:21.815Z" },
     { url = "https://files.pythonhosted.org/packages/fd/ac/c9e7d68607f71ef978c81e334ab2898b426944c71950212b1467186f69f9/cymem-2.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:84c1168c563d9d1e04546cb65e3e54fde2bf814f7c7faf11fc06436598e386d1", size = 46665, upload-time = "2025-11-14T14:58:23.512Z" },
     { url = "https://files.pythonhosted.org/packages/66/66/150e406a2db5535533aa3c946de58f0371f2e412e23f050c704588023e6e/cymem-2.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:e9027764dc5f1999fb4b4cabee1d0322c59e330c0a6485b436a68275f614277f", size = 39715, upload-time = "2025-11-14T14:58:24.773Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -844,6 +896,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -947,6 +1011,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/16/f70100614b69feb3ade7285f08c9c52d6cda0a5c03f3f5e2facd63acb211/msgpack-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c", size = 82926, upload-time = "2026-06-18T16:12:31.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3c/08ecd5cdfe4e2de43aec79062028ad0f7b2d9b1fea5430068c198ba570da/msgpack-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895", size = 82730, upload-time = "2026-06-18T16:12:32.894Z" },
+    { url = "https://files.pythonhosted.org/packages/19/9f/a70c9cb1a04ecc134005149367dcfe35d167284e8f65035a1e4156ad17b5/msgpack-1.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dabedcd0f23559f3596428c6589c1cd8c6eaed3a0d720795b07b0225d769203", size = 400729, upload-time = "2026-06-18T16:12:34.052Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7f/5ce020168cf0439041526e95aa068c722c016aee21624e331aeabeee2e8e/msgpack-1.2.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73", size = 407625, upload-time = "2026-06-18T16:12:35.239Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/fb7668ce0386819303047057aef6fc1da73b584291d9cff82b821744e2ef/msgpack-1.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01e2dd6c9b19d333a00282330cc8a73d38d8dabc306dc5b42cd668c3ac82e833", size = 377891, upload-time = "2026-06-18T16:12:36.684Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dc/9ebe654a73c3aed2e40aa6b52e3c2a02b5f53ef0085fa235a45d5b367f87/msgpack-1.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:350cb813d0af6e65d2f7ef0d729f7ff5be5a8bce03665892f43e5883d4ecc1b8", size = 391987, upload-time = "2026-06-18T16:12:37.839Z" },
+    { url = "https://files.pythonhosted.org/packages/42/eb/b67cf64218a2fa25e1c671fe1d3dbb06cbeb973e71bc4b822da079862d0b/msgpack-1.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ee1d9ed27d0497b848923746cf762ed2e7db24f4be7eec8e5cbe8c766aa707b7", size = 374603, upload-time = "2026-06-18T16:12:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2e/9ee200cde32fd1a0101b4006202fde554c1860adfb9bf7bff31ea4c08df8/msgpack-1.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:633727297ed063441fd1cda2288865487f33ad14eeb8831afb5f0c396a62cfce", size = 405121, upload-time = "2026-06-18T16:12:40.524Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b6/f10117be7ca7a51e8feed699a907b8e663a8cd66e115ae6b4fb30cc7945c/msgpack-1.2.1-cp310-cp310-win32.whl", hash = "sha256:298872ecf9e61950f1c6af4ca969b859ee91783bb920ef6e6172697d0c8aad74", size = 64088, upload-time = "2026-06-18T16:12:41.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/93/89976c696fb0224662239d952c47b4d1661b34d79a332ef5584facaa8579/msgpack-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:2ff164c1b0bcb740b073b99e945234d0212852fa378e44a208c425379140dbeb", size = 70113, upload-time = "2026-06-18T16:12:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6b/e9b1cdc042c4458801d2545ed782a95f3d6ba8e270cce8745b8603c7f748/msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22", size = 82812, upload-time = "2026-06-18T16:12:45.022Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3a/dd518a1bf78ed1e9ad8afe57307c079a00eafe4b3068932a27ca1ea56b4f/msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5", size = 82739, upload-time = "2026-06-18T16:12:46.025Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/7ba9e1542bf0771a27b8b37c1316e3f95ae9d748fd765284655c476ad4ef/msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06", size = 414233, upload-time = "2026-06-18T16:12:47.029Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/671d81534ea0e2b0e8a121be100020da09eb78861fe3aa8f3ef7dcd3bed1/msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4", size = 423843, upload-time = "2026-06-18T16:12:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b6/e5c737515ed1f166664b87601b532f58cbb73d8aa6a90b99f7c2c5037e8e/msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8", size = 390772, upload-time = "2026-06-18T16:12:49.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/46/62ed8c2e87d7021eab19921594d961ef3aa3794eec76c716dc30f3bfd433/msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b", size = 409559, upload-time = "2026-06-18T16:12:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/59aa3887b860bbf43532835e192b1c388a17590d6068ae4f8b2bc74c906e/msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e", size = 387838, upload-time = "2026-06-18T16:12:52.161Z" },
+    { url = "https://files.pythonhosted.org/packages/09/11/f8563e471093420cf6478cb3271a0175d8402b82d879783d4035d2d03360/msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f", size = 421732, upload-time = "2026-06-18T16:12:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cf/e673683c4c6c90c1022b24c65af4b03eda72b182a1176ef6449069d66acc/msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d", size = 64091, upload-time = "2026-06-18T16:12:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/ca212739d179f9083bff2c7c08c24101c3555a334fadc2b876b18768a3ae/msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8", size = 70462, upload-time = "2026-06-18T16:12:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/be/6798347b425e26f35db82e69dd83c09716c856a3714e7bffc4c0860fd830/msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66", size = 65059, upload-time = "2026-06-18T16:12:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
 ]
 
 [[package]]
@@ -1283,6 +1420,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1298,6 +1444,70 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/72/97fd1961e3d6f8323b1396669c346557a8581874e2c2a478a83dc5d616e7/phonenumbers-9.0.28.tar.gz", hash = "sha256:f1d810aaa43fbf3a5cb1ee54733218f8333a2a92c85c4d579a810403d6260a8c", size = 2298779, upload-time = "2026-04-13T14:19:50.741Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/bd/5e55cea252bf21402a2d5f2479edd7e24a4c9ebbe59f197080d0d4cd9093/phonenumbers-9.0.28-py2.py3-none-any.whl", hash = "sha256:ee8caabab4fd554efb6119e7b95cb69da40e0f04050611730eed839d93f39920", size = 2585077, upload-time = "2026-04-13T14:16:09.853Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -1398,7 +1608,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1410,6 +1620,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+audit = [
+    { name = "pip-audit" },
+]
 audit-s3 = [
     { name = "boto3" },
 ]
@@ -1459,6 +1672,7 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.28.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.28.0" },
+    { name = "pip-audit", marker = "extra == 'audit'", specifier = ">=2.7.0" },
     { name = "presidio-analyzer", specifier = ">=2.2.0" },
     { name = "presidio-anonymizer", specifier = ">=2.2.0" },
     { name = "prometheus-client", marker = "extra == 'dev'", specifier = ">=0.20.0" },
@@ -1472,7 +1686,7 @@ requires-dist = [
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
-provides-extras = ["nlp", "evidence", "redis", "audit-s3", "langchain", "crewai", "prometheus", "otel", "schema", "dev"]
+provides-extras = ["nlp", "evidence", "redis", "audit-s3", "audit", "langchain", "crewai", "prometheus", "otel", "schema", "dev"]
 
 [[package]]
 name = "prometheus-client"
@@ -1481,6 +1695,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -1601,6 +1827,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -2367,11 +2602,65 @@ wheels = [
 
 [[package]]
 name = "tomli"
-version = "2.0.2"
+version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096, upload-time = "2024-10-02T10:46:13.208Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237, upload-time = "2024-10-02T10:46:11.806Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Releases `presidio-hardened-x402` v0.7.0 with the SLO payment broker, SLO policy, arch-translucency evidence adapter, and provisioning PII entities.
- Remediates the third-party v0.7.0 audit notes: removes bare `assert` from the production-tree conformance runner, adds CI `pip-audit` over release extras, and records the audit remediation in `SECURITY-AUDIT-2026-06-21-v0.7.0.md`.
- Updates release docs, dependency lock, and publish workflow release-asset targeting.

## Root Cause / Release Gate

The third-party audit was a pass with low/info notes. This PR folds those notes into the source tree before the signed `v0.7.0` tag is published.

## Test Plan

- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m ruff format --check .`
- [x] `.venv/bin/python -m ruff check src/presidio_x402/conformance/runner.py --select S101 --isolated`
- [x] `/Users/vstantch/.local/bin/uv lock --check`
- [x] `/Users/vstantch/.local/bin/uv run --extra audit --extra evidence --extra redis --extra audit-s3 --extra langchain --extra prometheus --extra otel --extra schema pip-audit --progress-spinner=off --skip-editable`
- [x] `.venv/bin/python -m pytest tests/ -x -q --tb=short`
- [x] `.venv/bin/python -m presidio_x402.conformance`
- [x] `/Users/vstantch/.local/bin/uv build`
- [x] `/Users/vstantch/.local/bin/uv run --with twine python -m twine check dist/presidio_hardened_x402-0.7.0*`