### PR TITLE
Remediate Scorecard SAST, Signed-Releases, Branch-Protection

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,10 @@
 name: CodeQL
 
+# Real CodeQL analysis (free on public repos) uploads results to code scanning,
+# which OpenSSF Scorecard recognises as a SAST tool. Bandit is kept as a second,
+# fast Python-specific SAST pass — it is the *only* SAST on the private mirror,
+# where CodeQL is not available on the free tier.
+
 on:
   push:
     branches: [main]
@@ -14,12 +19,37 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (Python)
+    name: CodeQL Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload CodeQL results to code scanning
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          category: "/language:python"
+
+  bandit:
+    name: Bandit SAST
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,15 +41,22 @@ jobs:
           python -m pip install dist/*.whl
           cyclonedx-py environment --output-format JSON --output-file sbom.cdx.json
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: dist/*
+      - name: Stage provenance bundle as a release asset
+        # Copy the Sigstore/in-toto attestation bundle to a named file so it can
+        # be attached to the GitHub Release. OpenSSF Scorecard's Signed-Releases
+        # check inspects release assets and recognises `.intoto.jsonl` provenance.
+        run: cp "${{ steps.attest.outputs.bundle-path }}" provenance.intoto.jsonl
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts
           path: |
             dist/
             sbom.cdx.json
+            provenance.intoto.jsonl
 
   publish:
     name: Publish to PyPI (Trusted Publishing)
@@ -87,9 +94,9 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           if gh release view "$GITHUB_REF_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" dist/* sbom.cdx.json --repo "$GH_REPO" --clobber
+            gh release upload "$GITHUB_REF_NAME" dist/* sbom.cdx.json provenance.intoto.jsonl --repo "$GH_REPO" --clobber
           else
-            gh release create "$GITHUB_REF_NAME" dist/* sbom.cdx.json \
+            gh release create "$GITHUB_REF_NAME" dist/* sbom.cdx.json provenance.intoto.jsonl \
               --repo "$GH_REPO" \
               --verify-tag \
               --title "$GITHUB_REF_NAME" \

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # The default GITHUB_TOKEN cannot read branch-protection rules, so the
+          # Branch-Protection check errors. A fine-grained PAT (admin:read on this
+          # repo) stored as SCORECARD_TOKEN lets that check score; falls back to
+          # the default token when the secret is absent (non-breaking).
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
           # Publish to the public OpenSSF store so the score is externally
           # verifiable and a Scorecard badge can be rendered.
           publish_results: true


### PR DESCRIPTION
Closes the three fixable OpenSSF Scorecard gaps from the 2026-06-26 baseline (aggregate 5.3).

## Summary
- **SAST (0 → real CodeQL):** `codeql.yml` now runs actual CodeQL analysis (free on public repos), uploading to code scanning, alongside the existing bandit pass. The repo previously ran *only* bandit under the CodeQL name, so Scorecard saw no SAST tool.
- **Signed-Releases (0 → provenance attached):** `publish.yml` attaches the in-toto provenance bundle (`provenance.intoto.jsonl`) to the GitHub Release. Takes effect at the next release (≥ v0.8.0). The PyPI Sigstore/PEP 740 attestation was invisible to Scorecard, which only inspects Release assets.
- **Branch-Protection (error → token-ready):** scorecard-action now receives `repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}`. Non-breaking — falls back to the default token until the fine-grained PAT secret is added.

## Follow-up (human action)
Branch-Protection only scores once `SCORECARD_TOKEN` exists: create a fine-grained PAT (this repo, **Administration: read** + **Contents: read**) and `gh secret set SCORECARD_TOKEN`.

## Test plan
- [ ] CI green; CodeQL `analyze` job uploads a result to Security → Code scanning
- [ ] Next Scorecard run: SAST > 0, Token-Permissions recovered
- [ ] Next release attaches `provenance.intoto.jsonl`