### PR TITLE
Set top-level read-only permissions on CI and CodeQL workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: read-only token for all jobs (OpenSSF Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "30 5 * * 1"
 
+# Least privilege: read-only token at the top level (OpenSSF Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (Python)


### PR DESCRIPTION
## Summary
- Add explicit top-level `permissions: contents: read` to `ci.yml` and `codeql.yml` — the two workflows OpenSSF Scorecard flagged as having no declared token scope (Token-Permissions = 0).
- Least-privilege default; no job loses any permission it needs.

## Test plan
- [ ] CI green
- [ ] Next Scorecard run shows Token-Permissions recovering from 0