### PR TITLE
Redact URL before missing-header warning log (CodeQL high)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,6 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      security-events: write # upload SARIF to code scanning
       id-token: write # OIDC for publish_results to the OpenSSF store
     steps:
       - name: Checkout code
@@ -43,14 +42,13 @@ jobs:
           # verifiable and a Scorecard badge can be rendered.
           publish_results: true
 
+      # SARIF is published to the OpenSSF store (publish_results) and rendered via
+      # the README badge; it is deliberately NOT uploaded to GitHub code scanning,
+      # which would flood the Security tab with posture-check findings already
+      # tracked by the score. Kept as a build artifact for debugging only.
       - name: Upload SARIF artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
-
-      - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
-        with:
-          sarif_file: results.sarif

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -287,11 +287,12 @@ class HardenedX402Client:
 
         offer = self._binding.payment_offer(resp.status_code, resp.headers)  # type: ignore[arg-type]
         if not offer:
+            safe_url, _ = self._pii_filter.scan_and_redact(url)
             logger.warning(
                 "%s response missing %s header from %s",
                 self._binding.payment_required_status,
                 self._binding.header_name,
-                url,
+                safe_url,
             )
             return resp
 


### PR DESCRIPTION
## Summary
- **Fix CodeQL #21** (`py/clear-text-logging-sensitive-data`, high): the missing-payment-header warning in `gateway.py` logged the raw request URL, which can carry PII in slugs/query — the exposure this library exists to prevent. Redact with `scan_and_redact` first, matching the existing `PAYMENT_ERROR` path a few lines down. CodeQL will auto-close the alert on its next run.
- **Quiet the Security tab**: stop uploading the Scorecard SARIF to code scanning. It flooded the tab with posture-check findings (Pinned-Deps, Code-Review, …) already tracked by the score + badge. Score still publishes to the OpenSSF store; SARIF kept as a build artifact only.

## Test plan
- [x] ruff check + format clean
- [x] full pytest suite green
- [ ] CI green; CodeQL re-run closes alert #21