### PR TITLE
conformance: home the recompute-layer (recompute_mismatch)

### DIFF
--- a/tests/conformance/recompute-layer/README.md
+++ b/tests/conformance/recompute-layer/README.md
@@ -1,0 +1,64 @@
+# recompute-layer — `recompute_mismatch`
+
+Integrity is not derivation. A decision record can be intact, correctly signed, and
+schema-valid, and its recorded verdict can still fail to re-derive from its own controls.
+That failure needs its own name and its own check; this directory is both.
+
+## The four layers
+
+The boundaries are load-bearing, and people collapse them:
+
+- **integrity** — the record was preserved (hash/digest, schema);
+- **signature** — who signed it (admission: is the signer entitled to decide?);
+- **recompute** — the verdict follows from the *declared* controls — **this layer**;
+- **attestation** — the declared controls are the *real* controls (separate, not here).
+
+A record that fails the recompute layer is flagged under `recompute_mismatch`. The name
+was proposed and agreed on [x402-foundation/x402#2332](https://github.com/x402-foundation/x402/issues/2332)
+(babyblueviper1, Tuttotorna, vstantch, 2026-07-04): it is the honest name because nothing
+was tampered with — the decision simply does not follow from its own controls.
+
+`recompute_mismatch` is **additive, never an override**: an integrity/signature check can
+say the receipt is intact and correctly signed while recompute says the decision does not
+re-derive, and both stand on their own.
+
+## The concrete instance: `verdict = f(controls)`
+
+`f` is the pure precedence-combinator over the five recorded control verdicts
+(`[pii, trusted_wallet, policy, replay, mpa]`, first-failure-wins, MPA timeout → REFER)
+already pinned by the [`decision-ref`](../decision-ref/) fixture. `recompute_check.py`
+runs it over that fixture and **discriminates across layers**:
+
+| decision-ref vector | recompute | why |
+|---|---|---|
+| `presidio-x402-decision-001` | AGREES | clean controls, `f=ALLOW=recorded` |
+| `presidio-x402-decision-signer-equals-runtime` | AGREES | its failure is **admission** (signer is the actor's wallet) — a *different* layer; recompute correctly does not flag it |
+| `presidio-x402-decision-verdict-not-recomputable` | `recompute_mismatch` | recorded `ALLOW`, but `policy.verdict=VIOLATION` ⇒ `f=DENY` |
+
+That the admission negative is *not* flagged here is the point: recompute is one layer, not
+all of them.
+
+Run it:
+
+```
+python3 tests/conformance/recompute-layer/recompute_check.py   # exits 0; discriminates
+python3 -m pytest tests/test_recompute_layer.py -q             # CI coverage
+```
+
+## Scope — what this proves and does not
+
+- **Does** prove: given the recorded controls, the recorded verdict does not equal
+  `f(controls)`. The signed decision does not re-derive from its own inputs.
+- **Does not** prove: that the controls themselves are truthful. A recorder who lies about
+  `policy.verdict` gets a clean recompute over a false premise — an *attestation* failure,
+  not a recompute one. Recompute checks derivation, not honesty.
+
+## Provenance
+
+Proposed as a layer for the APS accountability-record suite
+([aeoess/aps-conformance-suite#9](https://github.com/aeoess/aps-conformance-suite/pull/9),
+cold-clone-graded clean twice by babyblueviper1, placement endorsed by Tuttotorna). APS
+declined new failure-class vocabulary on 2026-07-04 pending a written contribution policy,
+so the layer is homed here beside its concrete instance — the `decision-ref` fixture — where
+it is CI-covered. The APS-shaped record and cross-language verifier remain on the closed PR
+branch for reference.

--- a/tests/conformance/recompute-layer/recompute_check.py
+++ b/tests/conformance/recompute-layer/recompute_check.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""recompute-layer — the `recompute_mismatch` conformance class.
+
+Integrity checks (signature, digest, schema) prove a decision record is INTACT and
+correctly signed. They do NOT prove the recorded verdict RE-DERIVES from the record's
+own controls. This layer closes that gap for the concrete instance verdict = f(controls).
+
+Four layers, boundaries load-bearing:
+  integrity   -- the record was preserved
+  signature   -- who signed it (admission: is the signer entitled to decide?)
+  recompute   -- the verdict follows from the DECLARED controls   <-- this layer
+  attestation -- the declared controls are the REAL controls      (separate, not here)
+
+A record whose verdict does not re-derive is flagged under `recompute_mismatch` (name
+agreed on x402-foundation/x402#2332; parallels a `_mismatch` integrity class). It is
+never a substitute for another layer's verdict -- recompute is additive.
+
+Run over the sibling decision-ref fixture, this DISCRIMINATES across layers:
+  - presidio-x402-decision-001                      -> recompute AGREES
+  - presidio-x402-decision-signer-equals-runtime    -> recompute AGREES (its failure is
+      admission, a different layer -- recompute correctly does not flag it)
+  - presidio-x402-decision-verdict-not-recomputable -> recompute_mismatch
+
+Recompute checks derivation from the DECLARED controls; it cannot say the controls are
+truthful. A recorder who lies about a control verdict gets a clean recompute over a
+false premise -- that is an attestation failure, not a recompute one.
+
+Provenance: proposed as an APS accountability-record layer (aeoess/aps-conformance-suite
+PR #9); APS declined new failure-class vocabulary 2026-07-04 pending a contribution
+policy, so the layer is homed here beside its concrete instance. Zero dependencies.
+"""
+
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIXTURE = os.path.join(HERE, "..", "decision-ref", "presidio-x402-decision-ref-v1.fixture.json")
+
+RECOMPUTE_MISMATCH = "recompute_mismatch"
+
+# Control verdicts that force DENY, per control key (first-failure-wins).
+HARD_FAIL = {
+    "pii": {"PII_BLOCKED"},
+    "trusted_wallet": {"UNTRUSTED"},
+    "policy": {"VIOLATION"},
+    "replay": {"DUPLICATE"},
+    "mpa": {"DENIED"},
+}
+# mpa verdicts that force REFER (defer to a human / multi-party approver).
+MPA_REFER = {"PENDING", "TIMEOUT"}
+PRECEDENCE = ["pii", "trusted_wallet", "policy", "replay", "mpa"]
+
+# The one vector this layer is meant to flag; the others fail elsewhere or not at all.
+EXPECTED_FLAGGED = ["presidio-x402-decision-verdict-not-recomputable"]
+
+
+def f_controls(controls: dict) -> str:
+    """Precedence-combinator over the five recorded control verdicts.
+    First failure wins; returns ALLOW / DENY / REFER."""
+    for key in PRECEDENCE:
+        verdict = controls.get(key, {}).get("verdict")
+        if verdict in HARD_FAIL.get(key, set()):
+            return "DENY"
+        if key == "mpa" and verdict in MPA_REFER:
+            return "REFER"
+    return "ALLOW"
+
+
+def recompute(vec: dict):
+    """Return (recorded, recomputed, kind). kind is recompute_mismatch on a flag, else None."""
+    recorded = vec["artifact"]["verdict"]
+    recomputed = f_controls(vec["artifact"]["controls"])
+    kind = None if recomputed == recorded else RECOMPUTE_MISMATCH
+    return recorded, recomputed, kind
+
+
+def main() -> int:
+    with open(FIXTURE, encoding="utf-8") as fh:
+        fixture = json.load(fh)
+    print("recompute-layer -- verdict = f(controls), first-failure-wins\n")
+
+    flagged = []
+    for vec in fixture["vectors"]:
+        recorded, recomputed, kind = recompute(vec)
+        if kind is None:
+            note = "recompute AGREES"
+        else:
+            note = f"recompute DISAGREES -> {kind}"
+            flagged.append(vec["id"])
+        layer = ""
+        if vec.get("failure_mode") == "signer_equals_runtime":
+            layer = "  (admission failure -- a different layer; recompute does not flag it)"
+        print(f"  {vec['id']:48} recorded={recorded:6} f(controls)={recomputed:6} {note}{layer}")
+
+    print()
+    if flagged == EXPECTED_FLAGGED:
+        print(f"recompute_mismatch flagged exactly {flagged} (discriminates; not always-fail)")
+        return 0
+    print(f"[!] UNEXPECTED: flagged={flagged}, expected={EXPECTED_FLAGGED}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_recompute_layer.py
+++ b/tests/test_recompute_layer.py
@@ -1,0 +1,54 @@
+"""Conformance test for the recompute-layer (`recompute_mismatch`).
+
+Loads the standalone discriminator and asserts it flags exactly the decision-ref vector
+whose verdict does not re-derive from its controls, while leaving the admission negative
+(a different layer) unflagged. See tests/conformance/recompute-layer/README.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_DIR = Path(__file__).parent / "conformance" / "recompute-layer"
+_CHECK = _DIR / "recompute_check.py"
+_FIXTURE = (
+    Path(__file__).parent
+    / "conformance"
+    / "decision-ref"
+    / "presidio-x402-decision-ref-v1.fixture.json"
+)
+
+_spec = importlib.util.spec_from_file_location("recompute_check", _CHECK)
+rc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rc)
+
+_VECTORS = json.loads(_FIXTURE.read_text(encoding="utf-8"))["vectors"]
+_BY_ID = {v["id"]: v for v in _VECTORS}
+
+
+def test_verdict_not_recomputable_flags_recompute_mismatch():
+    v = _BY_ID["presidio-x402-decision-verdict-not-recomputable"]
+    _, recomputed, kind = rc.recompute(v)
+    assert recomputed == "DENY"
+    assert kind == rc.RECOMPUTE_MISMATCH
+
+
+@pytest.mark.parametrize(
+    "vid",
+    ["presidio-x402-decision-001", "presidio-x402-decision-signer-equals-runtime"],
+)
+def test_recompute_agrees_where_the_failure_is_not_derivation(vid):
+    # recompute is one layer: it agrees on the baseline and on the admission negative
+    # (whose failure signature, not derivation, is supposed to catch).
+    _, _, kind = rc.recompute(_BY_ID[vid])
+    assert kind is None
+
+
+def test_layer_discriminates_and_check_exits_clean():
+    flagged = [v["id"] for v in _VECTORS if rc.recompute(v)[2] is not None]
+    assert flagged == ["presidio-x402-decision-verdict-not-recomputable"]
+    assert rc.main() == 0


### PR DESCRIPTION
## Summary
- Re-homes the **recompute / derivation verification layer** into our own repo after APS declined new failure-class vocabulary ([aeoess/aps-conformance-suite#9](https://github.com/aeoess/aps-conformance-suite/pull/9), closed 2026-07-04 pending a written contribution policy). The layer was cold-clone-graded clean twice by babyblueviper1 and its placement endorsed by Tuttotorna on [x402#2332](https://github.com/x402-foundation/x402/issues/2332); it lives here now, beside its concrete instance.
- `tests/conformance/recompute-layer/recompute_check.py` runs `verdict = f(controls)` over the existing `decision-ref` fixture and **discriminates across layers**: `verdict-not-recomputable` flags `recompute_mismatch`, while the admission negative (`signer-equals-runtime`) is correctly *not* flagged — that failure belongs to the signature layer. Zero dependencies.
- `README.md` documents the four-layer boundary (integrity / signature / recompute / attestation), the `recompute_mismatch` name agreed on #2332, and the honesty ceiling (recompute checks derivation from the *declared* controls, not their truthfulness — that's attestation).
- `tests/test_recompute_layer.py` gives CI coverage.

## Test plan
- [x] `python3 tests/conformance/recompute-layer/recompute_check.py` → exits 0, discriminates (only `verdict-not-recomputable` flagged)
- [x] `ruff check .` + `ruff format --check .` clean
- [x] `pytest tests/test_recompute_layer.py` — 4 passed; full `pytest tests/` green
- [x] vstantch-code style lint clean on the shipped script