### PR TITLE
Add weekly OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+name: Scorecard supply-chain security
+
+# OpenSSF Scorecard — weekly supply-chain posture check.
+# Target score >= 7.0 (see sdlc/supply-chain.md). Results are published to the
+# repo Security tab (code scanning) and to the public OpenSSF results store; a
+# dip below target is triaged into the risk register.
+
+on:
+  # Re-run when branch-protection settings change (a Scorecard input).
+  branch_protection_rule:
+  schedule:
+    - cron: "40 6 * * 1" # Mondays 06:40 UTC
+  push:
+    branches: ["main"]
+
+# Least privilege by default; the analysis job elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # OIDC for publish_results to the OpenSSF store
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the public OpenSSF store so the score is externally
+          # verifiable and a Scorecard badge can be rendered.
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Wire a pinned `ossf/scorecard-action` workflow (`.github/workflows/scorecard.yml`) that runs every Monday and on `branch_protection_rule` changes.
- Publishes results to the Security tab (code scanning) and the public OpenSSF store; target score **≥ 7.0**, dips triaged into the risk register.
- Closes the gap where the SDLC docs documented Scorecard as "runs weekly" but it was never actually scheduled. supply-chain.md §6 wording corrected to match.

## Test plan
- [ ] CI green (all actions SHA-pinned per repo convention)
- [ ] First scheduled/`push` run produces a SARIF upload under Security → Code scanning