### PR TITLE
conformance: x402 payment-decision-ref fixture + recompute test

### DIFF
--- a/tests/conformance/decision-ref/README.md
+++ b/tests/conformance/decision-ref/README.md
@@ -1,0 +1,38 @@
+# x402 payment-decision-ref conformance fixture
+
+`decision_ref` for x402 payment decisions, aligned with the agent-governance
+decision-provenance contract that autogen#7353 and crewAI#4877 converged on
+(reference: `babyblueviper1/preaction-governance-conformance`):
+
+```
+artifact_hash = sha256(JCS(payment-decision@1 content))
+decision_ref  = sha256(JCS({artifact_hash, artifact_type, policy_version, verdict}))
+```
+
+The rich payment-decision content is the *artifact*; `decision_ref` is the thin,
+self-describing-preimage id over it (sibling to `action_ref`). x402's depth over the
+generic shape: `verdict = f(controls)` — a pure precedence-combinator over the five
+recorded control verdicts (`pii → trusted_wallet → policy → replay → mpa`,
+first-failure-wins; MPA timeout → `REFER`). The verdict is *recomputable*, not asserted.
+
+Leads with the two fail-closed negatives:
+
+- `signer_equals_runtime` — the verdict signer resolves to the actor's own wallet
+  (self-approval is not a second opinion).
+- `verdict_not_recomputable` — the recorded verdict ≠ `f(controls)`.
+
+The third negative we offered (details-hash over unredacted fields) is already
+`presidio-x402-002` / `PII_BLOCKED` in the action-ref fixture.
+
+Validate offline (zero-dependency, the same grading `@babyblueviper1` runs on landed
+vectors):
+
+```
+pytest tests/test_decision_ref_conformance.py
+```
+
+Regenerate the fixture: `python build_fixture.py`.
+
+**Destination:** contributed upstream to `giskard09/argentum-core`
+`examples/conformance/presidio/`, where `presidio-x402-001/002/003` (our action-ref /
+screen-ref vectors) already live.

--- a/tests/conformance/decision-ref/build_fixture.py
+++ b/tests/conformance/decision-ref/build_fixture.py
@@ -1,0 +1,240 @@
+"""Generate + self-validate the x402 payment-decision-ref conformance fixture.
+
+Drops into giskard09/argentum-core examples/conformance/presidio/ (same shape as
+action-ref-v1.fixture.json) and babyblueviper1's decision-ref-recompute slot:
+    decision_ref = sha256(JCS({artifact_hash, artifact_type, policy_version, verdict}))
+where artifact_hash = sha256(JCS(payment-decision@1 content)), and verdict = f(controls).
+"""
+
+import hashlib
+import json
+
+# ruff: noqa: E501  -- fixture generator: long descriptive strings are intentional
+
+
+def jcs(obj) -> str:
+    # RFC 8785 for our string-only payloads: recursive key sort, compact, UTF-8.
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+# --- f: pure precedence-combinator over the five recorded control verdicts ---
+def f(controls: dict) -> str:
+    if controls["pii"]["verdict"] == "PII_BLOCKED":
+        return "DENY"
+    if controls["trusted_wallet"]["verdict"] == "UNTRUSTED":
+        return "DENY"
+    if controls["policy"]["verdict"] == "VIOLATION":
+        return "DENY"
+    if controls["replay"]["verdict"] == "DUPLICATE":
+        return "DENY"
+    if controls["mpa"]["verdict"] == "DENIED":
+        return "DENY"
+    if controls["mpa"]["verdict"] in ("PENDING", "TIMEOUT"):
+        return "REFER"
+    return "ALLOW"
+
+
+ARTIFACT_TYPE = "presidio-hardened-x402/payment-decision@1"
+POLICY_VERSION = "presidio-x402.policy.v1"
+
+
+def payment_decision(issued_at, verdict, controls, *, amount="10000"):
+    return {
+        "schema": ARTIFACT_TYPE,
+        "issued_at": issued_at,
+        "agent_id": "did:presidio:x402:agent-7f3a9c",
+        "actor": {
+            "payment_signer": "wallet:evm:0xA11ce00000000000000000000000000000000001",
+            "binding": "x402",
+            "network": "eip155:8453",
+        },
+        "payment": {
+            "offer_hash": "sha256:" + sha256_hex("offer|" + issued_at),
+            "details_hash": "sha256:" + sha256_hex("details|redacted|" + issued_at),
+            "pay_to": "0x0273d0b906c9524dB2672318545aaDa1F478B1a1",
+            "amount": amount,
+            "currency": "USDC",
+            "resource_origin": "https://api.merchant.example",
+        },
+        "controls": controls,
+        "verdict": verdict,
+    }
+
+
+def decision_ref_preimage(artifact_hash, verdict):
+    return {
+        "artifact_hash": artifact_hash,
+        "artifact_type": ARTIFACT_TYPE,
+        "policy_version": POLICY_VERSION,
+        "verdict": verdict,
+    }
+
+
+def build_vector(
+    vid, description, *, issued_at, verdict, controls, signer, expect, failure_mode=None
+):
+    art = payment_decision(issued_at, verdict, controls)
+    art_jcs = jcs(art)
+    artifact_hash = sha256_hex(art_jcs)
+    pre = decision_ref_preimage(artifact_hash, verdict)
+    pre_jcs = jcs(pre)
+    decision_ref = sha256_hex(pre_jcs)
+    vec = {
+        "id": vid,
+        "description": description,
+        "expect": expect,  # "accept" | "reject"
+        "artifact": art,
+        "artifact_hash": artifact_hash,
+        "decision_ref_preimage_fields": [
+            "artifact_hash",
+            "artifact_type",
+            "policy_version",
+            "verdict",
+        ],
+        "decision_ref_preimage": pre,
+        "jcs_payload": pre_jcs,
+        "preimage_canonical_bytes_hex": pre_jcs.encode("utf-8").hex(),
+        "decision_ref": decision_ref,
+        # admission: who signed the evidence-ref envelope over this decision
+        "signer": signer,  # {"key_id":..., "resolves_to": "policy-issuer" | "actor-runtime"}
+        # semantic recompute: f over the recorded control verdicts
+        "verdict_recomputed": f(controls),
+    }
+    if failure_mode:
+        vec["failure_mode"] = failure_mode
+    return vec
+
+
+CTRL_ALLOW = {
+    "pii": {"verdict": "PII_REDACTED", "entities": ["EMAIL_ADDRESS"], "mutated": True},
+    "trusted_wallet": {"verdict": "TRUSTED"},
+    "policy": {
+        "verdict": "ALLOW",
+        "policy_snapshot_hash": "sha256:" + sha256_hex("policy-snap-effective"),
+        "limit_hash": "sha256:" + sha256_hex("limit"),
+    },
+    "replay": {"verdict": "FRESH", "fingerprint_hash": "sha256:" + sha256_hex("fp-1")},
+    "mpa": {"verdict": "NOT_REQUIRED", "required": False},
+}
+# NEG-2: controls say policy VIOLATION (so f -> DENY) but the record claims ALLOW.
+CTRL_VIOLATION = json.loads(json.dumps(CTRL_ALLOW))
+CTRL_VIOLATION["policy"]["verdict"] = "VIOLATION"
+
+POLICY_ISSUER = {
+    "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+    "resolves_to": "policy-issuer",
+}
+ACTOR_RUNTIME = {
+    "key_id": "wallet:evm:0xA11ce00000000000000000000000000000000001",
+    "resolves_to": "actor-runtime",
+}
+
+vectors = [
+    build_vector(
+        "presidio-x402-decision-001",
+        "Baseline ALLOW: an x402 payment-decision recorded before signing. PII redacted, "
+        "wallet trusted, policy ALLOW, replay FRESH, MPA not required -> f(controls)=ALLOW. "
+        "decision_ref recomputes from {artifact_hash, artifact_type, policy_version, verdict}; "
+        "signed by a policy issuer distinct from the payment wallet.",
+        issued_at="2026-06-30T22:00:00.000Z",
+        verdict="ALLOW",
+        controls=CTRL_ALLOW,
+        signer=POLICY_ISSUER,
+        expect="accept",
+    ),
+    build_vector(
+        "presidio-x402-decision-signer-equals-runtime",
+        "NEGATIVE (admission): identical decision content to -001, but the evidence-ref "
+        "envelope is signed by the actor's own payment wallet. Self-approval is not a second "
+        "opinion -> reject. decision_ref still recomputes mechanically; the failure is admission, "
+        "not the hash.",
+        issued_at="2026-06-30T22:00:00.000Z",
+        verdict="ALLOW",
+        controls=CTRL_ALLOW,
+        signer=ACTOR_RUNTIME,
+        expect="reject",
+        failure_mode="signer_equals_runtime",
+    ),
+    build_vector(
+        "presidio-x402-decision-verdict-not-recomputable",
+        "NEGATIVE (recompute): the record claims verdict=ALLOW, but controls.policy.verdict="
+        "VIOLATION, so f(controls)=DENY. A signed verdict that does not re-derive from its "
+        "recorded control verdicts is void -> reject. decision_ref hashes fine; verdict != f(controls).",
+        issued_at="2026-06-30T22:05:00.000Z",
+        verdict="ALLOW",
+        controls=CTRL_VIOLATION,
+        signer=POLICY_ISSUER,
+        expect="reject",
+        failure_mode="verdict_not_recomputable",
+    ),
+]
+
+fixture = {
+    "fixture_id": "presidio-x402-decision-ref-v1",
+    "version": "v1",
+    "spec": "plan/presidio-evidence-decision-ref-design.md",
+    "hash_algo": "sha256",
+    "preimage_format": "jcs-rfc8785-v1",
+    "generated_at": "2026-06-30",
+    "source": "presidio-hardened-x402 payment-decision (pre-signing); decision_ref shape per "
+    "babyblueviper1/preaction-governance-conformance (autogen#7353, crewAI#4877).",
+    "purpose": "decision_ref for x402 payment decisions: sha256(JCS({artifact_hash, artifact_type, "
+    "policy_version, verdict})) where artifact_hash = sha256(JCS(payment-decision@1)) and "
+    "verdict = f(controls), the precedence-combinator over the five recorded control verdicts. "
+    "Leads with the two fail-closed negatives (signer != runtime; verdict not recomputable).",
+    "reproduce_in_python": (
+        "import hashlib, json\n"
+        "def jcs(o): return json.dumps(o, sort_keys=True, separators=(',',':'), ensure_ascii=False)\n"
+        "artifact_hash = hashlib.sha256(jcs(payment_decision).encode()).hexdigest()\n"
+        "decision_ref = hashlib.sha256(jcs({'artifact_hash':artifact_hash,'artifact_type':t,'policy_version':p,'verdict':v}).encode()).hexdigest()"
+    ),
+    "f_precedence": ["pii", "trusted_wallet", "policy", "replay", "mpa"],
+    "vectors": vectors,
+}
+
+# ---- self-validate before emitting ----
+errors = []
+for v in vectors:
+    # 1. decision_ref recomputes from its published preimage fields
+    if sha256_hex(jcs(v["decision_ref_preimage"])) != v["decision_ref"]:
+        errors.append(f"{v['id']}: decision_ref does not recompute")
+    # 2. artifact_hash recomputes
+    if sha256_hex(jcs(v["artifact"])) != v["artifact_hash"]:
+        errors.append(f"{v['id']}: artifact_hash does not recompute")
+    # 3. tamper-sensitivity: flipping verdict changes decision_ref
+    tampered = dict(v["decision_ref_preimage"], verdict="DENY")
+    if (
+        sha256_hex(jcs(tampered)) == v["decision_ref"]
+        and v["decision_ref_preimage"]["verdict"] != "DENY"
+    ):
+        errors.append(f"{v['id']}: NOT tamper-sensitive on verdict")
+    # 4. the negatives must actually fail their check; the positive must pass both
+    signer_ok = v["signer"]["resolves_to"] != "actor-runtime"
+    recompute_ok = v["verdict_recomputed"] == v["artifact"]["verdict"]
+    accepted = signer_ok and recompute_ok
+    if v["expect"] == "accept" and not accepted:
+        errors.append(
+            f"{v['id']}: expected accept but checks fail (signer_ok={signer_ok}, recompute_ok={recompute_ok})"
+        )
+    if v["expect"] == "reject" and accepted:
+        errors.append(f"{v['id']}: expected reject but both checks pass")
+
+print("=== self-validation ===")
+print("OK" if not errors else "FAIL:\n  " + "\n  ".join(errors))
+for v in vectors:
+    print(
+        f"  {v['id']:48} expect={v['expect']:6} verdict={v['artifact']['verdict']:5} "
+        f"f={v['verdict_recomputed']:5} signer={v['signer']['resolves_to']:13} "
+        f"decision_ref={v['decision_ref'][:16]}…"
+    )
+
+with open(
+    "/private/tmp/claude-501/-Users-vstantch-projects-presidio-hardened-x402/9fadd1a0-1398-4383-8e14-12ded2f310ee/scratchpad/presidio-x402-decision-ref-v1.fixture.json",
+    "w",
+) as fh:
+    json.dump(fixture, fh, indent=2, ensure_ascii=False)
+print("\nwrote fixture JSON")

--- a/tests/conformance/decision-ref/presidio-x402-decision-ref-v1.fixture.json
+++ b/tests/conformance/decision-ref/presidio-x402-decision-ref-v1.fixture.json
@@ -1,0 +1,232 @@
+{
+  "fixture_id": "presidio-x402-decision-ref-v1",
+  "version": "v1",
+  "spec": "plan/presidio-evidence-decision-ref-design.md",
+  "hash_algo": "sha256",
+  "preimage_format": "jcs-rfc8785-v1",
+  "generated_at": "2026-06-30",
+  "source": "presidio-hardened-x402 payment-decision (pre-signing); decision_ref shape per babyblueviper1/preaction-governance-conformance (autogen#7353, crewAI#4877).",
+  "purpose": "decision_ref for x402 payment decisions: sha256(JCS({artifact_hash, artifact_type, policy_version, verdict})) where artifact_hash = sha256(JCS(payment-decision@1)) and verdict = f(controls), the precedence-combinator over the five recorded control verdicts. Leads with the two fail-closed negatives (signer != runtime; verdict not recomputable).",
+  "reproduce_in_python": "import hashlib, json\ndef jcs(o): return json.dumps(o, sort_keys=True, separators=(',',':'), ensure_ascii=False)\nartifact_hash = hashlib.sha256(jcs(payment_decision).encode()).hexdigest()\ndecision_ref = hashlib.sha256(jcs({'artifact_hash':artifact_hash,'artifact_type':t,'policy_version':p,'verdict':v}).encode()).hexdigest()",
+  "f_precedence": [
+    "pii",
+    "trusted_wallet",
+    "policy",
+    "replay",
+    "mpa"
+  ],
+  "vectors": [
+    {
+      "id": "presidio-x402-decision-001",
+      "description": "Baseline ALLOW: an x402 payment-decision recorded before signing. PII redacted, wallet trusted, policy ALLOW, replay FRESH, MPA not required -> f(controls)=ALLOW. decision_ref recomputes from {artifact_hash, artifact_type, policy_version, verdict}; signed by a policy issuer distinct from the payment wallet.",
+      "expect": "accept",
+      "artifact": {
+        "schema": "presidio-hardened-x402/payment-decision@1",
+        "issued_at": "2026-06-30T22:00:00.000Z",
+        "agent_id": "did:presidio:x402:agent-7f3a9c",
+        "actor": {
+          "payment_signer": "wallet:evm:0xA11ce00000000000000000000000000000000001",
+          "binding": "x402",
+          "network": "eip155:8453"
+        },
+        "payment": {
+          "offer_hash": "sha256:83dcb4e56772a36ffb7d255303364936d9cb4d638159273017e2cf99424bed0d",
+          "details_hash": "sha256:677ac8738c1de820f8534bedfc3d4a7d886964f31acfb9f5249acaa10854dca1",
+          "pay_to": "0x0273d0b906c9524dB2672318545aaDa1F478B1a1",
+          "amount": "10000",
+          "currency": "USDC",
+          "resource_origin": "https://api.merchant.example"
+        },
+        "controls": {
+          "pii": {
+            "verdict": "PII_REDACTED",
+            "entities": [
+              "EMAIL_ADDRESS"
+            ],
+            "mutated": true
+          },
+          "trusted_wallet": {
+            "verdict": "TRUSTED"
+          },
+          "policy": {
+            "verdict": "ALLOW",
+            "policy_snapshot_hash": "sha256:23420b8de1460fbc59fead4814bb4fdf2f736e8d7bfcf6c3932549386419d238",
+            "limit_hash": "sha256:55ea09e5715d0a8d9d94018d473bf23b2d7e630c2adb1f1acad3bada74c6fd05"
+          },
+          "replay": {
+            "verdict": "FRESH",
+            "fingerprint_hash": "sha256:858c06cf9c505c9f135e64d506f2e40dcb5bc6992bfd8d97f31e6b7caa8b0d38"
+          },
+          "mpa": {
+            "verdict": "NOT_REQUIRED",
+            "required": false
+          }
+        },
+        "verdict": "ALLOW"
+      },
+      "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+      "decision_ref_preimage_fields": [
+        "artifact_hash",
+        "artifact_type",
+        "policy_version",
+        "verdict"
+      ],
+      "decision_ref_preimage": {
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v1",
+        "verdict": "ALLOW"
+      },
+      "jcs_payload": "{\"artifact_hash\":\"c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662\",\"artifact_type\":\"presidio-hardened-x402/payment-decision@1\",\"policy_version\":\"presidio-x402.policy.v1\",\"verdict\":\"ALLOW\"}",
+      "preimage_canonical_bytes_hex": "7b2261727469666163745f68617368223a2263363161663465356631323666363039333135333734316163313637323035663763636132336231306462653938633336386331326331656637653836363632222c2261727469666163745f74797065223a22707265736964696f2d68617264656e65642d783430322f7061796d656e742d6465636973696f6e4031222c22706f6c6963795f76657273696f6e223a22707265736964696f2d783430322e706f6c6963792e7631222c2276657264696374223a22414c4c4f57227d",
+      "decision_ref": "655c85c5d14e7bdff09d21b8f292f767c8e519fa5c0529cc0b9f7f695ca2a31b",
+      "signer": {
+        "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+        "resolves_to": "policy-issuer"
+      },
+      "verdict_recomputed": "ALLOW"
+    },
+    {
+      "id": "presidio-x402-decision-signer-equals-runtime",
+      "description": "NEGATIVE (admission): identical decision content to -001, but the evidence-ref envelope is signed by the actor's own payment wallet. Self-approval is not a second opinion -> reject. decision_ref still recomputes mechanically; the failure is admission, not the hash.",
+      "expect": "reject",
+      "artifact": {
+        "schema": "presidio-hardened-x402/payment-decision@1",
+        "issued_at": "2026-06-30T22:00:00.000Z",
+        "agent_id": "did:presidio:x402:agent-7f3a9c",
+        "actor": {
+          "payment_signer": "wallet:evm:0xA11ce00000000000000000000000000000000001",
+          "binding": "x402",
+          "network": "eip155:8453"
+        },
+        "payment": {
+          "offer_hash": "sha256:83dcb4e56772a36ffb7d255303364936d9cb4d638159273017e2cf99424bed0d",
+          "details_hash": "sha256:677ac8738c1de820f8534bedfc3d4a7d886964f31acfb9f5249acaa10854dca1",
+          "pay_to": "0x0273d0b906c9524dB2672318545aaDa1F478B1a1",
+          "amount": "10000",
+          "currency": "USDC",
+          "resource_origin": "https://api.merchant.example"
+        },
+        "controls": {
+          "pii": {
+            "verdict": "PII_REDACTED",
+            "entities": [
+              "EMAIL_ADDRESS"
+            ],
+            "mutated": true
+          },
+          "trusted_wallet": {
+            "verdict": "TRUSTED"
+          },
+          "policy": {
+            "verdict": "ALLOW",
+            "policy_snapshot_hash": "sha256:23420b8de1460fbc59fead4814bb4fdf2f736e8d7bfcf6c3932549386419d238",
+            "limit_hash": "sha256:55ea09e5715d0a8d9d94018d473bf23b2d7e630c2adb1f1acad3bada74c6fd05"
+          },
+          "replay": {
+            "verdict": "FRESH",
+            "fingerprint_hash": "sha256:858c06cf9c505c9f135e64d506f2e40dcb5bc6992bfd8d97f31e6b7caa8b0d38"
+          },
+          "mpa": {
+            "verdict": "NOT_REQUIRED",
+            "required": false
+          }
+        },
+        "verdict": "ALLOW"
+      },
+      "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+      "decision_ref_preimage_fields": [
+        "artifact_hash",
+        "artifact_type",
+        "policy_version",
+        "verdict"
+      ],
+      "decision_ref_preimage": {
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v1",
+        "verdict": "ALLOW"
+      },
+      "jcs_payload": "{\"artifact_hash\":\"c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662\",\"artifact_type\":\"presidio-hardened-x402/payment-decision@1\",\"policy_version\":\"presidio-x402.policy.v1\",\"verdict\":\"ALLOW\"}",
+      "preimage_canonical_bytes_hex": "7b2261727469666163745f68617368223a2263363161663465356631323666363039333135333734316163313637323035663763636132336231306462653938633336386331326331656637653836363632222c2261727469666163745f74797065223a22707265736964696f2d68617264656e65642d783430322f7061796d656e742d6465636973696f6e4031222c22706f6c6963795f76657273696f6e223a22707265736964696f2d783430322e706f6c6963792e7631222c2276657264696374223a22414c4c4f57227d",
+      "decision_ref": "655c85c5d14e7bdff09d21b8f292f767c8e519fa5c0529cc0b9f7f695ca2a31b",
+      "signer": {
+        "key_id": "wallet:evm:0xA11ce00000000000000000000000000000000001",
+        "resolves_to": "actor-runtime"
+      },
+      "verdict_recomputed": "ALLOW",
+      "failure_mode": "signer_equals_runtime"
+    },
+    {
+      "id": "presidio-x402-decision-verdict-not-recomputable",
+      "description": "NEGATIVE (recompute): the record claims verdict=ALLOW, but controls.policy.verdict=VIOLATION, so f(controls)=DENY. A signed verdict that does not re-derive from its recorded control verdicts is void -> reject. decision_ref hashes fine; verdict != f(controls).",
+      "expect": "reject",
+      "artifact": {
+        "schema": "presidio-hardened-x402/payment-decision@1",
+        "issued_at": "2026-06-30T22:05:00.000Z",
+        "agent_id": "did:presidio:x402:agent-7f3a9c",
+        "actor": {
+          "payment_signer": "wallet:evm:0xA11ce00000000000000000000000000000000001",
+          "binding": "x402",
+          "network": "eip155:8453"
+        },
+        "payment": {
+          "offer_hash": "sha256:473a0708e4f623de90ce376f79b4ea6ca626120fa042d8d20ee7fef9804f2bc8",
+          "details_hash": "sha256:8fb8576420d871b0998615316fb0cfffff874908826efb085be026c2a609a6de",
+          "pay_to": "0x0273d0b906c9524dB2672318545aaDa1F478B1a1",
+          "amount": "10000",
+          "currency": "USDC",
+          "resource_origin": "https://api.merchant.example"
+        },
+        "controls": {
+          "pii": {
+            "verdict": "PII_REDACTED",
+            "entities": [
+              "EMAIL_ADDRESS"
+            ],
+            "mutated": true
+          },
+          "trusted_wallet": {
+            "verdict": "TRUSTED"
+          },
+          "policy": {
+            "verdict": "VIOLATION",
+            "policy_snapshot_hash": "sha256:23420b8de1460fbc59fead4814bb4fdf2f736e8d7bfcf6c3932549386419d238",
+            "limit_hash": "sha256:55ea09e5715d0a8d9d94018d473bf23b2d7e630c2adb1f1acad3bada74c6fd05"
+          },
+          "replay": {
+            "verdict": "FRESH",
+            "fingerprint_hash": "sha256:858c06cf9c505c9f135e64d506f2e40dcb5bc6992bfd8d97f31e6b7caa8b0d38"
+          },
+          "mpa": {
+            "verdict": "NOT_REQUIRED",
+            "required": false
+          }
+        },
+        "verdict": "ALLOW"
+      },
+      "artifact_hash": "ed0edbc8a78147d6e8cde44ef70b69b8b7f38a0de25b703c1e78262683516bca",
+      "decision_ref_preimage_fields": [
+        "artifact_hash",
+        "artifact_type",
+        "policy_version",
+        "verdict"
+      ],
+      "decision_ref_preimage": {
+        "artifact_hash": "ed0edbc8a78147d6e8cde44ef70b69b8b7f38a0de25b703c1e78262683516bca",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v1",
+        "verdict": "ALLOW"
+      },
+      "jcs_payload": "{\"artifact_hash\":\"ed0edbc8a78147d6e8cde44ef70b69b8b7f38a0de25b703c1e78262683516bca\",\"artifact_type\":\"presidio-hardened-x402/payment-decision@1\",\"policy_version\":\"presidio-x402.policy.v1\",\"verdict\":\"ALLOW\"}",
+      "preimage_canonical_bytes_hex": "7b2261727469666163745f68617368223a2265643065646263386137383134376436653863646534346566373062363962386237663338613064653235623730336331653738323632363833353136626361222c2261727469666163745f74797065223a22707265736964696f2d68617264656e65642d783430322f7061796d656e742d6465636973696f6e4031222c22706f6c6963795f76657273696f6e223a22707265736964696f2d783430322e706f6c6963792e7631222c2276657264696374223a22414c4c4f57227d",
+      "decision_ref": "0f700b3fcc4e784029eba971d7065b10b10cf4bc2c19a38d5bef9cbf57e25d94",
+      "signer": {
+        "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+        "resolves_to": "policy-issuer"
+      },
+      "verdict_recomputed": "DENY",
+      "failure_mode": "verdict_not_recomputable"
+    }
+  ]
+}

--- a/tests/test_decision_ref_conformance.py
+++ b/tests/test_decision_ref_conformance.py
@@ -1,0 +1,106 @@
+"""Conformance test for the x402 payment-decision-ref fixture.
+
+Mirrors babyblueviper1's `check_decision_ref.py` (autogen#7353 / crewAI#4877) against
+our `decision_ref` shape, and adds the payment-semantic recompute (`verdict = f(controls)`).
+Zero-dependency, offline — the same grading @babyblueviper1 runs on landed vectors.
+
+Fixture: tests/conformance/decision-ref/presidio-x402-decision-ref-v1.fixture.json
+Contributed upstream to giskard09/argentum-core examples/conformance/presidio/.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+FIXTURE = (
+    Path(__file__).parent
+    / "conformance"
+    / "decision-ref"
+    / "presidio-x402-decision-ref-v1.fixture.json"
+)
+
+
+def jcs(obj) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def f(controls: dict) -> str:
+    """Pure precedence-combinator over the five recorded control verdicts."""
+    if controls["pii"]["verdict"] == "PII_BLOCKED":
+        return "DENY"
+    if controls["trusted_wallet"]["verdict"] == "UNTRUSTED":
+        return "DENY"
+    if controls["policy"]["verdict"] == "VIOLATION":
+        return "DENY"
+    if controls["replay"]["verdict"] == "DUPLICATE":
+        return "DENY"
+    if controls["mpa"]["verdict"] == "DENIED":
+        return "DENY"
+    if controls["mpa"]["verdict"] in ("PENDING", "TIMEOUT"):
+        return "REFER"
+    return "ALLOW"
+
+
+_FIXTURE = json.loads(FIXTURE.read_text(encoding="utf-8"))
+_VECTORS = _FIXTURE["vectors"]
+_IDS = [v["id"] for v in _VECTORS]
+
+
+def _admission_ok(v: dict) -> bool:
+    # signer must not resolve to the actor's runtime (self-approval).
+    return v["signer"]["resolves_to"] != "actor-runtime"
+
+
+def _verdict_recomputes(v: dict) -> bool:
+    return f(v["artifact"]["controls"]) == v["artifact"]["verdict"]
+
+
+@pytest.mark.parametrize("v", _VECTORS, ids=_IDS)
+def test_decision_ref_recomputes_from_preimage(v):
+    """decision_ref = sha256(JCS(its own published preimage fields))."""
+    pre = v["decision_ref_preimage"]
+    assert set(v["decision_ref_preimage_fields"]) == set(pre.keys())
+    assert sha256_hex(jcs(pre)) == v["decision_ref"]
+    assert bytes.fromhex(v["preimage_canonical_bytes_hex"]).decode("utf-8") == v["jcs_payload"]
+    assert v["jcs_payload"] == jcs(pre)
+
+
+@pytest.mark.parametrize("v", _VECTORS, ids=_IDS)
+def test_artifact_hash_recomputes(v):
+    """artifact_hash = sha256(JCS(payment-decision@1 content))."""
+    assert sha256_hex(jcs(v["artifact"])) == v["artifact_hash"]
+    assert v["decision_ref_preimage"]["artifact_hash"] == v["artifact_hash"]
+
+
+@pytest.mark.parametrize("v", _VECTORS, ids=_IDS)
+def test_tamper_sensitive_on_verdict(v):
+    """Changing the verdict must change decision_ref."""
+    tampered = dict(v["decision_ref_preimage"])
+    alt = "DENY" if tampered["verdict"] != "DENY" else "ALLOW"
+    tampered["verdict"] = alt
+    assert sha256_hex(jcs(tampered)) != v["decision_ref"]
+
+
+@pytest.mark.parametrize("v", _VECTORS, ids=_IDS)
+def test_accept_reject_matches_expect(v):
+    """The two fail-closed negatives must fail; the baseline must pass both."""
+    accepted = _admission_ok(v) and _verdict_recomputes(v)
+    assert accepted == (v["expect"] == "accept"), (
+        f"{v['id']}: admission_ok={_admission_ok(v)} verdict_recomputes={_verdict_recomputes(v)}"
+    )
+
+
+def test_fixture_leads_with_negatives():
+    """A content type proves its worth by what it rejects — both named negatives present."""
+    fmodes = {v.get("failure_mode") for v in _VECTORS}
+    assert "signer_equals_runtime" in fmodes
+    assert "verdict_not_recomputable" in fmodes
+    assert any(v["expect"] == "accept" for v in _VECTORS)


### PR DESCRIPTION
## Summary
- Adds the x402 `decision_ref` conformance fixture + a zero-dependency recompute test, aligned with the decision-provenance contract autogen#7353 / crewAI#4877 converged on (ref: `babyblueviper1/preaction-governance-conformance`).
- `artifact_hash = sha256(JCS(payment-decision@1))`; `decision_ref = sha256(JCS({artifact_hash, artifact_type, policy_version, verdict}))`. x402 depth: `verdict = f(controls)` (precedence-combinator), so the verdict recomputes.
- Leads with the two fail-closed negatives (`signer_equals_runtime`, `verdict_not_recomputable`); the third (details-hash) is already `presidio-x402-002`.

## Test plan
- [x] `ruff` clean; `pytest tests/test_decision_ref_conformance.py` (13 passed) — recompute, artifact_hash, tamper-sensitivity, accept/reject expectations
- [x] Fixture self-validates via `build_fixture.py`

## Next
Upstream the fixture to `giskard09/argentum-core` `examples/conformance/presidio/`, where babyblueviper1 CI-grades it.