### PR TITLE
conformance(decision-ref): digest / forward-compat vector block

### DIFF
--- a/tests/conformance/decision-ref/build_fixture.py
+++ b/tests/conformance/decision-ref/build_fixture.py
@@ -8,6 +8,7 @@ where artifact_hash = sha256(JCS(payment-decision@1 content)), and verdict = f(c
 
 import hashlib
 import json
+import os
 
 # ruff: noqa: E501  -- fixture generator: long descriptive strings are intentional
 
@@ -173,6 +174,117 @@ vectors = [
     ),
 ]
 
+# --- second block: pshkv's digest / forward-compat axis (x402#2332, autogen#7353) ---
+# The first block tests admission + recompute (is a verdict *entitled* to its verdict).
+# This block tests the digest axis: is the id sensitive to its own preimage, and does it
+# fail closed on the unknown? Property vectors operate at the decision_ref preimage level
+# (not standalone signed records); the two fail-closed vectors carry expect="reject".
+BASE = vectors[0]
+BASE_AH = BASE["artifact_hash"]
+BASE_DR = BASE["decision_ref"]
+STD_FIELDS = ["artifact_hash", "artifact_type", "policy_version", "verdict"]
+
+
+def _pre(policy_version, verdict, *, extra=None):
+    d = {
+        "artifact_hash": BASE_AH,
+        "artifact_type": ARTIFACT_TYPE,
+        "policy_version": policy_version,
+        "verdict": verdict,
+    }
+    if extra:
+        d.update(extra)
+    return d
+
+
+def dfc_property(vid, description, assert_kind, pre, *, unsorted=None):
+    pre_jcs = jcs(pre)
+    v = {
+        "id": vid,
+        "axis": "digest",
+        "assert": assert_kind,  # "decision_ref_differs" | "decision_ref_equals"
+        "relative_to": "presidio-x402-decision-001",
+        "note": "preimage-level property vector: exercises decision_ref canonicalisation/"
+        "binding, not a standalone signed record.",
+        "description": description,
+        "baseline_decision_ref": BASE_DR,
+        "decision_ref_preimage_fields": STD_FIELDS,
+        "decision_ref_preimage": pre,
+        "jcs_payload": pre_jcs,
+        "preimage_canonical_bytes_hex": pre_jcs.encode("utf-8").hex(),
+        "decision_ref": sha256_hex(pre_jcs),
+    }
+    if unsorted is not None:
+        v["decision_ref_preimage_unsorted"] = unsorted
+    return v
+
+
+def dfc_failclosed(vid, description, assert_kind, pre, fields):
+    v = {
+        "id": vid,
+        "axis": "forward_compat",
+        "assert": assert_kind,  # "non_conformant" | "fail_closed"
+        "expect": "reject",
+        "description": description,
+        "decision_ref_preimage": pre,
+    }
+    if fields is not None:
+        v["decision_ref_preimage_fields"] = fields
+    return v
+
+
+digest_forward_compat_vectors = [
+    dfc_property(
+        "presidio-x402-decision-dfc-policy-version-binding",
+        "Same artifact_hash as -001, policy_version bumped v1 -> v2. policy_version is in the "
+        "preimage, so the same artifact under a different policy surface yields a DIFFERENT "
+        "decision_ref. An older id cannot silently stand in for a decision taken under a new policy.",
+        "decision_ref_differs",
+        _pre("presidio-x402.policy.v2", "ALLOW"),
+    ),
+    dfc_property(
+        "presidio-x402-decision-dfc-verdict-binding",
+        "Same artifact_hash and policy_version as -001, verdict ALLOW -> DENY. The verdict is "
+        "bound into decision_ref, so it cannot be swapped without the id moving. (Such a record "
+        "would also fail the first-block recompute; here we isolate the digest-binding property.)",
+        "decision_ref_differs",
+        _pre(POLICY_VERSION, "DENY"),
+    ),
+    dfc_property(
+        "presidio-x402-decision-dfc-canonicalisation-stable",
+        "Byte-for-byte the same preimage content as -001, presented with the keys in scrambled "
+        "order. JCS (RFC 8785) sorts keys before hashing, so the canonical bytes and the "
+        "decision_ref are IDENTICAL to -001. Reordering is not tampering.",
+        "decision_ref_equals",
+        _pre(POLICY_VERSION, "ALLOW"),
+        unsorted={
+            "verdict": "ALLOW",
+            "policy_version": POLICY_VERSION,
+            "artifact_type": ARTIFACT_TYPE,
+            "artifact_hash": BASE_AH,
+        },
+    ),
+    dfc_failclosed(
+        "presidio-x402-decision-dfc-missing-preimage-field-list",
+        "The record ships a decision_ref_preimage but declares no decision_ref_preimage_fields. "
+        "Without the self-describing field list a verifier cannot know the canonicalisation scope "
+        "(which keys, in what set) -> it must fail closed, not guess.",
+        "non_conformant",
+        _pre(POLICY_VERSION, "ALLOW"),
+        None,
+    ),
+    dfc_failclosed(
+        "presidio-x402-decision-dfc-unknown-field-fail-closed",
+        "A future policy version adds risk_tier to the preimage object but does NOT list it in "
+        "decision_ref_preimage_fields. Declared fields != object keys, so an older verifier would "
+        "hash a subset and silently accept a decision it cannot fully reconstruct -> fail closed. "
+        "The self-describing field list exists precisely so the surface can grow without this.",
+        "fail_closed",
+        _pre(POLICY_VERSION, "ALLOW", extra={"risk_tier": "elevated"}),
+        STD_FIELDS,
+    ),
+]
+
 fixture = {
     "fixture_id": "presidio-x402-decision-ref-v1",
     "version": "v1",
@@ -194,6 +306,12 @@ fixture = {
     ),
     "f_precedence": ["pii", "trusted_wallet", "policy", "replay", "mpa"],
     "vectors": vectors,
+    "digest_forward_compat_note": "Second block (x402#2332 / autogen#7353, pshkv's matrix): "
+    "the digest & forward-compat axis. Property vectors (axis=digest) assert decision_ref_differs "
+    "or decision_ref_equals at the preimage level; fail-closed vectors (axis=forward_compat) carry "
+    "expect=reject. Conformance rule for the latter: decision_ref_preimage_fields must be present, "
+    "non-empty, and set-equal to the preimage object's keys.",
+    "digest_forward_compat_vectors": digest_forward_compat_vectors,
 }
 
 # ---- self-validate before emitting ----
@@ -223,6 +341,32 @@ for v in vectors:
     if v["expect"] == "reject" and accepted:
         errors.append(f"{v['id']}: expected reject but both checks pass")
 
+# ---- self-validate the digest / forward-compat block ----
+for v in digest_forward_compat_vectors:
+    a = v["assert"]
+    pre = v["decision_ref_preimage"]
+    if a == "decision_ref_differs":
+        if sha256_hex(jcs(pre)) != v["decision_ref"]:
+            errors.append(f"{v['id']}: decision_ref does not recompute")
+        if v["decision_ref"] == v["baseline_decision_ref"]:
+            errors.append(f"{v['id']}: expected a DIFFERENT decision_ref from baseline")
+        if pre["artifact_hash"] != BASE_AH:
+            errors.append(f"{v['id']}: should reuse baseline artifact_hash (same artifact)")
+    elif a == "decision_ref_equals":
+        if not (jcs(v["decision_ref_preimage_unsorted"]) == jcs(pre) == v["jcs_payload"]):
+            errors.append(f"{v['id']}: scrambled input does not canonicalise to the same bytes")
+        if not (sha256_hex(jcs(pre)) == v["decision_ref"] == v["baseline_decision_ref"]):
+            errors.append(f"{v['id']}: expected the SAME decision_ref as baseline")
+    elif a in ("non_conformant", "fail_closed"):
+        if v["expect"] != "reject":
+            errors.append(f"{v['id']}: fail-closed vector must expect=reject")
+        fields = v.get("decision_ref_preimage_fields")
+        conformant = bool(fields) and set(fields) == set(pre.keys())
+        if conformant:
+            errors.append(f"{v['id']}: expected non-conformant preimage but it is well-formed")
+    else:
+        errors.append(f"{v['id']}: unknown assert '{a}'")
+
 print("=== self-validation ===")
 print("OK" if not errors else "FAIL:\n  " + "\n  ".join(errors))
 for v in vectors:
@@ -231,10 +375,15 @@ for v in vectors:
         f"f={v['verdict_recomputed']:5} signer={v['signer']['resolves_to']:13} "
         f"decision_ref={v['decision_ref'][:16]}…"
     )
+print("--- digest / forward-compat block ---")
+for v in digest_forward_compat_vectors:
+    dr = v.get("decision_ref", "—(reject)")[:16]
+    print(f"  {v['id']:52} assert={v['assert']:20} decision_ref={dr}…")
 
-with open(
-    "/private/tmp/claude-501/-Users-vstantch-projects-presidio-hardened-x402/9fadd1a0-1398-4383-8e14-12ded2f310ee/scratchpad/presidio-x402-decision-ref-v1.fixture.json",
-    "w",
-) as fh:
+out = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "presidio-x402-decision-ref-v1.fixture.json"
+)
+with open(out, "w") as fh:
     json.dump(fixture, fh, indent=2, ensure_ascii=False)
-print("\nwrote fixture JSON")
+    fh.write("\n")
+print(f"\nwrote fixture JSON -> {out}")

--- a/tests/conformance/decision-ref/presidio-x402-decision-ref-v1.fixture.json
+++ b/tests/conformance/decision-ref/presidio-x402-decision-ref-v1.fixture.json
@@ -228,5 +228,119 @@
       "verdict_recomputed": "DENY",
       "failure_mode": "verdict_not_recomputable"
     }
+  ],
+  "digest_forward_compat_note": "Second block (x402#2332 / autogen#7353, pshkv's matrix): the digest & forward-compat axis. Property vectors (axis=digest) assert decision_ref_differs or decision_ref_equals at the preimage level; fail-closed vectors (axis=forward_compat) carry expect=reject. Conformance rule for the latter: decision_ref_preimage_fields must be present, non-empty, and set-equal to the preimage object's keys.",
+  "digest_forward_compat_vectors": [
+    {
+      "id": "presidio-x402-decision-dfc-policy-version-binding",
+      "axis": "digest",
+      "assert": "decision_ref_differs",
+      "relative_to": "presidio-x402-decision-001",
+      "note": "preimage-level property vector: exercises decision_ref canonicalisation/binding, not a standalone signed record.",
+      "description": "Same artifact_hash as -001, policy_version bumped v1 -> v2. policy_version is in the preimage, so the same artifact under a different policy surface yields a DIFFERENT decision_ref. An older id cannot silently stand in for a decision taken under a new policy.",
+      "baseline_decision_ref": "655c85c5d14e7bdff09d21b8f292f767c8e519fa5c0529cc0b9f7f695ca2a31b",
+      "decision_ref_preimage_fields": [
+        "artifact_hash",
+        "artifact_type",
+        "policy_version",
+        "verdict"
+      ],
+      "decision_ref_preimage": {
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v2",
+        "verdict": "ALLOW"
+      },
+      "jcs_payload": "{\"artifact_hash\":\"c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662\",\"artifact_type\":\"presidio-hardened-x402/payment-decision@1\",\"policy_version\":\"presidio-x402.policy.v2\",\"verdict\":\"ALLOW\"}",
+      "preimage_canonical_bytes_hex": "7b2261727469666163745f68617368223a2263363161663465356631323666363039333135333734316163313637323035663763636132336231306462653938633336386331326331656637653836363632222c2261727469666163745f74797065223a22707265736964696f2d68617264656e65642d783430322f7061796d656e742d6465636973696f6e4031222c22706f6c6963795f76657273696f6e223a22707265736964696f2d783430322e706f6c6963792e7632222c2276657264696374223a22414c4c4f57227d",
+      "decision_ref": "99fb68a2f0cdc586899325412652cc1dcada040dc4fc03bb854a8d5d323ccfbb"
+    },
+    {
+      "id": "presidio-x402-decision-dfc-verdict-binding",
+      "axis": "digest",
+      "assert": "decision_ref_differs",
+      "relative_to": "presidio-x402-decision-001",
+      "note": "preimage-level property vector: exercises decision_ref canonicalisation/binding, not a standalone signed record.",
+      "description": "Same artifact_hash and policy_version as -001, verdict ALLOW -> DENY. The verdict is bound into decision_ref, so it cannot be swapped without the id moving. (Such a record would also fail the first-block recompute; here we isolate the digest-binding property.)",
+      "baseline_decision_ref": "655c85c5d14e7bdff09d21b8f292f767c8e519fa5c0529cc0b9f7f695ca2a31b",
+      "decision_ref_preimage_fields": [
+        "artifact_hash",
+        "artifact_type",
+        "policy_version",
+        "verdict"
+      ],
+      "decision_ref_preimage": {
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v1",
+        "verdict": "DENY"
+      },
+      "jcs_payload": "{\"artifact_hash\":\"c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662\",\"artifact_type\":\"presidio-hardened-x402/payment-decision@1\",\"policy_version\":\"presidio-x402.policy.v1\",\"verdict\":\"DENY\"}",
+      "preimage_canonical_bytes_hex": "7b2261727469666163745f68617368223a2263363161663465356631323666363039333135333734316163313637323035663763636132336231306462653938633336386331326331656637653836363632222c2261727469666163745f74797065223a22707265736964696f2d68617264656e65642d783430322f7061796d656e742d6465636973696f6e4031222c22706f6c6963795f76657273696f6e223a22707265736964696f2d783430322e706f6c6963792e7631222c2276657264696374223a2244454e59227d",
+      "decision_ref": "0096eed281b8daa69b16f247f7721f241a694249fa54184e7478f55fc3525e02"
+    },
+    {
+      "id": "presidio-x402-decision-dfc-canonicalisation-stable",
+      "axis": "digest",
+      "assert": "decision_ref_equals",
+      "relative_to": "presidio-x402-decision-001",
+      "note": "preimage-level property vector: exercises decision_ref canonicalisation/binding, not a standalone signed record.",
+      "description": "Byte-for-byte the same preimage content as -001, presented with the keys in scrambled order. JCS (RFC 8785) sorts keys before hashing, so the canonical bytes and the decision_ref are IDENTICAL to -001. Reordering is not tampering.",
+      "baseline_decision_ref": "655c85c5d14e7bdff09d21b8f292f767c8e519fa5c0529cc0b9f7f695ca2a31b",
+      "decision_ref_preimage_fields": [
+        "artifact_hash",
+        "artifact_type",
+        "policy_version",
+        "verdict"
+      ],
+      "decision_ref_preimage": {
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v1",
+        "verdict": "ALLOW"
+      },
+      "jcs_payload": "{\"artifact_hash\":\"c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662\",\"artifact_type\":\"presidio-hardened-x402/payment-decision@1\",\"policy_version\":\"presidio-x402.policy.v1\",\"verdict\":\"ALLOW\"}",
+      "preimage_canonical_bytes_hex": "7b2261727469666163745f68617368223a2263363161663465356631323666363039333135333734316163313637323035663763636132336231306462653938633336386331326331656637653836363632222c2261727469666163745f74797065223a22707265736964696f2d68617264656e65642d783430322f7061796d656e742d6465636973696f6e4031222c22706f6c6963795f76657273696f6e223a22707265736964696f2d783430322e706f6c6963792e7631222c2276657264696374223a22414c4c4f57227d",
+      "decision_ref": "655c85c5d14e7bdff09d21b8f292f767c8e519fa5c0529cc0b9f7f695ca2a31b",
+      "decision_ref_preimage_unsorted": {
+        "verdict": "ALLOW",
+        "policy_version": "presidio-x402.policy.v1",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662"
+      }
+    },
+    {
+      "id": "presidio-x402-decision-dfc-missing-preimage-field-list",
+      "axis": "forward_compat",
+      "assert": "non_conformant",
+      "expect": "reject",
+      "description": "The record ships a decision_ref_preimage but declares no decision_ref_preimage_fields. Without the self-describing field list a verifier cannot know the canonicalisation scope (which keys, in what set) -> it must fail closed, not guess.",
+      "decision_ref_preimage": {
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v1",
+        "verdict": "ALLOW"
+      }
+    },
+    {
+      "id": "presidio-x402-decision-dfc-unknown-field-fail-closed",
+      "axis": "forward_compat",
+      "assert": "fail_closed",
+      "expect": "reject",
+      "description": "A future policy version adds risk_tier to the preimage object but does NOT list it in decision_ref_preimage_fields. Declared fields != object keys, so an older verifier would hash a subset and silently accept a decision it cannot fully reconstruct -> fail closed. The self-describing field list exists precisely so the surface can grow without this.",
+      "decision_ref_preimage": {
+        "artifact_hash": "c61af4e5f126f6093153741ac167205f7cca23b10dbe98c368c12c1ef7e86662",
+        "artifact_type": "presidio-hardened-x402/payment-decision@1",
+        "policy_version": "presidio-x402.policy.v1",
+        "verdict": "ALLOW",
+        "risk_tier": "elevated"
+      },
+      "decision_ref_preimage_fields": [
+        "artifact_hash",
+        "artifact_type",
+        "policy_version",
+        "verdict"
+      ]
+    }
   ]
 }

--- a/tests/test_decision_ref_conformance.py
+++ b/tests/test_decision_ref_conformance.py
@@ -104,3 +104,43 @@ def test_fixture_leads_with_negatives():
     assert "signer_equals_runtime" in fmodes
     assert "verdict_not_recomputable" in fmodes
     assert any(v["expect"] == "accept" for v in _VECTORS)
+
+
+# --- second block: pshkv's digest / forward-compat axis (x402#2332, autogen#7353) ---
+_DFC = _FIXTURE.get("digest_forward_compat_vectors", [])
+_DFC_IDS = [v["id"] for v in _DFC]
+
+
+def _conformant_preimage(v: dict) -> bool:
+    """A preimage is verifiable only if its field list is present and set-equal to its keys."""
+    fields = v.get("decision_ref_preimage_fields")
+    return bool(fields) and set(fields) == set(v["decision_ref_preimage"].keys())
+
+
+@pytest.mark.parametrize("v", _DFC, ids=_DFC_IDS)
+def test_digest_forward_compat(v):
+    """Digest axis: id sensitive to its preimage, and fails closed on the unknown."""
+    a = v["assert"]
+    pre = v["decision_ref_preimage"]
+    if a == "decision_ref_differs":
+        # same artifact, one changed preimage field -> a different, still-recomputable id
+        assert pre["artifact_hash"] == _FIXTURE["vectors"][0]["artifact_hash"]
+        assert sha256_hex(jcs(pre)) == v["decision_ref"] != v["baseline_decision_ref"]
+    elif a == "decision_ref_equals":
+        # JCS is order-insensitive: scrambled keys canonicalise to the same bytes and id
+        assert jcs(v["decision_ref_preimage_unsorted"]) == jcs(pre) == v["jcs_payload"]
+        assert sha256_hex(jcs(pre)) == v["decision_ref"] == v["baseline_decision_ref"]
+    elif a in ("non_conformant", "fail_closed"):
+        assert v["expect"] == "reject"
+        assert not _conformant_preimage(v)
+    else:
+        pytest.fail(f"{v['id']}: unknown assert '{a}'")
+
+
+def test_digest_block_covers_pshkv_matrix():
+    """All five pshkv cases present: two bindings, canonicalisation, and both fail-closed."""
+    asserts = [v["assert"] for v in _DFC]
+    assert asserts.count("decision_ref_differs") == 2  # policy_version + verdict binding
+    assert "decision_ref_equals" in asserts  # reorder -> same digest
+    assert "non_conformant" in asserts  # missing preimage field list
+    assert "fail_closed" in asserts  # unknown field, not in declared list


### PR DESCRIPTION
## Summary
- Adds a **second block** to the decision-ref fixture — pshkv's digest/forward-compat matrix from [autogen#7353](https://github.com/microsoft/autogen/issues/7353#issuecomment-4868978346) / [x402#2332](https://github.com/x402-foundation/x402/issues/2332#issuecomment-4881274015). The first block tests *admission + recompute* (is a verdict entitled to its verdict); this block tests the *digest axis* (is the id sensitive to its own preimage, and does it fail closed on the unknown).
- Five vectors: `dfc-policy-version-binding` and `dfc-verdict-binding` (same artifact_hash, one changed preimage field → **different** decision_ref), `dfc-canonicalisation-stable` (reordered keys → JCS → **same** digest), and two fail-closed negatives — `dfc-missing-preimage-field-list` (no declared field list → non-conformant) and `dfc-unknown-field-fail-closed` (declared list ≠ object keys → fail closed).
- The three original vectors are **byte-identical** (verified) — babyblueviper1's recompute-grade on argentum-core #29 still holds. Generator (`build_fixture.py`) self-validates the new block; conformance rule for fail-closed: `decision_ref_preimage_fields` must be present, non-empty, and set-equal to the preimage object's keys.

## Test plan
- [x] `ruff check .` + `ruff format --check .` clean
- [x] `pytest tests/test_decision_ref_conformance.py` — 19 passed (13 original + 6 new)
- [x] full `pytest tests/` green
- [x] first-block vectors confirmed byte-identical to the merged fixture