### PR TITLE
Add screen_ref leg for composed-envelope screening pointer

### DIFF
--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -27,7 +27,12 @@ from __future__ import annotations
 import logging
 
 from ._types import PaymentProtocolBinding
-from .action_ref import compute_action_ref, format_action_ref_timestamp
+from .action_ref import (
+    compute_action_ref,
+    compute_screen_ref,
+    format_action_ref_timestamp,
+    format_screen_scope,
+)
 from .arch_translucency_adapter import ArchTranslucencyAdapter, SLOTrigger
 from .audit_log import AuditLog, FileAuditWriter, NullAuditWriter, StreamAuditWriter
 from .bindings.x402 import X402Binding
@@ -106,7 +111,9 @@ __all__ = [
     "ReplayGuard",
     "compute_fingerprint",
     "compute_action_ref",
+    "compute_screen_ref",
     "format_action_ref_timestamp",
+    "format_screen_scope",
     "AuditLog",
     "NullAuditWriter",
     "StreamAuditWriter",

--- a/src/presidio_x402/action_ref.py
+++ b/src/presidio_x402/action_ref.py
@@ -41,6 +41,18 @@ import hashlib
 import json
 import re
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# screen_ref scope grammar: ``presidio:x402.screen:<verdict>[:<entities>]``.
+# A ``screen_ref`` is an ``action_ref`` over a PII-screening *verdict* — the
+# pre-signing decision the gateway records before a payment leaves. It is the
+# sibling pointer offered alongside ``v_gate`` / ``mycelium_trail_id`` in the
+# composed envelope on x402-foundation/x402#2332.
+_SCREEN_SCOPE_PREFIX = "presidio:x402.screen"
+_SCREEN_ACTION_TYPE = "pii_screen"
 
 # RFC 3339 UTC, exactly 3 fractional (millisecond) digits, mandatory trailing
 # ``Z``. The spec closes JCS-determinism at the format level: one valid byte
@@ -112,3 +124,70 @@ def compute_action_ref(
         payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
     ).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
+
+
+def format_screen_scope(verdict: str, entities: Iterable[str] = ()) -> str:
+    """Build the canonical ``screen_ref`` scope segment for a PII verdict.
+
+    Returns ``presidio:x402.screen:<verdict>`` with, when *entities* is
+    non-empty, a trailing ``:<entities>`` segment of the **lexicographically
+    sorted, de-duplicated, comma-joined, space-free** entity types — the
+    normative rule from argentum-core ``docs/spec/action-ref.md`` §Scope
+    conventions (commit ``16dbc92``).
+
+    The sort is applied *here*, at the formatting boundary, precisely because
+    a screen's ``pii_entities_found`` comes out in **detection order**, which is
+    not guaranteed alphabetical. Canonicalising at emission is what stops two
+    honest implementations from diverging when one reports ``US_SSN`` before
+    ``EMAIL_ADDRESS``. A clean verdict (no PII) carries no entity segment::
+
+        format_screen_scope("PII_REDACTED", ["US_SSN", "EMAIL_ADDRESS"])
+        # -> "presidio:x402.screen:PII_REDACTED:EMAIL_ADDRESS,US_SSN"
+        format_screen_scope("clean-allow")
+        # -> "presidio:x402.screen:clean-allow"
+
+    Parameters
+    ----------
+    verdict:
+        Screening verdict label (``"PII_REDACTED"``, ``"PII_BLOCKED"``,
+        ``"clean-allow"``…). Must be non-empty and contain neither ``:`` nor
+        ``,`` (either would forge or split a scope segment).
+    entities:
+        Entity types found by the screen. Order and multiplicity are
+        irrelevant — they are sorted and de-duplicated. Pass nothing for a
+        clean verdict. No entity may contain ``,`` or ``:``.
+    """
+    if not verdict:
+        raise ValueError("screen verdict must be a non-empty string")
+    if ":" in verdict or "," in verdict:
+        raise ValueError(f"screen verdict must not contain ':' or ',' separators; got {verdict!r}")
+    canonical_entities = sorted(set(entities))
+    for entity in canonical_entities:
+        if "," in entity or ":" in entity:
+            raise ValueError(f"entity type must not contain ',' or ':' separators; got {entity!r}")
+    scope = f"{_SCREEN_SCOPE_PREFIX}:{verdict}"
+    if canonical_entities:
+        scope += ":" + ",".join(canonical_entities)
+    return scope
+
+
+def compute_screen_ref(
+    agent_id: str,
+    verdict: str,
+    entities: Iterable[str],
+    timestamp: str,
+) -> str:
+    """Compute the ``screen_ref`` for a PII-screening verdict.
+
+    A ``screen_ref`` is an :func:`compute_action_ref` over the fixed
+    ``action_type`` ``"pii_screen"`` and the canonical screen scope
+    (:func:`format_screen_scope`). It is the content-addressed pointer to the
+    screening *decision* — recorded before signing — that rides as a sibling of
+    ``v_gate`` and ``mycelium_trail_id`` in the composed envelope.
+
+    Parameters mirror :func:`compute_action_ref`; *verdict* and *entities* are
+    canonicalised into the scope, *timestamp* is the conformant
+    ``YYYY-MM-DDTHH:MM:SS.mmmZ`` string of the screening decision.
+    """
+    scope = format_screen_scope(verdict, entities)
+    return compute_action_ref(agent_id, _SCREEN_ACTION_TYPE, scope, timestamp)

--- a/tests/test_action_ref.py
+++ b/tests/test_action_ref.py
@@ -13,7 +13,12 @@ from datetime import datetime, timezone
 
 import pytest
 
-from presidio_x402.action_ref import compute_action_ref, format_action_ref_timestamp
+from presidio_x402.action_ref import (
+    compute_action_ref,
+    compute_screen_ref,
+    format_action_ref_timestamp,
+    format_screen_scope,
+)
 
 # --- Known-answer vectors (argentum-core mycelium-provider-protocol-v1) -------
 
@@ -110,3 +115,82 @@ def test_format_then_compute_roundtrip():
         compute_action_ref("nexus-agent-xa12.onrender.com", "oracle.signal", "BTC", ts)
         == "fdd7f810499f06be24355ca8e2bfb8c4b965cc80c838f41fa074683443d89f5a"
     )
+
+
+# --- screen_ref byte-match vectors -------------------------------------------
+# Lifted verbatim from argentum-core
+# examples/conformance/presidio/action-ref-v1.fixture.json (commit 16dbc92),
+# the byte-identical targets for the screen_ref leg of the composed envelope
+# on x402-foundation/x402#2332. action_type is the fixed "pii_screen"; scope
+# carries the lexicographically-sorted entity segment (rule normative since
+# 16dbc92). entities are passed in DETECTION order on purpose — the canonical
+# sort must happen inside compute_screen_ref, not at the call site.
+SCREEN_VECTORS = [
+    # id, verdict, entities (detection order), timestamp, expected
+    (
+        "presidio-x402-003",
+        "PII_REDACTED",
+        ["EMAIL_ADDRESS", "US_SSN"],
+        "2026-06-20T17:45:00.000Z",
+        "c832ef8610c6989f8c6f5cea51ac019b8ac9860e389110079a895e67595950a2",
+    ),
+    (
+        "presidio-x402-004",  # the vector that needed the sort fix (PII_BLOCKED)
+        "PII_BLOCKED",
+        ["US_SSN", "EMAIL_ADDRESS"],  # detection order reversed: sort must fix it
+        "2026-06-20T17:45:01.000Z",
+        "79509b33e9ad2bf7bf4f80bff2dd73d04e012204ae63bb1bbc1b9d052f337ef4",
+    ),
+    (
+        "presidio-x402-005",  # clean-allow: no entity segment at all
+        "clean-allow",
+        [],
+        "2026-06-20T17:45:02.000Z",
+        "d9f8ecb35fef996e58a72cee801c17b4ca40c3ed3dede89438830e7a4a8c911d",
+    ),
+]
+
+_SCREEN_AGENT_ID = "did:presidio:x402:agent-7f3a9c"
+
+
+@pytest.mark.parametrize("vid,verdict,entities,ts,expected", SCREEN_VECTORS)
+def test_screen_ref_byte_match(vid, verdict, entities, ts, expected):
+    assert compute_screen_ref(_SCREEN_AGENT_ID, verdict, entities, ts) == expected
+
+
+def test_screen_scope_sorts_entities_lexicographically():
+    # Detection order must not leak into the scope: US_SSN before EMAIL_ADDRESS
+    # canonicalizes to EMAIL_ADDRESS,US_SSN (E < U).
+    assert (
+        format_screen_scope("PII_BLOCKED", ["US_SSN", "EMAIL_ADDRESS"])
+        == "presidio:x402.screen:PII_BLOCKED:EMAIL_ADDRESS,US_SSN"
+    )
+
+
+def test_screen_scope_dedupes_entities():
+    # Multiplicity (two emails) must not leak into the canonical scope.
+    assert (
+        format_screen_scope("PII_REDACTED", ["EMAIL_ADDRESS", "EMAIL_ADDRESS", "US_SSN"])
+        == "presidio:x402.screen:PII_REDACTED:EMAIL_ADDRESS,US_SSN"
+    )
+
+
+def test_screen_scope_clean_allow_has_no_entity_segment():
+    assert format_screen_scope("clean-allow") == "presidio:x402.screen:clean-allow"
+
+
+def test_screen_scope_rejects_empty_verdict():
+    with pytest.raises(ValueError, match="non-empty"):
+        format_screen_scope("")
+
+
+@pytest.mark.parametrize("bad_verdict", ["PII:REDACTED", "PII,REDACTED"])
+def test_screen_scope_rejects_separator_in_verdict(bad_verdict):
+    # Both ':' and ',' would forge or split a scope segment; reject either.
+    with pytest.raises(ValueError, match="separator"):
+        format_screen_scope(bad_verdict, ["EMAIL_ADDRESS"])
+
+
+def test_screen_scope_rejects_separator_in_entity():
+    with pytest.raises(ValueError, match="separator"):
+        format_screen_scope("PII_REDACTED", ["EMAIL,ADDRESS"])


### PR DESCRIPTION
## Summary
- Wires `compute_screen_ref` / `format_screen_scope`: a PII-screening verdict gets a content-addressed `action_ref`, the sibling pointer offered alongside `v_gate` and `mycelium_trail_id` on [x402-foundation/x402#2332](https://github.com/x402-foundation/x402/issues/2332).
- Canonicalises the entity segment at the **emission boundary** (lexicographically sorted, de-duplicated, comma-joined, no spaces) so the screen's detection-order `pii_entities_found` cannot leak into the digest and make two honest implementations diverge.
- Verdict and entity values reject the `:` and `,` separators that would forge or split a scope segment.

## Test plan
- [x] Byte-identical to argentum-core `presidio-x402-003/004/005` at `16dbc92` (incl. `-004` fed reversed detection order to prove the sort)
- [x] Scope canonicalisation: sort, dedupe, clean-allow (no entity segment), separator-rejection
- [x] `ruff check .` + `ruff format --check .` clean
- [x] Full suite green
