### PR TITLE
Docs + version bump for v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 No unreleased changes.
 
+## [0.8.0] — 2026-06-29
+
+PII-completeness, byte-determinism, and supply-chain hardening (library). The
+headline change: NLP mode is now a structural **superset** of regex, so the
+high-accuracy engine can no longer silently miss the structured identifiers
+(SSN, phone, credit card, …) that the zero-setup regex engine already caught.
+
+### Added
+- **`screen_ref` leg** for composed-envelope screening pointers — a signed,
+  PII-free screening verdict block that other parties can canonicalize and
+  countersign alongside their own evidence refs.
+
+### Changed
+- **`pii_filter.py` — NLP mode is a superset of regex.** `mode="nlp"` now
+  registers the structural pattern recognizers (`US_SSN`, `PHONE_NUMBER`,
+  `CREDIT_CARD`, `EMAIL_ADDRESS`, `IBAN`, `IP_ADDRESS`) on top of the spaCy NER
+  pipeline, so it detects every entity regex mode does *plus* the NER entities.
+  Previously a bare `AnalyzerEngine` scored some structured identifiers below
+  threshold and let them through. The default zero-setup `mode="regex"` is
+  unchanged; `mode="nlp"` still requires the spaCy model extra.
+
+### Security
+- **`action_ref.py`** rejects empty entity-type sets and NFC-normalizes its
+  fields before hashing, closing two byte-determinism gaps so the same action
+  always yields the same `action_ref` (audit F1/F2).
+- **Log hygiene:** the missing-payment-header warning redacts the resource URL
+  before logging, so a PII-bearing URL cannot reach a log sink.
+- **Supply chain:** weekly OpenSSF Scorecard workflow + README badge; Scorecard
+  Token-Permissions / SAST / Signed-Releases / Branch-Protection remediations;
+  SLSA Build L3 provenance documented.
+- **Independent multi-round security audit** of the v0.8.0 release cycle —
+  library scope cleared (PII recognizer completeness, `action_ref` determinism,
+  log hygiene, supply chain) with no Critical/High/Medium findings; see
+  [`SECURITY-AUDIT-2026-06-29-v0.8.0.md`](SECURITY-AUDIT-2026-06-29-v0.8.0.md).
+
 ## [0.7.0] — 2026-06-21
 
 Market-based SLO enforcement (library). The agent becomes an economic actor that

--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -436,6 +436,44 @@ contain. This is why v0.6.0 evidence Phase-A (the `mica` verifier) was a hard pr
 
 ---
 
+## v0.8.0 Requirements (PII completeness + supply-chain hardening) — **library delivered 2026-06-29**
+
+A correctness-and-hardening milestone. No new payment surface; the focus is closing
+a screening-completeness gap, byte-determinism of the attribution primitive, log
+hygiene, and measured supply-chain provenance.
+
+### Delivered
+
+- [x] **NLP mode is a structural superset of regex** — `PIIFilter(mode="nlp")` registers
+  the structural recognizers (`US_SSN`, `PHONE_NUMBER`, `CREDIT_CARD`, `EMAIL_ADDRESS`,
+  `IBAN`, `IP_ADDRESS`) on top of the spaCy NER pipeline, so the high-accuracy engine
+  detects everything regex mode does plus the NER entities. Closes the gap where a bare
+  `AnalyzerEngine` scored some structured identifiers below threshold and let them
+  through. Default `mode="regex"` behaviour is unchanged.
+
+- [x] **`screen_ref` leg** — a signed, PII-free screening verdict block for
+  composed-envelope screening pointers, which other parties can canonicalize and
+  countersign alongside their own evidence refs.
+
+- [x] **`action_ref` byte-determinism** — rejects empty entity-type sets and
+  NFC-normalizes fields before hashing so the same action always yields the same ref
+  (audit F1/F2).
+
+- [x] **Log hygiene** — the missing-payment-header warning redacts the resource URL
+  before logging.
+
+- [x] **Supply-chain provenance** — weekly OpenSSF Scorecard workflow + README badge;
+  Scorecard Token-Permissions / SAST / Signed-Releases / Branch-Protection
+  remediations; SLSA Build L3 provenance documented.
+
+### Verification
+
+Independent multi-round security audit cleared the library scope (GO, no open
+Critical/High/Medium findings); see
+[`SECURITY-AUDIT-2026-06-29-v0.8.0.md`](SECURITY-AUDIT-2026-06-29-v0.8.0.md).
+
+---
+
 ## Security Model
 
 The threat model for presidio-hardened-x402 addresses the following adversaries:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml/badge.svg)](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/presidio-v/presidio-hardened-x402/badge)](https://securityscorecards.dev/viewer/?uri=github.com/presidio-v/presidio-hardened-x402)
 
-> v0.7.0 — market-based SLO enforcement: signed arch-translucency degradation evidence becomes a verified x402 capacity-payment trigger, with cooldowns, spend caps, provisioning redaction, and pluggable capacity providers.
+> v0.8.0 — NLP screening is now a structural superset of regex (the high-accuracy engine no longer misses structured identifiers like SSN/phone/card), plus a composed-envelope `screen_ref` leg, `action_ref` byte-determinism, URL-redacted log hygiene, and OpenSSF Scorecard / SLSA Build L3 supply-chain hardening.
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -427,7 +427,8 @@ All exceptions are importable from `presidio_x402`.
 | v0.4.0 | **Screening API launch** — hosted [`screen.presidio-group.eu`](https://screen.presidio-group.eu) free tier (regex mode, 100 req/day) · `ScreeningClient` + `remote_screening=True` mode · per-origin `pay_to` allowlist (chain-06 mitigation) · audit-cycle hardening (F-A/B 2026-05-03, F-C/D/E 2026-05-10, F1/F2/F3 2026-05-17); see [`CHANGELOG.md`](CHANGELOG.md) |
 | v0.5.0 | **OEM embed kit** — rail-agnostic `ScreeningPipeline` core + `bindings/x402` layer (`PaymentProtocolBinding` protocol, hedge against rail fragmentation: ACP/Tempo, AP2) · [SEMVER.md](SEMVER.md) stability guarantees · partner conformance suite (`python -m presidio_x402.conformance`) · CDP/LangChain/CrewAI quickstarts · SBOM in CI · freshness-bound MPA countersignatures (F-8) |
 | v0.6.0 | **Production hardening + evidence substrate** — multi-tenant replay namespaces · enterprise audit sinks (S3 / Splunk / Datadog) · signed `evidence-ref@1` verification · SLSA/OIDC release provenance · digest-pinned Docker base + hash-pinned spaCy model · latency SLO and all-matrix coverage CI gates · OTel spans · policy hot-reload · startup key gates · human-pentest retest closure |
-| **v0.7.0** | **SLO payment broker (library)** — x402 micropayments as runtime infrastructure bids: `SLOPaymentBroker` + `SLOPaymentPolicy` + evidence-anchored `ArchTranslucencyAdapter` + provisioning PII entities; cross-repo validated against `presidio-hardened-arch-translucency`. cs.DC preprint + empirical eval tracked separately — **latest release** |
+| v0.7.0 | **SLO payment broker (library)** — x402 micropayments as runtime infrastructure bids: `SLOPaymentBroker` + `SLOPaymentPolicy` + evidence-anchored `ArchTranslucencyAdapter` + provisioning PII entities; cross-repo validated against `presidio-hardened-arch-translucency`. cs.DC preprint + empirical eval tracked separately |
+| **v0.8.0** | **PII completeness + supply-chain hardening (library)** — `nlp` mode is now a structural superset of `regex` (no structured-identifier misses) · composed-envelope `screen_ref` leg · `action_ref` byte-determinism (NFC + non-empty entity sets) · URL-redacted log hygiene · OpenSSF Scorecard workflow/badge + SLSA Build L3 provenance · independent multi-round security audit cleared — **latest release** |
 | Unreleased on `main` | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
 
 See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.

--- a/SECURITY-AUDIT-2026-06-29-v0.8.0.md
+++ b/SECURITY-AUDIT-2026-06-29-v0.8.0.md
@@ -1,0 +1,43 @@
+# Independent Security Audit — v0.8.0 (library scope)
+
+Date: 2026-06-29
+
+Scope: `presidio-hardened-x402` v0.8.0 public library in `tools/` — the PII
+filter (regex/NLP modes), `action_ref` primitive, the composed-envelope
+`screen_ref` leg, log hygiene, the release/publish workflow, and supply-chain
+provenance.
+
+Verdict: **GO.** The v0.8.0 release cycle underwent an independent, multi-round
+adversarial security audit. The library scope cleared with no open
+Critical/High/Medium findings. Each round re-attempted the prior round's
+bypasses; the final round found no new issues in scope.
+
+## Library findings assessed
+
+| Severity | Finding | Assessment | Remediation |
+|---|---|---|---|
+| Medium | NLP mode could silently miss structured identifiers | Valid. A bare `AnalyzerEngine` scored some structured identifiers (e.g. `US_SSN`, `PHONE_NUMBER`) below threshold, so `mode="nlp"` detected fewer entities than the zero-setup `mode="regex"`. | `pii_filter.py` now registers the structural pattern recognizers on top of the spaCy NER pipeline, making NLP a strict **superset** of regex. Verified: `mode="nlp"` detects/redacts SSN, phone, credit card, email, IBAN, IP, plus NER entities. |
+| Low | `action_ref` byte-determinism gaps | Valid. Empty entity-type sets and non-NFC field encodings could yield a different `action_ref` for the same logical action. | `action_ref` rejects empty entity-type sets and NFC-normalizes its fields before hashing (audit F1/F2). |
+| Low | PII-bearing URL could reach a log sink | Valid. The missing-payment-header warning logged the raw resource URL. | The URL is redacted before the warning is logged. |
+| Info | Supply-chain provenance should be explicit and measured | Valid release-hardening item. | Weekly OpenSSF Scorecard workflow + README badge; Scorecard Token-Permissions / SAST / Signed-Releases / Branch-Protection remediations; SLSA Build L3 provenance documented. |
+
+## Release gate
+
+Before tagging v0.8.0, run:
+
+```bash
+.venv/bin/python -m ruff check .
+.venv/bin/python -m ruff format --check .
+/Users/vstantch/.local/bin/uv lock --check
+/Users/vstantch/.local/bin/uv run --extra audit --extra evidence --extra redis --extra audit-s3 --extra langchain --extra prometheus --extra otel --extra schema pip-audit --progress-spinner=off --skip-editable
+.venv/bin/python -m pytest tests/ -x -q --tb=short
+```
+
+Audit run results (final round): `ruff` clean, `pytest` 502 passed / 1 skipped,
+`pip-audit` no known vulnerabilities.
+
+## Note
+
+The full multi-round audit reports (which also cover internal, non-published
+service components outside this package) are retained in the private security
+record, not in this public repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -98,6 +98,14 @@ See `PRESIDIO-REQ.md` for the full threat model and security design rationale.
 | T-SLO-2 — Workload-metadata leakage to a compute provider | Opt-in provisioning PII entities (`WORKLOAD_CLASS`, `DATA_CLASSIFICATION`, `QUERY_PATTERN`) redact workload context before transmission |
 | T-SLO-3 — Vendor lock-in via payment coupling | Pluggable `CapacityProvider` registry |
 
+### v0.8.0 additions (PII completeness + determinism)
+
+| Threat | Mitigation |
+|--------|-----------|
+| The high-accuracy engine silently misses structured identifiers | `mode="nlp"` registers the structural recognizers (`US_SSN`, `PHONE_NUMBER`, `CREDIT_CARD`, `EMAIL_ADDRESS`, `IBAN`, `IP_ADDRESS`) as a superset of regex on top of NER — no structured identifier scores below threshold and slips through |
+| Non-deterministic `action_ref` (replay / attribution ambiguity) | `action_ref` rejects empty entity-type sets and NFC-normalizes fields before hashing — the same action always yields the same ref |
+| PII-bearing resource URL reaching a log sink | The missing-payment-header warning redacts the URL before it is logged |
+
 ## Dependency Security
 
 - Dependencies are pinned to minimum-safe versions
@@ -158,5 +166,8 @@ This repository is developed under the Presidio hardened-family SDLC. The public
 
 ## Manual Security Audit History
 
+- [`SECURITY-AUDIT-2026-06-29-v0.8.0.md`](SECURITY-AUDIT-2026-06-29-v0.8.0.md) —
+  v0.8.0 independent multi-round security review (library scope) — GO, no open
+  Critical/High/Medium findings.
 - [`SECURITY-AUDIT-2026-06-21-v0.7.0.md`](SECURITY-AUDIT-2026-06-21-v0.7.0.md) —
   v0.7.0 third-party functional/security audit remediation status.

--- a/SEMVER.md
+++ b/SEMVER.md
@@ -12,7 +12,7 @@ Everything exported in `presidio_x402.__all__`, plus the documented constructor/
 - **Minor (0.X.0):** additive API (new exports, new optional parameters with defaults), new optional extras. Existing code keeps working — including audit event shapes, exception types, and the wire behaviour of the x402 binding. Deprecations are announced here (docstring + CHANGELOG) at least one minor before any change.
 - **Major (1.0.0+):** the only place deprecated surface may be removed. None scheduled.
 
-**Pin guidance for partners:** `presidio-hardened-x402>=0.5,<0.6` in production; run the conformance suite (below) in your CI on every upgrade.
+**Pin guidance for partners:** `presidio-hardened-x402>=0.8,<0.9` in production; run the conformance suite (below) in your CI on every upgrade.
 
 ## Behavioural guarantees (stronger than API stability)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.7.0"
+version = "0.8.0"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1608,7 +1608,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- Bumps the library to **v0.8.0** and brings the release docs in sync. Held — do not merge until the release is authorized (this is the version-bearing commit the v0.8.0 tag will point at).
- v0.8.0 substance (library): `nlp` mode is now a structural superset of `regex` (no structured-identifier misses), composed-envelope `screen_ref` leg, `action_ref` byte-determinism, URL-redacted log hygiene, OpenSSF Scorecard / SLSA Build L3 hardening.
- Independent multi-round security audit cleared the library scope (GO, no open Critical/High/Medium).

## Changes
- `pyproject.toml`: `0.7.0` → `0.8.0`
- `CHANGELOG.md`: `[0.8.0]` section
- `README.md`: banner + roadmap (v0.8.0 = latest release)
- `SECURITY.md`: v0.8.0 additions table + audit-history entry
- `SECURITY-AUDIT-2026-06-29-v0.8.0.md`: new library-scoped audit summary
- `PRESIDIO-REQ.md`: v0.8.0 requirements section
- `SEMVER.md`: pin guidance → `>=0.8,<0.9`

## Test plan
- [x] `ruff check .` / `ruff format --check .` clean (no source changed)
- [x] No `src/` change → existing suite (502 passed / 1 skipped) unaffected
- [ ] Do not merge until release authorized