### PR TITLE
pii_filter: NLP mode is a superset of regex (register structural recognizers)

### DIFF
--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -218,6 +218,14 @@ _PROVISIONING_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 # Lookup pool for opt-in selection: structural defaults + provisioning entities.
 _ALL_PATTERNS: list[tuple[str, re.Pattern[str]]] = _REGEX_PATTERNS + _PROVISIONING_PATTERNS
 
+# Confidence assigned to our structural pattern recognizers when they augment the
+# spaCy NER in NLP mode. High, because these are validated structural patterns —
+# and crucially *above* any reasonable ``min_score`` so that SSNs/phones are not
+# silently dropped (Presidio's predefined US_SSN/PHONE recognizers score plain
+# dashed patterns ~0.05). Kept below 1.0 (the regex-mode certainty) to leave NER
+# room and signal "pattern, not validated value".
+_STRUCTURAL_NLP_SCORE = 0.85
+
 
 @dataclass
 class EntityResult:
@@ -267,12 +275,34 @@ class PIIFilter:
 
     def _init_presidio_nlp(self) -> None:
         try:
-            from presidio_analyzer import AnalyzerEngine
+            from presidio_analyzer import AnalyzerEngine, Pattern, PatternRecognizer
             from presidio_anonymizer import AnonymizerEngine
 
             self._analyzer = AnalyzerEngine()
+            # NLP mode must be a SUPERSET of regex mode: register our high-confidence
+            # structural recognizers alongside the spaCy NER. Without this, the *paid*
+            # NLP tier silently misses SSNs and phone numbers that the free regex tier
+            # catches, because Presidio's predefined US_SSN/PHONE recognizers score
+            # plain dashed patterns ~0.05 — below ``min_score``. (See _STRUCTURAL_NLP_SCORE.)
+            for _name, _compiled in _REGEX_PATTERNS:
+                _rx = _compiled.pattern
+                if _compiled.flags & re.IGNORECASE:
+                    _rx = "(?i)" + _rx
+                self._analyzer.registry.add_recognizer(
+                    PatternRecognizer(
+                        supported_entity=_name,
+                        name=f"PresidioHardenedStructural-{_name}",
+                        patterns=[
+                            Pattern(
+                                name=f"{_name} (structural)",
+                                regex=_rx,
+                                score=_STRUCTURAL_NLP_SCORE,
+                            )
+                        ],
+                    )
+                )
             self._anonymizer = AnonymizerEngine()
-            logger.debug("PIIFilter initialized in NLP mode")
+            logger.debug("PIIFilter initialized in NLP mode (NER + structural recognizers)")
         except ImportError as exc:
             raise ImportError(
                 "NLP mode requires: pip install presidio-hardened-x402[nlp] "

--- a/tests/test_pii_filter.py
+++ b/tests/test_pii_filter.py
@@ -241,6 +241,56 @@ class TestPIIFilterRegexMode:
         assert entities[0].entity_type == "EMAIL_ADDRESS"
         assert entities[0].original_text == "alice@example.com"
 
+    def test_nlp_mode_registers_structural_recognizers(self, monkeypatch):
+        # Regression: NLP mode must be a SUPERSET of regex mode. Presidio's predefined
+        # US_SSN/PHONE recognizers score plain dashed patterns ~0.05 (below min_score),
+        # so without registering our high-confidence structural recognizers the *paid*
+        # NLP tier silently misses SSNs and phone numbers the free regex tier catches.
+        from presidio_x402.pii_filter import _REGEX_PATTERNS, _STRUCTURAL_NLP_SCORE
+
+        registered = []
+
+        class FakePattern:
+            def __init__(self, *, name, regex, score):
+                self.name, self.regex, self.score = name, regex, score
+
+        class FakePatternRecognizer:
+            def __init__(self, *, supported_entity, name, patterns):
+                self.supported_entity = supported_entity
+                self.patterns = patterns
+
+        class FakeRegistry:
+            def add_recognizer(self, rec):
+                registered.append(rec)
+
+        class FakeAnalyzer:
+            def __init__(self):
+                self.registry = FakeRegistry()
+
+        monkeypatch.setitem(
+            sys.modules,
+            "presidio_analyzer",
+            types.SimpleNamespace(
+                AnalyzerEngine=FakeAnalyzer,
+                Pattern=FakePattern,
+                PatternRecognizer=FakePatternRecognizer,
+            ),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "presidio_anonymizer",
+            types.SimpleNamespace(AnonymizerEngine=lambda: object()),
+        )
+
+        PIIFilter(mode="nlp")
+
+        got = {r.supported_entity: r.patterns[0].score for r in registered}
+        expected = {name for name, _ in _REGEX_PATTERNS}
+        assert expected <= set(got), f"missing structural recognizers: {expected - set(got)}"
+        # the two the bare AnalyzerEngine specifically dropped
+        assert "US_SSN" in got and "PHONE_NUMBER" in got
+        assert all(score == _STRUCTURAL_NLP_SCORE for score in got.values())
+
     def test_nlp_scan_returns_original_text_when_all_results_below_threshold(self, monkeypatch):
         class FakeOperatorConfig:
             def __init__(self, operator_name, params):

--- a/tests/test_pii_filter.py
+++ b/tests/test_pii_filter.py
@@ -279,7 +279,7 @@ class TestPIIFilterRegexMode:
         monkeypatch.setitem(
             sys.modules,
             "presidio_anonymizer",
-            types.SimpleNamespace(AnonymizerEngine=lambda: object()),
+            types.SimpleNamespace(AnonymizerEngine=object),
         )
 
         PIIFilter(mode="nlp")


### PR DESCRIPTION
## Problem
NLP mode (`PIIFilter(mode="nlp")`) used a bare `AnalyzerEngine()`, so structural PII detection relied on Presidio's predefined recognizers. Presidio scores plain dashed `US_SSN`/`PHONE_NUMBER` patterns ~0.05 — below `min_score` — so they were silently dropped. The **paid NLP Standard tier was therefore weaker on SSN/phone than the free regex tier** (a tier inversion), surfaced by the v0.8.0 live settle test.

## Fix
Register our high-confidence structural pattern recognizers (the `_REGEX_PATTERNS` set, score `_STRUCTURAL_NLP_SCORE=0.85`) into the NLP analyzer's registry, so **`nlp = structural patterns ∪ spaCy NER`** — a true superset. The docstring already promised this; the code now delivers it.

## Validation
Against the live spaCy model (deployed image): `"…SSN 123-45-6789, card 4111…, call 415-555-0132, email j@acme.example"` → all of `US_SSN, PHONE_NUMBER, CREDIT_CARD, EMAIL_ADDRESS, PERSON` redacted (previously only `CREDIT_CARD, PERSON`).

## Test plan
- [x] New `test_nlp_mode_registers_structural_recognizers` (mocks presidio; asserts US_SSN/PHONE + all structural registered at the high score)
- [x] ruff clean; full suite 502 passed / 1 skipped
- Found during the v0.8.0 pre-release validation; **held for the codex audit** before tag/publish.