### PR TITLE
action_ref: reject empty entity types + NFC-normalize fields (audit F1, F2)

### DIFF
--- a/src/presidio_x402/action_ref.py
+++ b/src/presidio_x402/action_ref.py
@@ -14,12 +14,13 @@ external service. A Mycelium/ARGENTUM "provider" integration (an optional
 
 Spec: argentum-core ``docs/spec/action-ref.md`` (stable ref ``action-ref-v1.0``).
 
-.. note:: Safe band
+.. note:: Canonicalisation
 
-   The :func:`json.dumps` canonicalisation below is RFC 8785-compatible for the
-   input shapes this primitive targets: ASCII field values and conformant
-   ``YYYY-MM-DDTHH:MM:SS.mmmZ`` timestamps. For non-ASCII or surrogate-pair
-   field values, use an RFC 8785 library to guarantee byte-level portability.
+   The :func:`json.dumps` canonicalisation below is RFC 8785-compatible: string
+   fields are NFC-normalised before hashing (so NFD-form Unicode yields the same
+   digest a normalising verifier computes), and timestamps are pinned to the
+   conformant ``YYYY-MM-DDTHH:MM:SS.mmmZ`` form. NFC is a no-op for the ASCII
+   inputs this primitive targets (DIDs, ``payment.send``, ASCII scopes).
 
 Usage::
 
@@ -40,6 +41,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import unicodedata
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -112,10 +114,13 @@ def compute_action_ref(
             "timestamp must be RFC 3339 UTC with exactly 3 millisecond digits "
             f"and a trailing 'Z' (YYYY-MM-DDTHH:MM:SS.mmmZ); got {timestamp!r}"
         )
+    # NFC-normalise the string fields so a caller passing NFD-form Unicode yields the
+    # same digest as an RFC 8785 verifier (which normalises to NFC). No-op for ASCII
+    # inputs (DIDs, ``payment.send``, ASCII scopes), so existing digests are unchanged.
     payload = {
-        "agent_id": agent_id,
-        "action_type": action_type,
-        "scope": scope,
+        "agent_id": unicodedata.normalize("NFC", agent_id),
+        "action_type": unicodedata.normalize("NFC", action_type),
+        "scope": unicodedata.normalize("NFC", scope),
         "timestamp": timestamp,
     }
     # JCS (RFC 8785): lexicographic key order, no inter-token whitespace, UTF-8.
@@ -163,6 +168,8 @@ def format_screen_scope(verdict: str, entities: Iterable[str] = ()) -> str:
         raise ValueError(f"screen verdict must not contain ':' or ',' separators; got {verdict!r}")
     canonical_entities = sorted(set(entities))
     for entity in canonical_entities:
+        if not entity:
+            raise ValueError("entity type must be a non-empty string")
         if "," in entity or ":" in entity:
             raise ValueError(f"entity type must not contain ',' or ':' separators; got {entity!r}")
     scope = f"{_SCREEN_SCOPE_PREFIX}:{verdict}"

--- a/tests/test_action_ref.py
+++ b/tests/test_action_ref.py
@@ -194,3 +194,30 @@ def test_screen_scope_rejects_separator_in_verdict(bad_verdict):
 def test_screen_scope_rejects_separator_in_entity():
     with pytest.raises(ValueError, match="separator"):
         format_screen_scope("PII_REDACTED", ["EMAIL,ADDRESS"])
+
+
+def test_screen_scope_rejects_empty_entity():
+    # F1 (audit 2026-06-28): an empty entity would emit a trailing-colon scope
+    # ("presidio:x402.screen:PII_REDACTED:") that no verifier can reproduce.
+    with pytest.raises(ValueError, match="non-empty"):
+        format_screen_scope("PII_REDACTED", [""])
+
+
+def test_compute_screen_ref_rejects_empty_entity():
+    with pytest.raises(ValueError, match="non-empty"):
+        compute_screen_ref(_SCREEN_AGENT_ID, "PII_REDACTED", [""], "2026-06-28T19:30:00.000Z")
+
+
+def test_action_ref_nfc_normalises_unicode_fields():
+    # F2 (audit 2026-06-28): NFD- and NFC-form inputs must hash identically, so a
+    # non-ASCII field can't produce an action_ref only one verifier accepts.
+    import unicodedata
+
+    ts = "2026-06-28T19:30:00.000Z"
+    nfc = unicodedata.normalize("NFC", "café")  # 'é' as U+00E9
+    nfd = unicodedata.normalize("NFD", "café")  # 'e' + combining acute U+0301
+    assert nfc != nfd  # distinct byte sequences before normalisation
+    assert compute_action_ref(nfd, "pii_screen", "x", ts) == compute_action_ref(
+        nfc, "pii_screen", "x", ts
+    )
+    # ASCII determinism is unaffected — guarded by the published-vector byte-match tests above.


### PR DESCRIPTION
Remediates the two LOW findings from the 2026-06-28 Felix x402 audit, both in `action_ref.py`.

## Summary
- **F1 (new, CWE-20):** `format_screen_scope` now raises `ValueError` on empty-string entity types — previously `entities=[""]` produced the malformed scope `presidio:x402.screen:PII_REDACTED:` (trailing colon) that no conformant verifier can reproduce.
- **F2 (carried, CWE-20):** `compute_action_ref` NFC-normalizes `agent_id`/`action_type`/`scope` before hashing, closing the RFC 8785 byte-portability gap for non-ASCII inputs. **No-op for ASCII**, so the published `presidio-x402-003/004/005` vectors and the live composed-envelope digests (`a6b5cf6e…`) are unchanged. Docstring "Safe band" caveat updated.

## Test plan
- [x] New tests: empty-entity rejection (`format_screen_scope` + `compute_screen_ref`), NFC≡NFD digest equality
- [x] Published-vector byte-match tests still pass (ASCII digests unchanged)
- [x] ruff clean; full suite 501 passed / 1 skipped