### PR TITLE
Release x402 v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,35 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-No unreleased changes.
+## [0.9.0] — 2026-07-05
+
+### Added
+- **Capability certificates (`presidio-hardened/capability-grant@1`).** A
+  signed, offline-verifiable, attenuable spending grant format for turning
+  operator policy into a portable capability chain. Grants use the family
+  canonical JSON profile, detached Ed25519 signatures, SHA-256 content
+  addressing, float-free amount encoding, monotone caveat attenuation, strict
+  expiry, and a `PolicyConfig` bridge for admitted chains.
+- **Decision-ref emission (`presidio-hardened-x402/payment-decision@1`).** A signed,
+  portable, offline-verifiable record of one payment decision — the per-control gate
+  verdicts (`pii → trusted_wallet → policy → replay → mpa`), hashed inputs, and the
+  effective policy hash bound into the family `evidence-ref@1` envelope, with a thin,
+  recomputable `decision_ref` correlation id (Pillar II of the Computational
+  Jurisprudence program). New `presidio_x402.decision_ref` module: `DecisionRefEmitter`,
+  `build_payment_decision_content`, `build_decision_evidence`, `compute_decision_ref`,
+  `verify_decision_ref`, `f_controls`, `ControlResults`, file/null writers, and an
+  offline CLI verifier (`python -m presidio_x402.decision_ref`). Emission is **opt-in
+  via `HardenedX402Client(decision_ref_emitter=...)` and off by default** — behaviour is
+  byte-identical to prior releases when unset, and there is no network I/O on the emit
+  path. The verifier fails closed with distinct reasons (hash mismatch, non-recomputable
+  verdict, self-approval `signer_equals_runtime`, unknown signer, bad signature, broken
+  parent linkage) and, when the policy came from a `capability-grant@1` chain, checks
+  provenance linkage to the chain's terminal `grant_hash`. PII-freedom is structural: the
+  record carries only hashes and entity-type labels, never a raw metadata string; the
+  `offer_hash` is the SHA-256 digest of the raw 402 offer bytes as received and is omitted
+  with `offer_hash_absent: "not-retained"` when those bytes are unavailable. Wire format
+  pinned by `tests/conformance/decision-ref/` and
+  `plan/presidio-evidence-decision-ref-design.md`.
 
 ## [0.8.1] — 2026-06-29
 

--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -474,6 +474,53 @@ Critical/High/Medium findings); see
 
 ---
 
+## v0.9.0 Requirements (proof-carrying decision evidence) — **delivered 2026-07-05**
+
+Additive, opt-in evidence surface. No change to the shipped screening order or to
+default behaviour; the feature is off unless a caller supplies an emitter.
+
+### Delivered
+
+- [x] **Decision-ref emission (`presidio-hardened-x402/payment-decision@1`)** — a
+  signed, portable, offline-verifiable record of one payment decision (Pillar II of
+  the Computational Jurisprudence program). Binds the per-control gate verdicts
+  (`pii → trusted_wallet → policy → replay → mpa`), hashed inputs, and the effective
+  policy content hash into the family `evidence-ref@1` envelope, with a thin,
+  recomputable `decision_ref` correlation id. Implemented in
+  `src/presidio_x402/decision_ref.py`; wired into `ScreeningPipeline` /
+  `HardenedX402Client` via `decision_ref_emitter=` (**default off — behaviour
+  byte-identical when unset**). No network I/O on the emit path.
+
+- [x] **Capability certificates (`presidio-hardened/capability-grant@1`)** — signed,
+  offline-verifiable, attenuable spending grants that turn operator policy into a
+  portable capability chain. Implemented in `src/presidio_x402/capability.py` with
+  detached Ed25519 signatures, family canonical JSON, SHA-256 content addressing,
+  float-free amounts, monotone caveat narrowing, strict expiry, and a `PolicyConfig`
+  bridge for admitted chains.
+
+- [x] **Fail-closed offline verifier** — `verify_decision_ref` (+ a
+  `python -m presidio_x402.decision_ref` CLI) checks signature, hash integrity,
+  verdict recomputation (`verdict == f(controls)`), self-approval refusal
+  (`signer_equals_runtime`), and — when the policy came from a `capability-grant@1`
+  chain — provenance linkage to the chain's terminal `grant_hash`. Distinct reason
+  code per layer; never fails open.
+
+- [x] **PII-freedom by construction** — the record carries only hashes, an origin,
+  and entity-type labels. `offer_hash` is the SHA-256 digest of the raw 402 offer
+  bytes as received; when the raw bytes are unavailable the field is omitted with
+  `offer_hash_absent: "not-retained"`. No field accepts a raw metadata string, and
+  a PII-bearing corpus test asserts no raw string reaches any emitted record.
+
+### Honest-claims bound
+
+The record proves what the library **concluded under a declared predicate**,
+tamper-evidently (signed) and admissibly (recomputable). It does **not** prove the
+process was uncompromised or that the declared controls are the real controls
+(that is an attestation layer, not this one) — **no TEE claim**. The optional
+public-chain anchor (`decision-anchor@1`) is deferred, not implemented.
+
+---
+
 ## Security Model
 
 The threat model for presidio-hardened-x402 addresses the following adversaries:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml/badge.svg)](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/presidio-v/presidio-hardened-x402/badge)](https://securityscorecards.dev/viewer/?uri=github.com/presidio-v/presidio-hardened-x402)
 
-> v0.8.0 — NLP screening is now a structural superset of regex (the high-accuracy engine no longer misses structured identifiers like SSN/phone/card), plus a composed-envelope `screen_ref` leg, `action_ref` byte-determinism, URL-redacted log hygiene, and OpenSSF Scorecard / SLSA Build L3 supply-chain hardening.
+> v0.9.0 — proof-carrying x402 evidence: attenuable `capability-grant@1` spending grants plus opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records.
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -368,6 +368,56 @@ The signing key lives in a separate bridge sidecar (arch-translucency stays key-
 holds only the public key. The wire contract is pinned by the `evidence-ref@1`
 golden-vector tests shared with arch-translucency.
 
+---
+
+## Decision-ref emission (`payment-decision@1`)
+
+A **decision-ref** is a signed, portable record of one payment decision that a third
+party verifies **offline** — without re-running the gateway. It binds the per-control
+gate verdicts (`pii → trusted_wallet → policy → replay → mpa`), the hashed inputs, and
+the effective policy hash into the family `evidence-ref@1` envelope, with a thin,
+recomputable `decision_ref` correlation id. Emission is **opt-in and off by default**;
+when no emitter is configured, behaviour is byte-identical to prior releases and no
+decision-ref code runs. There is no network I/O on the emit path.
+
+```python
+from presidio_x402 import HardenedX402Client, DecisionRefEmitter, verify_decision_ref
+from presidio_x402.decision_ref import FileDecisionRefWriter
+
+# Signer independence is claim-critical: a policy/approval identity distinct from the
+# payment wallet — a self-signed record fails closed on verify (signer_equals_runtime).
+emitter = DecisionRefEmitter(
+    signing_key=POLICY_PRIVATE_KEY_HEX,          # Ed25519 (or an HMAC secret)
+    signer="presidio-hardened-x402-policy",
+    writer=FileDecisionRefWriter("/var/log/x402-decisions.jsonl"),
+)
+client = HardenedX402Client(payment_signer=signer, decision_ref_emitter=emitter)
+# ... one signed payment-decision@1 record is emitted per paid payment.
+
+# Verify offline against a pinned trust store (fail-closed, distinct reasons):
+result = verify_decision_ref(envelope, {"presidio-hardened-x402-policy":
+    {"alg": "ed25519", "public_key": POLICY_PUBLIC_KEY_HEX}})
+assert result.ok and result.verdict == "ALLOW"
+```
+
+The verifier checks signature, hash integrity, that the recorded verdict **re-derives**
+from the recorded controls (`verdict == f(controls)` — the line between *attested* and
+*admissible*), that the signer is not the actor's own controller (self-approval fails
+closed), and — when the spending policy came from a capability chain
+(`capability-grant@1`) — parent linkage to the chain's terminal `grant_hash`.
+A minimal offline CLI is provided:
+
+```bash
+python -m presidio_x402.decision_ref envelope.jsonl trust-store.json
+```
+
+**Honest bound.** A decision-ref proves what the library concluded under a *declared*
+predicate, tamper-evidently and recomputably. It does **not** prove the process was
+uncompromised or that the declared controls are the real controls (no TEE claim). Wire
+format and `decision_ref` derivation are pinned by the conformance fixture under
+`tests/conformance/decision-ref/` and the design note
+`plan/presidio-evidence-decision-ref-design.md`.
+
 ### Provisioning Metadata Redaction
 
 Capacity-upgrade requests can reveal workload type, data classification, or access pattern.
@@ -428,8 +478,9 @@ All exceptions are importable from `presidio_x402`.
 | v0.5.0 | **OEM embed kit** — rail-agnostic `ScreeningPipeline` core + `bindings/x402` layer (`PaymentProtocolBinding` protocol, hedge against rail fragmentation: ACP/Tempo, AP2) · [SEMVER.md](SEMVER.md) stability guarantees · partner conformance suite (`python -m presidio_x402.conformance`) · CDP/LangChain/CrewAI quickstarts · SBOM in CI · freshness-bound MPA countersignatures (F-8) |
 | v0.6.0 | **Production hardening + evidence substrate** — multi-tenant replay namespaces · enterprise audit sinks (S3 / Splunk / Datadog) · signed `evidence-ref@1` verification · SLSA/OIDC release provenance · digest-pinned Docker base + hash-pinned spaCy model · latency SLO and all-matrix coverage CI gates · OTel spans · policy hot-reload · startup key gates · human-pentest retest closure |
 | v0.7.0 | **SLO payment broker (library)** — x402 micropayments as runtime infrastructure bids: `SLOPaymentBroker` + `SLOPaymentPolicy` + evidence-anchored `ArchTranslucencyAdapter` + provisioning PII entities; cross-repo validated against `presidio-hardened-arch-translucency`. cs.DC preprint + empirical eval tracked separately |
-| **v0.8.0** | **PII completeness + supply-chain hardening (library)** — `nlp` mode is now a structural superset of `regex` (no structured-identifier misses) · composed-envelope `screen_ref` leg · `action_ref` byte-determinism (NFC + non-empty entity sets) · URL-redacted log hygiene · OpenSSF Scorecard workflow/badge + SLSA Build L3 provenance · independent multi-round security audit cleared — **latest release** |
-| Unreleased on `main` | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
+| v0.8.0 | PII completeness + supply-chain hardening (library) — `nlp` mode is now a structural superset of `regex` (no structured-identifier misses) · composed-envelope `screen_ref` leg · `action_ref` byte-determinism (NFC + non-empty entity sets) · URL-redacted log hygiene · OpenSSF Scorecard workflow/badge + SLSA Build L3 provenance · independent multi-round security audit cleared |
+| **v0.9.0** | **Proof-carrying x402 evidence** — `capability-grant@1` attenuable spending grants + opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records — **latest release** |
+| Future | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
 
 See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.8.1"
+version = "0.9.0"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -36,8 +36,33 @@ from .action_ref import (
 from .arch_translucency_adapter import ArchTranslucencyAdapter, SLOTrigger
 from .audit_log import AuditLog, FileAuditWriter, NullAuditWriter, StreamAuditWriter
 from .bindings.x402 import X402Binding
+from .capability import (
+    CAPABILITY_SCHEMA_ID,
+    CapabilityError,
+    Caveats,
+    Grant,
+    VerifiedGrantChain,
+    delegate_grant,
+    issue_grant,
+    policy_config_from_chain,
+    verify_chain,
+)
 from .compliance_report import ComplianceReport
 from .core import ScreeningPipeline
+from .decision_ref import (
+    PAYMENT_DECISION_SCHEMA_ID,
+    ControlResults,
+    DecisionRefEmitter,
+    DecisionRefError,
+    DecisionRefVerification,
+    FileDecisionRefWriter,
+    NullDecisionRefWriter,
+    build_decision_evidence,
+    build_payment_decision_content,
+    compute_decision_ref,
+    f_controls,
+    verify_decision_ref,
+)
 from .exceptions import (
     MPADeniedError,
     MPATimeoutError,
@@ -69,7 +94,7 @@ from .slo_broker import (
 )
 from .slo_policy import SLOPaymentPolicy
 
-__version__ = "0.7.0"
+__version__ = "0.9.0"
 __all__ = [
     # Primary public API
     "HardenedX402Client",
@@ -79,11 +104,34 @@ __all__ = [
     "ScreeningPipeline",
     "PaymentProtocolBinding",
     "X402Binding",
+    # Capability certificates (capability-grant@1) — Pillar I
+    "issue_grant",
+    "delegate_grant",
+    "verify_chain",
+    "policy_config_from_chain",
+    "VerifiedGrantChain",
+    "Grant",
+    "Caveats",
+    "CapabilityError",
+    "CAPABILITY_SCHEMA_ID",
     # MiCA/EU signed evidence (evidence-ref@1 wire format)
     "build_evidence",
     "Obligation",
     "OBLIGATION_MAP",
     "EvidenceError",
+    # Decision-ref emission (payment-decision@1 in evidence-ref@1) — Pillar II
+    "DecisionRefEmitter",
+    "DecisionRefError",
+    "DecisionRefVerification",
+    "ControlResults",
+    "NullDecisionRefWriter",
+    "FileDecisionRefWriter",
+    "build_payment_decision_content",
+    "build_decision_evidence",
+    "compute_decision_ref",
+    "verify_decision_ref",
+    "f_controls",
+    "PAYMENT_DECISION_SCHEMA_ID",
     # Multi-party authorization
     "MPAConfig",
     "MPAApproverConfig",

--- a/src/presidio_x402/capability.py
+++ b/src/presidio_x402/capability.py
@@ -1,0 +1,914 @@
+"""Capability certificates — operator-signed, attenuable spending grants.
+
+Turns spending *authority* from configuration (``PolicyConfig`` read from env or
+kwargs) into a *capability*: a signed, portable, attenuable, expiring grant that
+a verifier admits **locally, with no network round-trip**. This is Pillar I of
+the Computational Jurisprudence program (Stantchev, arXiv 2026) and the seed of a
+caveat-format standards track (see ``plan/capability-certificates-design.md``).
+
+Schema: ``presidio-hardened/capability-grant@1``.
+
+Design creed — *more secure = less coordination*. The honest exercise path is
+O(1) local verification. Monotone attenuation holds **by construction**: the
+caveat language is conjunctive and negation-free, so a child grant can only ever
+*narrow* the authority of its parent, never broaden it. Every caveat rule below is
+a subset rule; adding a caveat can only shrink the admitted (url, amount, time)
+set. Do **not** add a caveat type whose combination with another can widen
+authority — that would break the monotonicity property the paper restricts to
+exactly this fragment.
+
+Wire format (family Layer-0, mirrored via :mod:`presidio_x402.mica`):
+
+- canonical JSON = sorted keys, ``(",", ":")`` separators, UTF-8,
+  ``ensure_ascii=False``, **floats rejected** (:func:`mica.canonical_bytes`);
+- ``grant_id`` / ``parent_hash`` content addressing = SHA-256 over the canonical
+  bytes of the grant *including* its signature (a grant is only addressable once
+  signed);
+- detached Ed25519 signature over the canonical bytes of the grant with the
+  ``signature`` field **removed** (the signing preimage — see
+  :func:`_signing_preimage`);
+- ``trust-store@1`` shape (reused via :func:`mica.load_trust_store`) supplies the
+  operator public key that a root grant verifies against.
+
+Amounts are integer micro-USD (``int``) or a decimal *string* (``"0.05"``);
+never a float. The strict canonical profile rejects floats outright, and the
+caveat parser converts both accepted forms to :class:`~decimal.Decimal` for
+comparison, mirroring ``policy_engine._decimal_usd``.
+
+Out of scope for ``@1`` (stated in the design doc): revocation beyond expiry
+(accumulators are the research track — **expiry IS the revocation story for
+@1**), sealed chains / ZK proof tiers, bonds, and MCP-server exposure. This pass
+adds no network call and does not wire capability into the MCP server or the
+screening-api.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+
+from .mica import (
+    EvidenceError,
+    canonical_bytes,
+    load_trust_store,
+    sha256_hex,
+)
+
+CAPABILITY_SCHEMA_ID = "presidio-hardened/capability-grant@1"
+
+#: The grant fields (including ``signature``) — any other key fails closed.
+_GRANT_FIELDS = frozenset(
+    {
+        "schema",
+        "grant_id",
+        "subject",
+        "subject_public_key",
+        "caveats",
+        "issuer",
+        "parent_hash",
+        "issued_at",
+        "signature",
+    }
+)
+
+_KNOWN_CAVEATS = frozenset(
+    {
+        "max_per_call_usd",
+        "daily_limit_usd",
+        "window_seconds",
+        "valid_from",
+        "valid_until",
+        "endpoint_prefixes",
+    }
+)
+
+_MAX_STR = 512
+
+
+class CapabilityError(EvidenceError):
+    """Raised on any capability-grant rejection (fail-closed, distinct reasons).
+
+    Subclasses :class:`~presidio_x402.mica.EvidenceError` so a caller that already
+    catches the family evidence error also catches capability failures. The
+    message carries the distinct rejection reason (unknown schema, bad hex,
+    expired, unsigned, broadened, …).
+    """
+
+
+# ---------------------------------------------------------------------------
+# Amount / time helpers (float-free, mirroring policy_engine + action_ref)
+# ---------------------------------------------------------------------------
+
+
+def _amount_decimal(value: object, field_name: str) -> Decimal:
+    """Parse an amount to :class:`Decimal`. Accepts ``int`` (micro-USD) or a
+    decimal ``str``; **rejects floats** and non-finite / negative values.
+
+    Integer inputs are interpreted as micro-USD (1e-6 USD) so a caveat can be
+    expressed in atomic units without a float ever entering the wire form. A
+    string is a plain decimal USD amount (``"0.05"``). This mirrors the
+    family float rule (``mica._reject_floats``) and ``policy_engine._decimal_usd``.
+    """
+    if isinstance(value, bool):  # bool is an int subclass — never an amount
+        raise CapabilityError(f"{field_name} must not be a boolean")
+    if isinstance(value, float):
+        raise CapabilityError(
+            f"{field_name} must be an integer (micro-USD) or a decimal string, "
+            "never a float (strict canonical profile rejects floats)"
+        )
+    if isinstance(value, int):
+        amount = Decimal(value) / Decimal(1_000_000)
+    elif isinstance(value, str):
+        try:
+            amount = Decimal(value)
+        except InvalidOperation as exc:
+            raise CapabilityError(
+                f"{field_name} is not a valid decimal amount: {value!r}"
+            ) from exc
+    else:
+        raise CapabilityError(
+            f"{field_name} must be an integer or decimal string, got {type(value)}"
+        )
+    if not amount.is_finite() or amount < 0:
+        raise CapabilityError(f"{field_name} must be a finite non-negative USD amount")
+    return amount
+
+
+def _parse_rfc3339_utc(value: object, field_name: str) -> datetime:
+    """Parse an RFC 3339 UTC timestamp string to an aware ``datetime`` in UTC.
+
+    Accepts a trailing ``Z`` or an explicit ``+00:00``; a naive or non-UTC value
+    is rejected (an unverifiable window is never admitted). Mirrors the
+    conformant-timestamp discipline in :mod:`presidio_x402.action_ref`.
+    """
+    if not isinstance(value, str) or not value:
+        raise CapabilityError(f"{field_name} must be a non-empty RFC3339 UTC string")
+    raw = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise CapabilityError(f"{field_name} is not a valid RFC3339 timestamp: {value!r}") from exc
+    if dt.tzinfo is None:
+        raise CapabilityError(f"{field_name} must be timezone-aware (UTC); got naive {value!r}")
+    return dt.astimezone(timezone.utc)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _rfc3339(dt: datetime) -> str:
+    """Emit an RFC3339 UTC string with a trailing ``Z`` (second precision)."""
+    return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Caveat model — all conjunctive, all optional except the (implicit) validity
+# window, all subset-preserving. See the design doc's monotone-fragment argument.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Caveats:
+    """Parsed, normalised caveats of one grant.
+
+    Every field is optional; ``None`` means *unconstrained on this axis by this
+    grant*. Because caveats are conjunctive across a chain, an axis left ``None``
+    by one hop is still constrained by any other hop that sets it — the effective
+    authority is the **intersection**, so absence never widens.
+    """
+
+    max_per_call_usd: Decimal | None = None
+    daily_limit_usd: Decimal | None = None
+    window_seconds: int | None = None
+    valid_from: datetime | None = None
+    valid_until: datetime | None = None
+    endpoint_prefixes: tuple[str, ...] | None = None
+
+
+def _parse_caveats(raw: object) -> Caveats:
+    """Validate and normalise a caveats object (fail-closed on any anomaly)."""
+    if not isinstance(raw, Mapping):
+        raise CapabilityError("caveats must be an object")
+    unknown = set(raw.keys()) - _KNOWN_CAVEATS
+    if unknown:
+        # Fail closed on unknown caveat keys: an unrecognised caveat could be a
+        # negation/widening type from a future, non-monotone fragment, and
+        # silently ignoring it would admit authority the issuer did not grant.
+        raise CapabilityError(f"unknown caveat(s): {sorted(unknown)} (fail-closed)")
+
+    max_call = (
+        _amount_decimal(raw["max_per_call_usd"], "caveats.max_per_call_usd")
+        if "max_per_call_usd" in raw
+        else None
+    )
+    daily = (
+        _amount_decimal(raw["daily_limit_usd"], "caveats.daily_limit_usd")
+        if "daily_limit_usd" in raw
+        else None
+    )
+
+    window = None
+    if "window_seconds" in raw:
+        w = raw["window_seconds"]
+        if isinstance(w, bool) or not isinstance(w, int) or w <= 0:
+            raise CapabilityError("caveats.window_seconds must be a positive integer")
+        window = w
+
+    valid_from = (
+        _parse_rfc3339_utc(raw["valid_from"], "caveats.valid_from")
+        if "valid_from" in raw
+        else None
+    )
+    valid_until = (
+        _parse_rfc3339_utc(raw["valid_until"], "caveats.valid_until")
+        if "valid_until" in raw
+        else None
+    )
+    if valid_from is not None and valid_until is not None and valid_from > valid_until:
+        raise CapabilityError("caveats.valid_from must not be after caveats.valid_until")
+
+    prefixes: tuple[str, ...] | None = None
+    if "endpoint_prefixes" in raw:
+        ep = raw["endpoint_prefixes"]
+        if (
+            not isinstance(ep, Sequence)
+            or isinstance(ep, (str, bytes))
+            or len(ep) == 0
+            or not all(isinstance(p, str) and p for p in ep)
+        ):
+            raise CapabilityError(
+                "caveats.endpoint_prefixes must be a non-empty list of non-empty URL prefixes"
+            )
+        for p in ep:
+            if not (p.startswith("http://") or p.startswith("https://")):
+                raise CapabilityError(f"endpoint prefix must be an http(s) URL prefix; got {p!r}")
+        prefixes = tuple(ep)
+
+    return Caveats(
+        max_per_call_usd=max_call,
+        daily_limit_usd=daily,
+        window_seconds=window,
+        valid_from=valid_from,
+        valid_until=valid_until,
+        endpoint_prefixes=prefixes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grant model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Grant:
+    """One parsed, structurally-valid capability grant (not yet chain-verified).
+
+    ``raw`` retains the exact wire dict so content-addressing and signature
+    verification recompute from the original bytes, never from a re-serialised
+    view. ``grant_hash`` is the SHA-256 over the canonical bytes of ``raw``
+    (including the signature) — the value a child cites as ``parent_hash``.
+    """
+
+    schema: str
+    grant_id: str
+    subject: str
+    subject_public_key: str | None
+    caveats: Caveats
+    issuer: str
+    parent_hash: str | None
+    issued_at: datetime
+    signature: str
+    raw: Mapping[str, object]
+    grant_hash: str
+
+    @property
+    def is_root(self) -> bool:
+        return self.parent_hash is None
+
+
+def _require_str(
+    raw: Mapping[str, object], name: str, *, allow_missing: bool = False
+) -> str | None:
+    if name not in raw:
+        if allow_missing:
+            return None
+        raise CapabilityError(f"grant missing required field {name!r}")
+    value = raw[name]
+    if value is None and allow_missing:
+        return None
+    if not isinstance(value, str) or not value or len(value) > _MAX_STR:
+        raise CapabilityError(
+            f"grant field {name!r} must be a non-empty string <= {_MAX_STR} chars"
+        )
+    if "\x00" in value:
+        raise CapabilityError(f"grant field {name!r} contains a null byte")
+    return value
+
+
+def _is_hex(value: str, length: int | None = None) -> bool:
+    try:
+        b = bytes.fromhex(value)
+    except ValueError:
+        return False
+    return length is None or len(b) == length
+
+
+def _signing_preimage(raw: Mapping[str, object]) -> bytes:
+    """The canonical bytes a grant's detached signature is computed over.
+
+    Defined exactly as: the grant object with the ``signature`` field removed,
+    encoded by :func:`mica.canonical_bytes` (sorted keys, ``(",", ":")``, UTF-8,
+    ``ensure_ascii=False``, floats rejected). Every other field — including
+    ``grant_id`` and ``parent_hash`` — is inside the signed preimage, so the
+    binding to the parent and the grant's own id are both signature-protected.
+    """
+    without_sig = {k: v for k, v in raw.items() if k != "signature"}
+    return canonical_bytes(without_sig)
+
+
+def parse_grant(raw: object) -> Grant:
+    """Structurally validate one grant dict and content-address it (fail-closed).
+
+    Checks: exact schema constant, presence/typing of required fields, hex shape
+    of ``subject_public_key`` (when present) and ``signature``, and caveat
+    well-formedness. Does **not** verify the signature or chain — that is
+    :func:`verify_chain`'s job. Distinct :class:`CapabilityError` messages per
+    failure class.
+    """
+    if not isinstance(raw, Mapping):
+        raise CapabilityError("grant must be an object")
+    extra = set(raw.keys()) - _GRANT_FIELDS
+    if extra:
+        raise CapabilityError(f"grant has unknown field(s): {sorted(extra)} (fail-closed)")
+
+    schema = raw.get("schema")
+    if schema != CAPABILITY_SCHEMA_ID:
+        raise CapabilityError(
+            f"unsupported grant schema {schema!r} (expected {CAPABILITY_SCHEMA_ID!r})"
+        )
+
+    grant_id = _require_str(raw, "grant_id")
+    subject = _require_str(raw, "subject")
+    issuer = _require_str(raw, "issuer")
+    signature = _require_str(raw, "signature")
+    if not _is_hex(signature, 64):
+        raise CapabilityError(
+            "grant signature must be 128 lowercase hex chars (Ed25519, 64 bytes)"
+        )
+
+    subject_pub = _require_str(raw, "subject_public_key", allow_missing=True)
+    if subject_pub is not None and not _is_hex(subject_pub, 32):
+        raise CapabilityError(
+            "subject_public_key must be 64 lowercase hex chars (Ed25519 public key, 32 bytes)"
+        )
+
+    parent_hash = _require_str(raw, "parent_hash", allow_missing=True)
+    if parent_hash is not None and not _is_hex(parent_hash, 32):
+        raise CapabilityError("parent_hash must be a 64-hex SHA-256 content hash")
+
+    if "caveats" not in raw:
+        raise CapabilityError("grant missing required field 'caveats'")
+    caveats = _parse_caveats(raw["caveats"])
+
+    issued_at = _parse_rfc3339_utc(raw.get("issued_at"), "issued_at")
+
+    grant_hash = sha256_hex(raw)  # content hash over the FULL (signed) grant
+
+    return Grant(
+        schema=schema,
+        grant_id=grant_id,  # type: ignore[arg-type]
+        subject=subject,  # type: ignore[arg-type]
+        subject_public_key=subject_pub,
+        caveats=caveats,
+        issuer=issuer,  # type: ignore[arg-type]
+        parent_hash=parent_hash,
+        issued_at=issued_at,
+        signature=signature,  # type: ignore[arg-type]
+        raw=dict(raw),
+        grant_hash=grant_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issuance / delegation (write path)
+# ---------------------------------------------------------------------------
+
+
+def _caveats_to_wire(caveats: Mapping[str, object]) -> dict[str, object]:
+    """Validate caveats then echo the exact wire form the caller supplied.
+
+    Parsing first fails closed on any malformed caveat; the returned dict is the
+    caller's own values (so amounts stay in their chosen ``int``/``str`` form and
+    canonicalisation is byte-stable), sorted for readability only — canonical
+    bytes re-sort regardless.
+    """
+    _parse_caveats(caveats)  # fail-closed validation; result intentionally unused
+    return {k: caveats[k] for k in sorted(caveats)}
+
+
+def issue_grant(
+    *,
+    subject: str,
+    issuer: str,
+    caveats: Mapping[str, object],
+    issuer_private_key: str,
+    subject_public_key: str | None = None,
+    issued_at: datetime | None = None,
+    grant_id: str | None = None,
+) -> dict[str, object]:
+    """Mint and sign a **root** capability grant (no parent).
+
+    The returned dict is a wire-ready ``capability-grant@1`` object. The
+    detached Ed25519 signature is computed over :func:`_signing_preimage` with
+    ``issuer_private_key`` (64 lowercase hex, the operator key whose public half
+    lives in the verifier trust store). ``grant_id`` defaults to the SHA-256 of
+    the signing preimage so distinct grants get distinct ids without a nonce.
+
+    Supply ``subject_public_key`` when the grant may be *further delegated*: a
+    child's signature verifies against it, so a root that omits it is a leaf that
+    cannot delegate.
+    """
+    caveats_wire = _caveats_to_wire(caveats)
+    body: dict[str, object] = {
+        "schema": CAPABILITY_SCHEMA_ID,
+        "subject": subject,
+        "issuer": issuer,
+        "caveats": caveats_wire,
+        "parent_hash": None,
+        "issued_at": _rfc3339(issued_at or _utcnow()),
+    }
+    if subject_public_key is not None:
+        if not _is_hex(subject_public_key, 32):
+            raise CapabilityError("subject_public_key must be 64 lowercase hex chars")
+        body["subject_public_key"] = subject_public_key
+    body["grant_id"] = grant_id or sha256_hex(body)
+    body["signature"] = _sign_preimage(body, issuer_private_key)
+    return body
+
+
+def delegate_grant(
+    parent: Mapping[str, object],
+    *,
+    parent_private_key: str,
+    caveats: Mapping[str, object],
+    subject: str,
+    subject_public_key: str | None = None,
+    issuer: str | None = None,
+    issued_at: datetime | None = None,
+    grant_id: str | None = None,
+) -> dict[str, object]:
+    """Mint and sign a **child** grant attenuating ``parent``.
+
+    The child's ``parent_hash`` is the content hash of ``parent`` (over its full
+    signed bytes). The child signature is computed with ``parent_private_key`` —
+    the private half of the parent's ``subject_public_key`` — so a verifier
+    checks the child against the parent's declared delegation key. Raises if the
+    parent did not publish a ``subject_public_key`` (a leaf cannot delegate) or
+    if the requested caveats are not an attenuation of the parent's (checked here
+    at mint time *and* re-checked in :func:`verify_chain`, which is authoritative).
+    """
+    parent_grant = parse_grant(parent)
+    if parent_grant.subject_public_key is None:
+        raise CapabilityError(
+            "parent grant published no subject_public_key — it is a leaf and cannot be delegated"
+        )
+    child_caveats = _parse_caveats(caveats)
+    # Fail-closed at mint time so a misuse is caught early; verify_chain repeats
+    # this as the authoritative gate on the read path.
+    _check_attenuation(parent_grant.caveats, child_caveats)
+
+    caveats_wire = _caveats_to_wire(caveats)
+    body: dict[str, object] = {
+        "schema": CAPABILITY_SCHEMA_ID,
+        "subject": subject,
+        "issuer": issuer or parent_grant.subject,
+        "caveats": caveats_wire,
+        "parent_hash": parent_grant.grant_hash,
+        "issued_at": _rfc3339(issued_at or _utcnow()),
+    }
+    if subject_public_key is not None:
+        if not _is_hex(subject_public_key, 32):
+            raise CapabilityError("subject_public_key must be 64 lowercase hex chars")
+        body["subject_public_key"] = subject_public_key
+    body["grant_id"] = grant_id or sha256_hex(body)
+    body["signature"] = _sign_preimage(body, parent_private_key)
+    return body
+
+
+def _sign_preimage(body: Mapping[str, object], private_key: str) -> str:
+    """Detached Ed25519 signature over the grant signing preimage (hex).
+
+    Reuses the family signing primitive shape (:func:`mica.sign_evidence`) but
+    signs the capability preimage rather than the evidence ``{content_hash,
+    signer}`` tuple, because a capability grant's authority lives in the *whole*
+    object (caveats, parent binding, subject), not a hash summary.
+    """
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    if not private_key or not _is_hex(private_key, 32):
+        raise CapabilityError("issuer/parent private key must be 64 lowercase hex chars")
+    sk = ed25519.Ed25519PrivateKey.from_private_bytes(bytes.fromhex(private_key))
+    return sk.sign(_signing_preimage(body)).hex()
+
+
+# ---------------------------------------------------------------------------
+# Attenuation — every rule makes child authority a SUBSET of the parent's.
+# ---------------------------------------------------------------------------
+
+
+def _limit_narrows(parent: Decimal | None, child: Decimal | None, name: str) -> None:
+    """A monetary cap: child must be present and <= parent whenever the parent
+    constrains it. If the parent caps an axis, the child may not leave it
+    unbounded (that would widen), and may not raise it."""
+    if parent is None:
+        return  # parent unconstrained on this axis — child may set any bound (narrows or equal)
+    if child is None:
+        raise CapabilityError(
+            f"attenuation violation: parent caps {name} at {parent} but child leaves it "
+            "unbounded (would broaden authority)"
+        )
+    if child > parent:
+        raise CapabilityError(
+            f"attenuation violation: child {name}={child} exceeds parent {name}={parent} "
+            "(would broaden authority)"
+        )
+
+
+def _window_subset(parent: Caveats, child: Caveats) -> None:
+    """Child validity window must be a subset of the parent's.
+
+    ``valid_from`` may only move later (>=), ``valid_until`` only earlier (<=).
+    A parent bound that the child drops would widen the window, so a child must
+    carry a bound at least as tight as any the parent sets."""
+    if parent.valid_from is not None and (
+        child.valid_from is None or child.valid_from < parent.valid_from
+    ):
+        raise CapabilityError(
+            "attenuation violation: child valid_from is earlier than / drops parent's "
+            "(would widen the validity window)"
+        )
+    if parent.valid_until is not None and (
+        child.valid_until is None or child.valid_until > parent.valid_until
+    ):
+        raise CapabilityError(
+            "attenuation violation: child valid_until is later than / drops parent's "
+            "(would widen the validity window)"
+        )
+
+
+def _window_seconds_narrows(parent: Caveats, child: Caveats) -> None:
+    """``window_seconds`` sizes the rolling aggregate ledger window.
+
+    For a fixed aggregate cap, a shorter rolling window evicts spend sooner and
+    admits more throughput over time. A child may therefore only keep or lengthen
+    the parent's budget window. Dropping a parent-set window is also a broadening.
+    """
+    if parent.window_seconds is None:
+        return
+    if child.window_seconds is None or child.window_seconds < parent.window_seconds:
+        raise CapabilityError(
+            "attenuation violation: child window_seconds is shorter than / drops parent's "
+            "(a shorter budget window evicts spend sooner — would broaden authority)"
+        )
+
+
+def _prefixes_extend(parent: Caveats, child: Caveats) -> None:
+    """Every child endpoint prefix must fall under a parent prefix on URL
+    host/path boundaries.
+
+    This makes the child's admitted-URL set a subset of the parent's without
+    allowing prefix-confusion siblings such as ``/inference-evil`` or
+    ``api.example.com.evil``.
+    """
+    from .policy_engine import _endpoint_prefix_matches
+
+    if parent.endpoint_prefixes is None:
+        return  # parent unrestricted on URL — child may add any restriction (narrows)
+    if child.endpoint_prefixes is None:
+        raise CapabilityError(
+            "attenuation violation: parent restricts endpoint_prefixes but child drops them "
+            "(would broaden the admitted-URL set)"
+        )
+    for cp in child.endpoint_prefixes:
+        if not any(_endpoint_prefix_matches(pp, cp) for pp in parent.endpoint_prefixes):
+            raise CapabilityError(
+                f"attenuation violation: child prefix {cp!r} does not extend any parent prefix "
+                f"{list(parent.endpoint_prefixes)!r} (would broaden the admitted-URL set)"
+            )
+
+
+def _check_attenuation(parent: Caveats, child: Caveats) -> None:
+    """Assert the child caveats are an attenuation (subset) of the parent's.
+
+    Every rule below is a subset rule: it can only shrink the admitted
+    (url, amount, time) set, never grow it. Together they make the whole caveat
+    fragment monotone by construction. Raises :class:`CapabilityError` with a
+    distinct reason on the first violation."""
+    _limit_narrows(parent.max_per_call_usd, child.max_per_call_usd, "max_per_call_usd")
+    _limit_narrows(parent.daily_limit_usd, child.daily_limit_usd, "daily_limit_usd")
+    _window_seconds_narrows(parent, child)
+    _window_subset(parent, child)
+    _prefixes_extend(parent, child)
+
+
+# ---------------------------------------------------------------------------
+# Chain verification (read path) — fail-closed, no network, O(chain length).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerifiedGrantChain:
+    """A capability chain that has passed full verification.
+
+    Holds the ordered parsed grants (root first) and the **effective caveats** =
+    the intersection of every hop's caveats. The effective caveats are what the
+    :class:`~presidio_x402.policy_engine.PolicyConfig` bridge consumes and what
+    :meth:`check_payment` enforces at exercise time.
+    """
+
+    grants: tuple[Grant, ...]
+    effective: Caveats
+
+    @property
+    def subject(self) -> str:
+        """The terminal subject — the agent this chain authorises."""
+        return self.grants[-1].subject
+
+    def check_payment(
+        self,
+        *,
+        resource_url: str,
+        amount_usd: Decimal | int | str,
+        at: datetime | None = None,
+    ) -> None:
+        """Exercise-time check: a payment must satisfy EVERY grant in the chain.
+
+        Intersection semantics — sound by construction: the effective caveats are
+        the intersection of the chain, so a single check against ``effective`` is
+        equivalent to checking each hop. Raises :class:`CapabilityError` with a
+        distinct reason if the amount exceeds any hop's per-call cap, the URL is
+        outside the intersected prefix set, or the moment is outside the validity
+        window. ``daily_limit_usd`` / ``window_seconds`` are aggregate budgets
+        enforced by the :class:`~presidio_x402.policy_engine.PolicyEngine` ledger
+        via the config bridge, not by this per-call check.
+        """
+        now = at or _utcnow()
+        amount = _exercise_amount(amount_usd)
+        eff = self.effective
+
+        if eff.valid_from is not None and now < eff.valid_from:
+            raise CapabilityError(f"payment at {_rfc3339(now)} is before grant valid_from")
+        if eff.valid_until is not None and now > eff.valid_until:
+            raise CapabilityError(
+                f"payment at {_rfc3339(now)} is after grant valid_until (expired)"
+            )
+
+        if eff.max_per_call_usd is not None and amount > eff.max_per_call_usd:
+            raise CapabilityError(
+                f"payment {amount} exceeds effective max_per_call_usd {eff.max_per_call_usd}"
+            )
+
+        if eff.endpoint_prefixes is not None:
+            from .policy_engine import _endpoint_prefix_matches
+
+            if any(_endpoint_prefix_matches(p, resource_url) for p in eff.endpoint_prefixes):
+                return
+            raise CapabilityError(
+                f"resource_url {resource_url!r} is outside the granted endpoint prefixes "
+                f"{list(eff.endpoint_prefixes)!r}"
+            )
+
+
+def _exercise_amount(value: Decimal | int | str) -> Decimal:
+    if isinstance(value, Decimal):
+        if not value.is_finite() or value < 0:
+            raise CapabilityError("exercise amount must be a finite non-negative Decimal")
+        return value
+    return _amount_decimal(value, "amount_usd")
+
+
+def _intersect(grants: Sequence[Grant]) -> Caveats:
+    """Intersect the caveats of a verified chain into effective caveats.
+
+    Each axis takes the tighter bound across all hops (max of lower bounds, min
+    of upper bounds / caps), and endpoint prefixes intersect to the most-specific
+    (deepest) hop's set — which, because attenuation guarantees every child
+    prefix extends a parent prefix, is already a subset of every ancestor's set.
+    Because attenuation was verified hop-by-hop first, this intersection is
+    well-defined and equals the terminal grant's caveats on the monotone axes;
+    computing it explicitly keeps the bridge robust to any future non-strict hop.
+    """
+    max_call: Decimal | None = None
+    daily: Decimal | None = None
+    window: int | None = None
+    vfrom: datetime | None = None
+    vuntil: datetime | None = None
+    prefixes: tuple[str, ...] | None = None
+
+    for g in grants:
+        c = g.caveats
+        max_call = _tighter_cap(max_call, c.max_per_call_usd)
+        daily = _tighter_cap(daily, c.daily_limit_usd)
+        window = _tighter_window(window, c.window_seconds)
+        if c.valid_from is not None:
+            vfrom = c.valid_from if vfrom is None else max(vfrom, c.valid_from)
+        if c.valid_until is not None:
+            vuntil = c.valid_until if vuntil is None else min(vuntil, c.valid_until)
+        if c.endpoint_prefixes is not None:
+            # Attenuation guarantees the deeper set extends the shallower, so the
+            # deeper (later) set is the intersection. Keep the latest non-None.
+            prefixes = c.endpoint_prefixes
+
+    return Caveats(
+        max_per_call_usd=max_call,
+        daily_limit_usd=daily,
+        window_seconds=window,
+        valid_from=vfrom,
+        valid_until=vuntil,
+        endpoint_prefixes=prefixes,
+    )
+
+
+def _tighter_cap(current, candidate):
+    """min() that treats ``None`` as 'unconstrained' (candidate wins)."""
+    if candidate is None:
+        return current
+    if current is None:
+        return candidate
+    return min(current, candidate)
+
+
+def _tighter_window(current: int | None, candidate: int | None) -> int | None:
+    """The tighter aggregate window is the longer one."""
+    if candidate is None:
+        return current
+    if current is None:
+        return candidate
+    return max(current, candidate)
+
+
+def verify_chain(
+    chain: Sequence[Mapping[str, object]],
+    trust_store: str | Mapping[str, object],
+    *,
+    at: datetime | None = None,
+) -> VerifiedGrantChain:
+    """Verify a capability chain end-to-end and return it (fail-closed).
+
+    Steps, all local and O(chain length):
+
+    1. Parse every grant (schema, fields, hex, caveats) — fail-closed.
+    2. The **root** grant's signature verifies against an operator key resolved
+       from ``trust_store`` (``trust-store@1`` shape, via
+       :func:`mica.load_trust_store`), keyed by the root ``issuer``.
+    3. Each **child** grant's ``parent_hash`` must equal the content hash of the
+       preceding grant, and its signature must verify against the parent's
+       ``subject_public_key`` (the parent must have published one).
+    4. Attenuation is checked **hop-by-hop**: each child's caveats must be a
+       subset of its parent's (:func:`_check_attenuation`).
+    5. The chain's *validity window* is checked against ``at`` (default: now); an
+       expired or not-yet-valid chain is rejected here so verification and
+       exercise agree.
+
+    Returns a :class:`VerifiedGrantChain` whose ``effective`` caveats are the
+    intersection of the chain. Any failure raises :class:`CapabilityError` with a
+    distinct reason; nothing fails open.
+    """
+    if not isinstance(chain, Sequence) or isinstance(chain, (str, bytes)) or len(chain) == 0:
+        raise CapabilityError("chain must be a non-empty list of grants (root first)")
+
+    grants = [parse_grant(g) for g in chain]
+
+    root = grants[0]
+    if not root.is_root:
+        raise CapabilityError("first grant in chain must be a root (parent_hash absent/null)")
+
+    trust = load_trust_store(trust_store)
+    entry = trust.get(root.issuer)
+    if entry is None:
+        raise CapabilityError(
+            f"root issuer {root.issuer!r} is not in the trust store (unknown operator key)"
+        )
+    if entry.get("alg") != "ed25519":
+        raise CapabilityError(
+            f"root issuer {root.issuer!r} trust entry must be ed25519 for capability grants"
+        )
+    root_msg_ok = _verify_grant_sig(root, entry["keys"])  # type: ignore[index]
+    if not root_msg_ok:
+        raise CapabilityError(
+            f"root grant signature does not verify against any trust-store key for "
+            f"issuer {root.issuer!r}"
+        )
+
+    # Walk children: hash-link, signature against parent key, attenuation.
+    for parent, child in zip(grants, grants[1:], strict=False):
+        if child.is_root:
+            raise CapabilityError(
+                "only the first grant may be a root; a later grant has no parent"
+            )
+        if child.parent_hash != parent.grant_hash:
+            raise CapabilityError(
+                "chain broken: child parent_hash does not match the preceding grant's content hash"
+            )
+        if parent.subject_public_key is None:
+            raise CapabilityError(
+                "chain broken: parent published no subject_public_key, so it cannot delegate"
+            )
+        if not _verify_grant_sig(child, [parent.subject_public_key]):
+            raise CapabilityError(
+                "child grant signature does not verify against the parent's subject_public_key"
+            )
+        _check_attenuation(parent.caveats, child.caveats)
+
+    effective = _intersect(grants)
+
+    # Validity-window gate at verification time so verify and exercise agree.
+    now = at or _utcnow()
+    if effective.valid_from is not None and now < effective.valid_from:
+        raise CapabilityError("capability chain is not yet valid (before valid_from)")
+    if effective.valid_until is not None and now > effective.valid_until:
+        raise CapabilityError("capability chain has expired (after valid_until)")
+
+    return VerifiedGrantChain(grants=tuple(grants), effective=effective)
+
+
+def _verify_grant_sig(grant: Grant, public_keys: Sequence[str]) -> bool:
+    """Verify a grant's detached Ed25519 signature over its signing preimage.
+
+    Reuses the family verification primitive shape but over the capability
+    preimage. Fail-closed: bad hex, bad key, or a non-matching signature all
+    return ``False``. Succeeds if the signature matches ANY listed key (supports
+    operator key rotation for the root)."""
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    message = _signing_preimage(grant.raw)
+    for key in public_keys:
+        if not (isinstance(key, str) and _is_hex(key, 32)):
+            continue
+        try:
+            pk = ed25519.Ed25519PublicKey.from_public_bytes(bytes.fromhex(key))
+            pk.verify(bytes.fromhex(grant.signature), message)
+            return True
+        except (InvalidSignature, ValueError):
+            continue
+    return False
+
+
+# ---------------------------------------------------------------------------
+# PolicyEngine bridge — capability -> configuration, at config-build time only.
+# ---------------------------------------------------------------------------
+
+
+def policy_config_from_chain(chain: VerifiedGrantChain, *, agent_id: str | None = None):
+    """Build a :class:`~presidio_x402.policy_engine.PolicyConfig` from a verified
+    chain's **effective caveats** (the intersection).
+
+    This is the whole integration surface: spending authority that used to be
+    read from env/kwargs is now the projection of a verified capability chain.
+    The existing gate order (PII -> trusted-wallet -> policy -> replay -> MPA) is
+    unchanged; the capability check slots in exactly where the policy *config* is
+    built, not as a new gate and not as a network call. Amounts are carried as
+    decimal *strings* into the config so no float ever enters — the downstream
+    ``PolicyEngine`` re-parses them with its own ``Decimal`` path.
+
+    Per-call and per-endpoint caps map to ``PolicyConfig``; the endpoint prefixes
+    become per-endpoint caps at the effective ``max_per_call_usd`` (or the daily
+    limit when no per-call cap is set) so the policy ledger enforces the granted
+    URL scope. The validity window is **not** a ``PolicyConfig`` concept — it is
+    enforced by :meth:`VerifiedGrantChain.check_payment` at exercise time, which
+    the caller invokes alongside the policy check.
+
+    Float boundary: the *grant* wire form is strictly float-free (the strict
+    canonical profile rejects floats), and the effective caveats are carried as
+    :class:`~decimal.Decimal`. ``PolicyConfig``, however, is in-process **runtime
+    configuration** whose amount fields are declared ``float`` and are re-parsed
+    to ``Decimal`` internally by ``PolicyEngine._decimal_usd`` before any
+    comparison. The bridge therefore converts the exact ``Decimal`` caps to
+    ``float`` at this one boundary — the float lives only inside the runtime
+    policy object, never in a grant, a signature preimage, or any canonical
+    bytes. This keeps the wire-format invariant intact while feeding
+    ``PolicyEngine`` a value of its declared type (matching every other
+    ``PolicyConfig`` construction site).
+    """
+    from .policy_engine import PolicyConfig
+
+    eff = chain.effective
+    per_endpoint: dict[str, float] = {}
+    endpoint_cap = (
+        eff.max_per_call_usd if eff.max_per_call_usd is not None else eff.daily_limit_usd
+    )
+    if eff.endpoint_prefixes is not None and endpoint_cap is not None:
+        for prefix in eff.endpoint_prefixes:
+            per_endpoint[prefix] = float(endpoint_cap)
+
+    return PolicyConfig(
+        max_per_call_usd=float(eff.max_per_call_usd) if eff.max_per_call_usd is not None else None,
+        daily_limit_usd=float(eff.daily_limit_usd) if eff.daily_limit_usd is not None else None,
+        per_endpoint=per_endpoint,
+        window_seconds=eff.window_seconds if eff.window_seconds is not None else 86_400,
+        agent_id=agent_id or chain.subject,
+    )

--- a/src/presidio_x402/core.py
+++ b/src/presidio_x402/core.py
@@ -36,6 +36,8 @@ from .telemetry import security_control_span, set_span_attribute
 if TYPE_CHECKING:
     from ._types import PaymentDetails
     from .audit_log import AuditLog
+    from .capability import VerifiedGrantChain
+    from .decision_ref import DecisionRefEmitter
     from .metrics import MetricsCollector
     from .mpa import MPAEngine
     from .pii_filter import PIIFilter
@@ -117,6 +119,9 @@ class ScreeningPipeline:
         trusted_wallets: dict[str, frozenset[str]] | None = None,
         screening_client: ScreeningClient | None = None,
         remote_screening: bool = False,
+        decision_ref_emitter: DecisionRefEmitter | None = None,
+        capability_chain: VerifiedGrantChain | None = None,
+        agent_id: str | None = None,
     ) -> None:
         if remote_screening and screening_client is None:
             raise ValueError("remote_screening=True requires a screening_client instance")
@@ -131,6 +136,12 @@ class ScreeningPipeline:
         self._trusted_wallets = trusted_wallets
         self._screening_client = screening_client
         self._remote_screening = remote_screening
+        # Decision-ref emission is strictly opt-in: when the emitter is None (the
+        # default) NO decision-ref code path runs and apply() is byte-identical to
+        # prior releases. See presidio_x402.decision_ref.
+        self._decision_emitter = decision_ref_emitter
+        self._capability_chain = capability_chain
+        self._agent_id = agent_id
 
     def rollback(self, *, resource_url: str, amount_usd: float, fingerprint: str) -> None:
         """Reverse the spend + replay fingerprint speculatively committed in
@@ -152,6 +163,7 @@ class ScreeningPipeline:
         details: PaymentDetails,
         *,
         mpa_signatures: dict[str, str] | None = None,
+        raw_offer_hash: str | None = None,
     ) -> tuple[PaymentDetails, str]:
         """Apply PIIFilter → PolicyEngine → ReplayGuard → MPAEngine → AuditLog.
 
@@ -166,6 +178,16 @@ class ScreeningPipeline:
         re-raising.
         """
         amount_usd = amount_to_usd(details.amount, details.currency)
+
+        # Decision-ref emission is opt-in. When an emitter is configured we track
+        # each control's verdict as it runs so a single payment-decision@1 record
+        # can be signed on the success path. When it is None this stays None and
+        # no extra work happens (byte-identical default behaviour).
+        decision_controls = None
+        if self._decision_emitter is not None:
+            from .decision_ref import ControlResults
+
+            decision_controls = ControlResults()
 
         # Preserve the original resource_url for replay-guard fingerprinting.
         # In pii_action="redact" mode the URL gets rewritten with PII tokens
@@ -280,6 +302,20 @@ class ScreeningPipeline:
                     self._metrics.record_pii_detection(entity_types, "warn")
             set_span_attribute(pii_span, "presidio_x402.outcome", "allowed")
 
+        # Record the PII verdict for the decision-ref (success path: never
+        # PII_BLOCKED, since that raises above). Only entity-type LABELS enter
+        # here — the screened strings never do (PII-freedom by construction).
+        if decision_controls is not None:
+            entity_labels = sorted({e.entity_type for e in pii_entities})
+            if not entity_labels:
+                decision_controls.pii_verdict = "PII_NONE"
+            elif self._pii_action == "redact":
+                decision_controls.pii_verdict = "PII_REDACTED"
+                decision_controls.pii_mutated = True
+            elif self._pii_action == "warn":
+                decision_controls.pii_verdict = "PII_WARNED"
+            decision_controls.pii_entities = tuple(entity_labels)
+
         # ------------------------------------------------------------------
         # 2. Trusted-wallet allowlist (pay_to substitution defence)
         # ------------------------------------------------------------------
@@ -324,6 +360,14 @@ class ScreeningPipeline:
                     resource_url=details.resource_url, amount_usd=amount_usd
                 )
                 set_span_attribute(policy_span, "presidio_x402.outcome", "allowed")
+                if decision_controls is not None:
+                    from .decision_ref import policy_limit_hash, policy_snapshot_hash
+
+                    decision_controls.policy_verdict = "ALLOW"
+                    decision_controls.policy_snapshot_hash = policy_snapshot_hash(
+                        self._policy.config
+                    )
+                    decision_controls.policy_limit_hash = policy_limit_hash(self._policy.config)
             except PolicyViolationError as exc:
                 set_span_attribute(policy_span, "presidio_x402.outcome", "blocked")
                 set_span_attribute(
@@ -363,6 +407,11 @@ class ScreeningPipeline:
             try:
                 self._replay.check_and_record(fingerprint)
                 set_span_attribute(replay_span, "presidio_x402.outcome", "allowed")
+                if decision_controls is not None:
+                    from .decision_ref import fingerprint_hash
+
+                    decision_controls.replay_verdict = "FRESH"
+                    decision_controls.replay_fingerprint_hash = fingerprint_hash(fingerprint)
             except ReplayDetectedError:
                 set_span_attribute(replay_span, "presidio_x402.outcome", "blocked")
                 set_span_attribute(
@@ -400,6 +449,10 @@ class ScreeningPipeline:
                     set_span_attribute(mpa_span, "presidio_x402.outcome", "approved")
                     if self._metrics:
                         self._metrics.record_mpa_event("approved")
+                    if decision_controls is not None:
+                        decision_controls.mpa_verdict = "APPROVED"
+                        decision_controls.mpa_required = True
+                        decision_controls.mpa_threshold = self._mpa.config.threshold
                 except (MPADeniedError, MPATimeoutError) as exc:
                     # Roll back the spend + replay fingerprint committed at steps 3–4:
                     # an MPA-denied/timed-out payment was never signed, so it must not
@@ -426,4 +479,55 @@ class ScreeningPipeline:
                         self._metrics.record_payment_blocked(f"mpa_{outcome}", amount_usd)
                     raise
 
+        # Trusted-wallet verdict on the success path is TRUSTED (an UNTRUSTED
+        # pay_to raises above, before we reach here).
+        if decision_controls is not None:
+            decision_controls.trusted_wallet_verdict = "TRUSTED"
+
+        # Emit the signed payment-decision@1 record immediately before returning
+        # to the caller, which signs next. No network I/O on this path.
+        if self._decision_emitter is not None and decision_controls is not None:
+            self._emit_decision_ref(details, decision_controls, raw_offer_hash=raw_offer_hash)
+
         return details, fingerprint
+
+    def _emit_decision_ref(
+        self,
+        details: PaymentDetails,
+        controls: object,
+        *,
+        raw_offer_hash: str | None = None,
+    ) -> None:
+        """Build and write one payment-decision@1 record (opt-in path only).
+
+        Best-effort by contract: emission must never change the payment outcome,
+        so any emitter/signing failure is caught and logged rather than raised —
+        a decision the gateway already made must not be undone by a record of it.
+        """
+        from .decision_ref import capability_parents, details_hash
+
+        try:
+            origin = resource_origin(details.resource_url)
+            d_hash = details_hash(
+                pay_to=details.pay_to,
+                amount=details.amount,
+                currency=details.currency,
+                network=details.network,
+            )
+            self._decision_emitter.emit(  # type: ignore[union-attr]
+                agent_id=self._agent_id or "",
+                payment_signer=details.pay_to,
+                network=details.network,
+                binding="x402",
+                offer_hash=raw_offer_hash,
+                offer_hash_absent="not-retained",
+                details_hash=d_hash,
+                pay_to=details.pay_to,
+                amount=details.amount,
+                currency=details.currency,
+                resource_origin=origin,
+                controls=controls,  # type: ignore[arg-type]
+                parents=capability_parents(self._capability_chain),
+            )
+        except Exception:
+            logger.exception("decision-ref emission failed (payment outcome unaffected)")

--- a/src/presidio_x402/decision_ref.py
+++ b/src/presidio_x402/decision_ref.py
@@ -1,0 +1,1046 @@
+"""Decision-ref emission — per-payment proof-carrying decision records.
+
+A **decision-ref** is a signed, portable record of one gateway payment decision:
+the inputs (as hashes), the predicate identity (the effective policy config
+content hash, and — when the policy came from a capability chain — the chain's
+terminal ``grant_hash`` as a provenance parent), the per-control verdicts, the
+recomputable top-level conclusion, and a detached signature. A third party
+verifies it **offline** against a pinned trust store, without re-running the
+gateway (Pillar II of the Computational Jurisprudence program; Stantchev, arXiv
+2026).
+
+This module implements the binding design note
+``plan/presidio-evidence-decision-ref-design.md`` (Phase-A scope):
+
+- Attested content schema: ``presidio-hardened-x402/payment-decision@1`` — the
+  per-payment artifact whose ``controls{}`` block carries the individual
+  ``pii → trusted_wallet → policy → replay → mpa`` gate verdicts (the design note
+  names this schema, so it is used verbatim rather than the generic
+  ``decision-ref@1`` family default). One artifact per payment is the record the
+  brief's "one record per gate decision plus a per-payment envelope linking them"
+  asks for: the per-control verdicts are the gate decisions, the artifact is the
+  envelope that binds them, and ``f(controls)`` re-derives the top-level verdict.
+- ``artifact_hash = sha256(canonical_bytes(payment_decision_content))`` = the
+  ``content_hash`` of the single evidence ref in the envelope.
+- ``decision_ref = sha256(canonical_bytes({artifact_hash, artifact_type,
+  policy_version, verdict}))`` — the thin, self-describing-preimage correlation id
+  (sibling to ``action_ref``), whose preimage fields travel in the envelope.
+- Envelope: the family ``presidio-hardened/evidence-ref@1`` wire format produced
+  and verified by :mod:`presidio_x402.mica` (canonical JSON, SHA-256 content
+  hash, detached Ed25519/HMAC).
+
+Wire format follows the family Layer-0 rules mirrored in :mod:`presidio_x402.mica`
+(``canonical_bytes``: sorted keys, ``(",", ":")`` separators, UTF-8,
+``ensure_ascii=False``, floats rejected). Amounts are strings or integer atomic
+units — never floats.
+
+**Privacy rule (PII-freedom by construction).** The attested content contains only
+hashes, an origin, and entity-type *labels*. Raw ``resource_url``, ``description``,
+``reason``, ``pay_to`` beyond a hashed offer, request bodies, model prompts, and
+output payloads never enter the record — consistent with how
+:mod:`presidio_x402.audit_log` redacts. The only screening output that appears is
+the entity-type finding set (e.g. ``["EMAIL_ADDRESS"]``) and a hash; the screened
+*strings* never do.
+
+**Honesty bound.** A decision-ref proves what the library concluded under a
+*declared* predicate (the recorded control verdicts + policy hash), recomputably
+and tamper-evidently. It does **not** prove the process was not compromised, that
+the declared controls are the real controls (that is an attestation layer, not
+this one), or anything TEE-like. Signing makes it tamper-evident; recomputation
+(``verdict == f(controls)``) makes it admissible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from .mica import (
+    EVIDENCE_SCHEMA_ID,
+    EvidenceError,
+    load_trust_store,
+    sha256_hex,
+    sign_evidence,
+    verify_ed25519,
+    verify_hmac,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .capability import VerifiedGrantChain
+
+PAYMENT_DECISION_SCHEMA_ID = "presidio-hardened-x402/payment-decision@1"
+DEFAULT_POLICY_VERSION = "presidio-x402.policy.v1"
+DEFAULT_DECISION_SIGNER = "presidio-hardened-x402-policy"
+
+#: The four fields of the thin decision_ref preimage (self-describing).
+DECISION_REF_PREIMAGE_FIELDS = ("artifact_hash", "artifact_type", "policy_version", "verdict")
+
+#: The precedence order of the five controls (first-failure-wins). Byte-identical
+#: to the shipped gateway order in :mod:`presidio_x402.core`.
+CONTROL_PRECEDENCE = ("pii", "trusted_wallet", "policy", "replay", "mpa")
+
+#: Control verdicts that force a terminal DENY, per control key.
+_HARD_FAIL = {
+    "pii": frozenset({"PII_BLOCKED"}),
+    "trusted_wallet": frozenset({"UNTRUSTED"}),
+    "policy": frozenset({"VIOLATION"}),
+    "replay": frozenset({"DUPLICATE"}),
+    "mpa": frozenset({"DENIED"}),
+}
+#: MPA verdicts that force REFER (a quorum that has not answered is recoverable).
+_MPA_REFER = frozenset({"PENDING", "TIMEOUT"})
+
+#: Permitted verdict enums per control (design note "Decision function f").
+_ALLOWED_VERDICTS = {
+    "pii": frozenset({"PII_NONE", "PII_WARNED", "PII_REDACTED", "PII_BLOCKED"}),
+    "trusted_wallet": frozenset({"TRUSTED", "UNTRUSTED"}),
+    "policy": frozenset({"ALLOW", "VIOLATION"}),
+    "replay": frozenset({"FRESH", "DUPLICATE"}),
+    "mpa": frozenset({"NOT_REQUIRED", "APPROVED", "PENDING", "TIMEOUT", "DENIED"}),
+}
+_HASH_REF_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class DecisionRefError(EvidenceError):
+    """Raised on any decision-ref rejection (fail-closed, distinct reasons).
+
+    Subclasses :class:`~presidio_x402.mica.EvidenceError` so a caller already
+    catching the family evidence error also catches decision-ref failures. The
+    message carries the distinct rejection reason (bad schema, hash mismatch,
+    verdict not recomputable, self-approval, broken parent linkage, …).
+    """
+
+
+# ---------------------------------------------------------------------------
+# The recomputable verdict function f — a pure precedence-combinator over the
+# five recorded control verdicts. Never re-executes a control; the verifier
+# re-applies it offline to controls{} and checks it equals the recorded verdict.
+# ---------------------------------------------------------------------------
+
+
+def f_controls(controls: Mapping[str, object]) -> str:
+    """Recompute the top-level verdict from the recorded control verdicts.
+
+    Pure precedence-combinator, first-failure-wins over
+    ``pii → trusted_wallet → policy → replay → mpa`` (:data:`CONTROL_PRECEDENCE`):
+    any hard-fail verdict ⇒ ``DENY``; else an unanswered MPA quorum
+    (``PENDING``/``TIMEOUT``) ⇒ ``REFER``; else ``ALLOW``. Touches no spaCy,
+    Redis, MPA webhook, or network — that is what lets it be CI-graded offline.
+    """
+    verdicts = _validated_control_verdicts(controls)
+    for key in CONTROL_PRECEDENCE:
+        verdict = verdicts[key]
+        if verdict in _HARD_FAIL[key]:
+            return "DENY"
+        if key == "mpa" and verdict in _MPA_REFER:
+            return "REFER"
+    return "ALLOW"
+
+
+def _validate_hash_ref(value: object, field_name: str, *, required: bool) -> None:
+    if value is None and not required:
+        return
+    if not (isinstance(value, str) and _HASH_REF_RE.fullmatch(value)):
+        raise DecisionRefError(f"control field {field_name} must be a sha256:<64hex> hash")
+
+
+def _validated_control_verdicts(controls: Mapping[str, object]) -> dict[str, str]:
+    """Validate the signed controls block and return its verdicts.
+
+    Missing, unknown, or enum-invalid controls fail closed. The verifier must not
+    treat an omitted hard-fail control as implicit ALLOW.
+    """
+    actual = set(controls)
+    expected = set(CONTROL_PRECEDENCE)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise DecisionRefError(
+            f"controls block must contain exactly {list(CONTROL_PRECEDENCE)}; "
+            f"missing={missing}, extra={extra}"
+        )
+
+    entries: dict[str, Mapping[str, object]] = {}
+    verdicts: dict[str, str] = {}
+    for key in CONTROL_PRECEDENCE:
+        entry = controls.get(key)
+        if not isinstance(entry, Mapping):
+            raise DecisionRefError(f"control {key!r} must be an object")
+        entries[key] = entry
+        verdict = entry.get("verdict")
+        if not (isinstance(verdict, str) and verdict in _ALLOWED_VERDICTS[key]):
+            raise DecisionRefError(
+                f"control {key!r} has verdict {verdict!r} not in "
+                f"{sorted(_ALLOWED_VERDICTS[key])} (fail-closed)"
+            )
+        verdicts[key] = verdict
+
+    pii = entries["pii"]
+    entities = pii.get("entities")
+    mutated = pii.get("mutated")
+    if not (
+        isinstance(entities, list)
+        and all(isinstance(e, str) and 0 < len(e) <= 128 for e in entities)
+        and isinstance(mutated, bool)
+    ):
+        raise DecisionRefError("control 'pii' must carry entities[] and mutated boolean")
+
+    policy = entries["policy"]
+    _validate_hash_ref(
+        policy.get("policy_snapshot_hash"), "policy.policy_snapshot_hash", required=True
+    )
+    _validate_hash_ref(policy.get("limit_hash"), "policy.limit_hash", required=False)
+
+    replay = entries["replay"]
+    _validate_hash_ref(replay.get("fingerprint_hash"), "replay.fingerprint_hash", required=False)
+
+    mpa = entries["mpa"]
+    required = mpa.get("required")
+    if not isinstance(required, bool):
+        raise DecisionRefError("control 'mpa' must carry required boolean")
+    threshold = mpa.get("threshold")
+    if threshold is not None and not (isinstance(threshold, str) and threshold):
+        raise DecisionRefError("control 'mpa.threshold' must be a non-empty string when present")
+    approval_refs = mpa.get("approval_refs")
+    if approval_refs is not None and not (
+        isinstance(approval_refs, list)
+        and all(isinstance(ref, str) and 0 < len(ref) <= 512 for ref in approval_refs)
+    ):
+        raise DecisionRefError("control 'mpa.approval_refs' must be a string list when present")
+
+    return verdicts
+
+
+# ---------------------------------------------------------------------------
+# Control-result collector — the PII-free inputs the pipeline populates.
+# Every field is either a hash, an enum label, or an entity-type list. No raw
+# metadata string can be assigned here (there is no field for one).
+# ---------------------------------------------------------------------------
+
+
+def _sha256_prefixed(payload: object) -> str:
+    """``sha256:<64hex>`` over the canonical bytes of *payload* (design shape)."""
+    return "sha256:" + sha256_hex(payload)
+
+
+def _hash_str(text: str) -> str:
+    """``sha256:<64hex>`` of a single string — the ONLY way a raw string ever
+    contributes to the record, and only as a one-way digest (never the string)."""
+    return _sha256_prefixed(text)
+
+
+@dataclass
+class ControlResults:
+    """The five per-control gate verdicts + hashed inputs, gathered before signing.
+
+    The gateway/pipeline populates this from the control results it already
+    computes; :func:`build_payment_decision_content` renders it into the attested
+    ``payment-decision@1`` content. **PII-freedom is structural**: the only string
+    fields are enum verdict labels, entity-type labels, and pre-computed hashes —
+    there is no field that accepts a raw ``resource_url``/``description``/
+    ``reason``/request-body, so a raw metadata string cannot leak into a record
+    even by a caller mistake.
+    """
+
+    # PII gate
+    pii_verdict: str = "PII_NONE"
+    pii_entities: tuple[str, ...] = ()
+    pii_mutated: bool = False
+
+    # Trusted-wallet gate
+    trusted_wallet_verdict: str = "TRUSTED"
+
+    # Policy gate
+    policy_verdict: str = "ALLOW"
+    policy_snapshot_hash: str = ""  # sha256: of the effective PolicyConfig
+    policy_limit_hash: str | None = None
+
+    # Replay gate
+    replay_verdict: str = "FRESH"
+    replay_fingerprint_hash: str | None = None  # sha256: of the fingerprint, never the fingerprint
+
+    # MPA gate
+    mpa_verdict: str = "NOT_REQUIRED"
+    mpa_required: bool = False
+    mpa_threshold: str | None = None
+    mpa_approval_refs: tuple[str, ...] = ()
+
+    def _validate(self) -> None:
+        pairs = (
+            ("pii", self.pii_verdict),
+            ("trusted_wallet", self.trusted_wallet_verdict),
+            ("policy", self.policy_verdict),
+            ("replay", self.replay_verdict),
+            ("mpa", self.mpa_verdict),
+        )
+        for key, verdict in pairs:
+            if verdict not in _ALLOWED_VERDICTS[key]:
+                raise DecisionRefError(
+                    f"control {key!r} has verdict {verdict!r} not in "
+                    f"{sorted(_ALLOWED_VERDICTS[key])} (fail-closed)"
+                )
+
+    def to_controls(self) -> dict[str, object]:
+        """Render the ``controls{}`` block of the attested content (validated)."""
+        self._validate()
+        policy: dict[str, object] = {
+            "verdict": self.policy_verdict,
+            "policy_snapshot_hash": self.policy_snapshot_hash,
+        }
+        if self.policy_limit_hash is not None:
+            policy["limit_hash"] = self.policy_limit_hash
+        replay: dict[str, object] = {"verdict": self.replay_verdict}
+        if self.replay_fingerprint_hash is not None:
+            replay["fingerprint_hash"] = self.replay_fingerprint_hash
+        mpa: dict[str, object] = {
+            "verdict": self.mpa_verdict,
+            "required": bool(self.mpa_required),
+        }
+        if self.mpa_threshold is not None:
+            mpa["threshold"] = self.mpa_threshold
+        if self.mpa_approval_refs:
+            mpa["approval_refs"] = list(self.mpa_approval_refs)
+        return {
+            "pii": {
+                "verdict": self.pii_verdict,
+                # Sorted + de-duplicated so two honest emitters that detect the
+                # same entities in different order produce byte-identical content.
+                "entities": sorted(set(self.pii_entities)),
+                "mutated": bool(self.pii_mutated),
+            },
+            "trusted_wallet": {"verdict": self.trusted_wallet_verdict},
+            "policy": policy,
+            "replay": replay,
+            "mpa": mpa,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Hash helpers over the control inputs (redacted where PII-bearing).
+# ---------------------------------------------------------------------------
+
+
+def policy_snapshot_hash(config: object) -> str:
+    """Content hash of the *effective* policy config (the predicate identity).
+
+    Hashes a canonical, float-free projection of the ``PolicyConfig`` (the
+    effective policy after inheritance — the input ``f`` must re-derive against,
+    per the design note's resolved open question). Amounts are stringified so no
+    float enters the canonical bytes.
+    """
+    snap = _policy_config_snapshot(config)
+    return _sha256_prefixed(snap)
+
+
+def policy_limit_hash(config: object) -> str:
+    """Content hash of just the limit surface of the policy (per the design's
+    ``limit_hash``). A stable pointer to the numeric caps in force."""
+    snap = _policy_config_snapshot(config)
+    limits = {
+        "max_per_call_usd": snap["max_per_call_usd"],
+        "daily_limit_usd": snap["daily_limit_usd"],
+        "per_endpoint": snap["per_endpoint"],
+        "window_seconds": snap["window_seconds"],
+    }
+    return _sha256_prefixed(limits)
+
+
+def _policy_config_snapshot(config: object) -> dict[str, object]:
+    """Float-free canonical projection of a ``PolicyConfig`` (or dict)."""
+
+    def _amt(v: object) -> str | None:
+        return None if v is None else str(v)
+
+    get = (
+        (lambda k, d=None: config.get(k, d))
+        if isinstance(config, Mapping)
+        else (lambda k, d=None: getattr(config, k, d))
+    )
+    per_endpoint_raw = get("per_endpoint", {}) or {}
+    per_endpoint = {k: _amt(v) for k, v in sorted(per_endpoint_raw.items())}
+    return {
+        "max_per_call_usd": _amt(get("max_per_call_usd")),
+        "daily_limit_usd": _amt(get("daily_limit_usd")),
+        "per_endpoint": per_endpoint,
+        "window_seconds": get("window_seconds", 86_400),
+    }
+
+
+def fingerprint_hash(fingerprint: str) -> str:
+    """``sha256:`` of a replay fingerprint — the fingerprint itself never enters
+    the record (it is derived from the original, pre-redaction URL)."""
+    return _hash_str(fingerprint)
+
+
+def offer_hash(raw_offer: bytes | str) -> str:
+    """``sha256:`` of the raw 402 payment offer bytes, exactly as received.
+
+    The offer may carry PII, so only its byte digest enters the record — never
+    the offer text. Callers should pass the transport's raw header/body bytes.
+    ``str`` input is encoded as UTF-8 only for tests and legacy helpers.
+    """
+    raw = raw_offer.encode("utf-8") if isinstance(raw_offer, str) else bytes(raw_offer)
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def details_hash(*, pay_to: str, amount: str, currency: str, network: str) -> str:
+    """``sha256:`` over the **post-redaction** payment details (the design note's
+    resolved rule: the proposal hash is taken over post-redaction details)."""
+    return _sha256_prefixed(
+        {"pay_to": pay_to, "amount": amount, "currency": currency, "network": network}
+    )
+
+
+def _utcnow_ms_z() -> str:
+    """RFC3339 UTC with millisecond precision and trailing ``Z``."""
+    dt = datetime.now(tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+# ---------------------------------------------------------------------------
+# Attested content + thin decision_ref derivation.
+# ---------------------------------------------------------------------------
+
+
+def build_payment_decision_content(
+    *,
+    agent_id: str,
+    payment_signer: str,
+    network: str,
+    binding: str,
+    offer_hash: str | None = None,
+    offer_hash_absent: str | None = None,
+    details_hash: str,
+    pay_to: str,
+    amount: str,
+    currency: str,
+    resource_origin: str,
+    controls: ControlResults,
+    issued_at: str | None = None,
+    policy_version: str = DEFAULT_POLICY_VERSION,
+    parents: Sequence[str] | None = None,
+    prior_decision_refs: Sequence[str] | None = None,
+) -> dict[str, object]:
+    """Build the ``presidio-hardened-x402/payment-decision@1`` attested content.
+
+    The top-level ``verdict`` is set to ``f(controls)`` so the artifact is
+    recomputable by construction — a verifier re-applies :func:`f_controls` to the
+    ``controls{}`` block and gets the same value. All monetary values are strings;
+    no float enters the content (``canonical_bytes`` rejects floats regardless).
+    """
+    controls_block = controls.to_controls()
+    verdict = f_controls(controls_block)
+    payment: dict[str, object] = {
+        "details_hash": details_hash,
+        "pay_to": pay_to,
+        "amount": amount,
+        "currency": currency,
+        "resource_origin": resource_origin,
+    }
+    if offer_hash is not None:
+        payment["offer_hash"] = offer_hash
+    else:
+        payment["offer_hash_absent"] = offer_hash_absent or "not-retained"
+
+    return {
+        "schema": PAYMENT_DECISION_SCHEMA_ID,
+        "issued_at": issued_at or _utcnow_ms_z(),
+        "agent_id": agent_id,
+        "actor": {
+            "payment_signer": payment_signer,
+            "binding": binding,
+            "network": network,
+        },
+        "payment": payment,
+        "controls": controls_block,
+        "verdict": verdict,
+        "policy_version": policy_version,
+        "provenance": {
+            "parents": list(parents or []),
+            "prior_decision_refs": list(prior_decision_refs or []),
+        },
+    }
+
+
+def artifact_hash(content: Mapping[str, object]) -> str:
+    """``sha256`` (64 lowercase hex) over the canonical bytes of the content —
+    the artifact hash and the ``content_hash`` of the evidence ref."""
+    return sha256_hex(content)
+
+
+def compute_decision_ref(
+    *,
+    artifact_hash: str,
+    policy_version: str,
+    verdict: str,
+    artifact_type: str = PAYMENT_DECISION_SCHEMA_ID,
+) -> str:
+    """The thin, self-describing ``decision_ref`` id.
+
+    ``sha256(canonical_bytes({artifact_hash, artifact_type, policy_version,
+    verdict}))`` — a stable correlation key whose four preimage fields travel in
+    the envelope so any holder recomputes it independently.
+    """
+    return sha256_hex(
+        decision_ref_preimage(
+            artifact_hash=artifact_hash,
+            policy_version=policy_version,
+            verdict=verdict,
+            artifact_type=artifact_type,
+        )
+    )
+
+
+def decision_ref_preimage(
+    *,
+    artifact_hash: str,
+    policy_version: str,
+    verdict: str,
+    artifact_type: str = PAYMENT_DECISION_SCHEMA_ID,
+) -> dict[str, str]:
+    """The four-field self-describing preimage of the ``decision_ref``."""
+    return {
+        "artifact_hash": artifact_hash,
+        "artifact_type": artifact_type,
+        "policy_version": policy_version,
+        "verdict": verdict,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Capability-chain provenance linkage (parents array).
+# ---------------------------------------------------------------------------
+
+
+def capability_parents(chain: VerifiedGrantChain | None) -> list[str]:
+    """Provenance parents contributed by a capability chain (may be empty).
+
+    When the policy in force was projected from a verified capability chain, the
+    chain's **terminal ``grant_hash``** is the parent that binds this decision to
+    the authority it was decided under (provenance-parents convention). ``None``
+    (config-sourced policy) contributes no parent.
+    """
+    if chain is None:
+        return []
+    return [f"capability-grant:{chain.grants[-1].grant_hash}"]
+
+
+def build_decision_evidence(
+    content: Mapping[str, object],
+    *,
+    signing_key: str,
+    algorithm: str = "ed25519",
+    signer: str = DEFAULT_DECISION_SIGNER,
+    key_id: str | None = None,
+    source_version: str | None = None,
+    parents: Sequence[str] | None = None,
+    prior_decision_refs: Sequence[str] | None = None,
+) -> dict[str, object]:
+    """Build a signed ``presidio-hardened/evidence-ref@1`` envelope over *content*.
+
+    The single evidence ref's ``content_hash`` is the artifact hash; the detached
+    signature is over ``canonical({content_hash, signer})`` (the family primitive,
+    :func:`mica.sign_evidence`) so it is byte-compatible with the family verifier.
+    Fail-closed: no key ⇒ no envelope.
+
+    ``parents`` links provenance parents — the capability grant hash when the
+    policy came from a chain (:func:`capability_parents`) — and
+    ``prior_decision_refs`` links earlier decision-refs of the *same* payment
+    (e.g. a REFER that later resolved). Both are copied into the signed
+    ``payment_decision.provenance`` block before hashing; the envelope-level
+    ``provenance`` block is a convenience mirror for consumers.
+
+    **No network I/O.** This function only computes hashes and a signature.
+    """
+    signed_content = dict(content)
+    content_provenance = signed_content.get("provenance")
+    parent_list = (
+        list(parents)
+        if parents is not None
+        else list(content_provenance.get("parents", []))
+        if isinstance(content_provenance, Mapping)
+        else []
+    )
+    prior_list = (
+        list(prior_decision_refs)
+        if prior_decision_refs is not None
+        else list(content_provenance.get("prior_decision_refs", []))
+        if isinstance(content_provenance, Mapping)
+        else []
+    )
+    if not all(isinstance(p, str) and p for p in parent_list) or not all(
+        isinstance(p, str) and p for p in prior_list
+    ):
+        raise DecisionRefError("provenance parents/prior_decision_refs must be non-empty strings")
+    signed_content["provenance"] = {
+        "parents": parent_list,
+        "prior_decision_refs": prior_list,
+    }
+
+    if signed_content.get("schema") != PAYMENT_DECISION_SCHEMA_ID:
+        raise DecisionRefError(
+            f"attested content schema must be {PAYMENT_DECISION_SCHEMA_ID!r}; "
+            f"got {signed_content.get('schema')!r}"
+        )
+    # Recompute the verdict fail-closed at emission: never sign a non-recomputable
+    # artifact (the line between attested and admissible — autogen#7353).
+    controls = signed_content.get("controls")
+    if not isinstance(controls, Mapping):
+        raise DecisionRefError("attested content missing a controls{} block")
+    recomputed = f_controls(controls)
+    if signed_content.get("verdict") != recomputed:
+        raise DecisionRefError(
+            f"refusing to sign a non-recomputable decision: recorded verdict "
+            f"{signed_content.get('verdict')!r} != f(controls) {recomputed!r} (fail-closed)"
+        )
+
+    a_hash = artifact_hash(signed_content)
+    signature = sign_evidence(a_hash, signer, algorithm=algorithm, key=signing_key)
+    version = source_version or _library_version()
+    claimed_at = _utcnow_ms_z()
+    policy_version = str(signed_content.get("policy_version", DEFAULT_POLICY_VERSION))
+    verdict = str(signed_content.get("verdict"))
+    d_ref = compute_decision_ref(
+        artifact_hash=a_hash, policy_version=policy_version, verdict=verdict
+    )
+
+    ref = {
+        "item_id": d_ref,
+        "source": signer,
+        "source_version": version,
+        "ledger_ref": f"x402-decision:{d_ref}",
+        "content_hash": a_hash,
+        "signer": signer,
+        "signature": signature,
+        "claimed_at": claimed_at,
+    }
+    envelope: dict[str, object] = {
+        "schema": EVIDENCE_SCHEMA_ID,
+        "use_case": "x402-payment-decision",
+        "source": signer,
+        "source_version": version,
+        "generated_at": claimed_at,
+        "attested_content": {"schema": PAYMENT_DECISION_SCHEMA_ID},
+        "evidence": [ref],
+        # Companion data (ignored by generic evidence-ref@1 verifiers; consumed by
+        # verify_decision_ref below):
+        "signing_algorithm": algorithm,
+        "payment_decision": signed_content,
+        "artifact_hash": a_hash,
+        "decision_ref": d_ref,
+        "decision_ref_preimage_fields": list(DECISION_REF_PREIMAGE_FIELDS),
+        "decision_ref_preimage": decision_ref_preimage(
+            artifact_hash=a_hash, policy_version=policy_version, verdict=verdict
+        ),
+        "provenance": {"parents": parent_list, "prior_decision_refs": prior_list},
+        "disclaimer": (
+            "Proof-carrying record of one x402 payment decision under a declared "
+            "predicate: it is tamper-evident (signed) and admissible (verdict = "
+            "f(controls) recomputes). It does NOT prove the process was uncompromised "
+            "or that the declared controls are the real controls (no TEE claim)."
+        ),
+    }
+    if key_id is not None:
+        ref["key_id"] = key_id
+        envelope["key_id"] = key_id
+    return envelope
+
+
+def _library_version() -> str:
+    from . import __version__
+
+    return __version__
+
+
+# ---------------------------------------------------------------------------
+# Verifier (read path) — fully offline, fail-closed, distinct reasons.
+# ---------------------------------------------------------------------------
+
+#: Distinct fail-closed reason codes (one per verification layer).
+REASON_MALFORMED = "malformed"
+REASON_HASH_MISMATCH = "hash_mismatch"
+REASON_DECISION_REF_MISMATCH = "decision_ref_mismatch"
+REASON_VERDICT_NOT_RECOMPUTABLE = "verdict_not_recomputable"
+REASON_SIGNER_EQUALS_RUNTIME = "signer_equals_runtime"
+REASON_UNKNOWN_SIGNER = "unknown_signer"
+REASON_BAD_SIGNATURE = "bad_signature"
+REASON_PARENT_LINKAGE = "parent_linkage"
+
+
+@dataclass(frozen=True)
+class DecisionRefVerification:
+    """The outcome of verifying one decision-ref envelope (never raises to caller).
+
+    ``ok`` is the fail-closed conjunction of every layer. When ``ok`` is false,
+    ``reason`` carries exactly one distinct reason code (the first layer that
+    failed, in verification order) so a caller can branch on *why*.
+    """
+
+    ok: bool
+    reason: str | None = None
+    decision_ref: str | None = None
+    verdict: str | None = None
+    recomputed_verdict: str | None = None
+    checked: tuple[str, ...] = field(default_factory=tuple)
+
+    def __bool__(self) -> bool:  # let `if result:` mean "verified"
+        return self.ok
+
+
+def _fail(reason: str, **kw: object) -> DecisionRefVerification:
+    return DecisionRefVerification(ok=False, reason=reason, **kw)  # type: ignore[arg-type]
+
+
+def verify_decision_ref(
+    envelope: Mapping[str, object],
+    trust_store: str | Mapping[str, object],
+    *,
+    require_parents: Sequence[str] | None = None,
+    actor_controllers: Sequence[str] | None = None,
+) -> DecisionRefVerification:
+    """Verify one decision-ref envelope offline, fail-closed, distinct reasons.
+
+    Layers, in order (first failure wins, each its own reason code):
+
+    1. **structure** — envelope shape, exactly one evidence ref, present
+       ``payment_decision`` companion (``malformed``).
+    2. **hash integrity** — ``content_hash`` == ``sha256(canonical(content))``
+       (``hash_mismatch``); the thin ``decision_ref`` recomputes from its declared
+       preimage and equals the recorded id (``decision_ref_mismatch``).
+    3. **recompute** — recorded ``verdict`` == ``f(controls)``
+       (``verdict_not_recomputable``): the line between attested and admissible.
+    4. **admission** — the signer must not resolve to the actor's own controller
+       (self-approval fails closed — ``signer_equals_runtime``). Pass
+       ``actor_controllers`` to name the wallets/runtimes that count as the actor;
+       the actor's ``payment_signer`` is always included.
+    5. **signature** — the detached signature verifies against a key for ``signer``
+       in the trust store (``unknown_signer`` / ``bad_signature``).
+    6. **parent linkage** — if ``require_parents`` is given, every required parent
+       must appear in the recorded ``provenance.parents`` (``parent_linkage``).
+
+    Never raises to the caller — a malformed input returns
+    ``ok=False`` with a reason. This guarantees verification itself cannot fail open.
+    """
+    checked: list[str] = []
+
+    # 1. Structure.
+    if not isinstance(envelope, Mapping):
+        return _fail(REASON_MALFORMED)
+    evidence = envelope.get("evidence")
+    content = envelope.get("payment_decision")
+    if (
+        not isinstance(evidence, list)
+        or len(evidence) != 1
+        or not isinstance(evidence[0], Mapping)
+        or not isinstance(content, Mapping)
+    ):
+        return _fail(REASON_MALFORMED)
+    ref = evidence[0]
+    content_hash = ref.get("content_hash")
+    signer = ref.get("signer")
+    signature = ref.get("signature")
+    if not (
+        isinstance(content_hash, str) and isinstance(signer, str) and isinstance(signature, str)
+    ):
+        return _fail(REASON_MALFORMED)
+    if content.get("schema") != PAYMENT_DECISION_SCHEMA_ID:
+        return _fail(REASON_MALFORMED)
+    checked.append("structure")
+
+    # 2. Hash integrity.
+    try:
+        recomputed_hash = sha256_hex(content)
+    except EvidenceError:
+        return _fail(REASON_MALFORMED, checked=tuple(checked))
+    if recomputed_hash != content_hash:
+        return _fail(REASON_HASH_MISMATCH, checked=tuple(checked))
+    policy_version = str(content.get("policy_version", DEFAULT_POLICY_VERSION))
+    verdict = content.get("verdict")
+    if not isinstance(verdict, str):
+        return _fail(REASON_MALFORMED, checked=tuple(checked))
+    recomputed_ref = compute_decision_ref(
+        artifact_hash=recomputed_hash, policy_version=policy_version, verdict=verdict
+    )
+    recorded_ref = envelope.get("decision_ref")
+    if recorded_ref is not None and recorded_ref != recomputed_ref:
+        return _fail(
+            REASON_DECISION_REF_MISMATCH, decision_ref=recomputed_ref, checked=tuple(checked)
+        )
+    checked.append("hash")
+
+    # 3. Recompute (attested -> admissible).
+    controls = content.get("controls")
+    if not isinstance(controls, Mapping):
+        return _fail(REASON_MALFORMED, decision_ref=recomputed_ref, checked=tuple(checked))
+    try:
+        recomputed_verdict = f_controls(controls)
+    except DecisionRefError:
+        return _fail(REASON_MALFORMED, decision_ref=recomputed_ref, checked=tuple(checked))
+    if recomputed_verdict != verdict:
+        return _fail(
+            REASON_VERDICT_NOT_RECOMPUTABLE,
+            decision_ref=recomputed_ref,
+            verdict=verdict,
+            recomputed_verdict=recomputed_verdict,
+            checked=tuple(checked),
+        )
+    checked.append("recompute")
+
+    # 4. Admission (signer must not be the actor's own controller).
+    controllers = set(actor_controllers or ())
+    actor = content.get("actor")
+    if isinstance(actor, Mapping) and isinstance(actor.get("payment_signer"), str):
+        controllers.add(actor["payment_signer"])
+    key_id = ref.get("key_id") if isinstance(ref.get("key_id"), str) else None
+    if signer in controllers or (key_id is not None and key_id in controllers):
+        return _fail(
+            REASON_SIGNER_EQUALS_RUNTIME,
+            decision_ref=recomputed_ref,
+            verdict=verdict,
+            recomputed_verdict=recomputed_verdict,
+            checked=tuple(checked),
+        )
+    checked.append("admission")
+
+    # 5. Signature.
+    try:
+        trust = load_trust_store(trust_store)
+    except EvidenceError:
+        return _fail(REASON_MALFORMED, decision_ref=recomputed_ref, checked=tuple(checked))
+    entry = trust.get(signer)
+    if entry is None:
+        return _fail(REASON_UNKNOWN_SIGNER, decision_ref=recomputed_ref, checked=tuple(checked))
+    alg = entry.get("alg")
+    keys = entry.get("keys")
+    verify = verify_ed25519 if alg == "ed25519" else verify_hmac
+    if not (
+        isinstance(keys, list)
+        and any(isinstance(k, str) and verify(content_hash, signer, signature, k) for k in keys)
+    ):
+        return _fail(REASON_BAD_SIGNATURE, decision_ref=recomputed_ref, checked=tuple(checked))
+    checked.append("signature")
+
+    # 6. Parent linkage.
+    if require_parents:
+        provenance = content.get("provenance")
+        recorded_parents = provenance.get("parents") if isinstance(provenance, Mapping) else None
+        recorded_set = set(recorded_parents) if isinstance(recorded_parents, list) else set()
+        if not set(require_parents).issubset(recorded_set):
+            return _fail(
+                REASON_PARENT_LINKAGE,
+                decision_ref=recomputed_ref,
+                verdict=verdict,
+                recomputed_verdict=recomputed_verdict,
+                checked=tuple(checked),
+            )
+    checked.append("parents")
+
+    return DecisionRefVerification(
+        ok=True,
+        reason=None,
+        decision_ref=recomputed_ref,
+        verdict=verdict,
+        recomputed_verdict=recomputed_verdict,
+        checked=tuple(checked),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pluggable emitter — the opt-in seam wired into the pipeline (default OFF).
+# Mirrors the AuditWriter pattern: a small object the gateway is handed; when
+# absent, no decision-ref code runs and behaviour is byte-identical.
+# ---------------------------------------------------------------------------
+
+
+class DecisionRefWriter:
+    """Sink protocol for emitted decision-ref envelopes (structural).
+
+    Any object with a ``write(envelope: dict) -> None`` method qualifies. Two
+    built-ins are provided below. A writer MUST NOT perform network I/O on the
+    emit path (the design note forbids it); file writers follow the audit-log
+    file conventions.
+    """
+
+    def write(self, envelope: Mapping[str, object]) -> None:  # pragma: no cover - protocol
+        raise NotImplementedError
+
+
+class NullDecisionRefWriter(DecisionRefWriter):
+    """Discards envelopes. The explicit off-switch used in tests."""
+
+    def write(self, envelope: Mapping[str, object]) -> None:
+        return
+
+
+class FileDecisionRefWriter(DecisionRefWriter):
+    """Appends one JSON envelope per line to a file (JSON-L), fsync by default.
+
+    Mirrors :class:`~presidio_x402.audit_log.FileAuditWriter`: per-write fsync so
+    the record survives a kernel-level process death, a lock for thread-safety,
+    UTF-8, ``ensure_ascii`` off for byte-parity with the family canonical form.
+    """
+
+    def __init__(self, path: str, *, fsync: bool = True) -> None:
+        import threading
+
+        self._path = path
+        self._fsync = fsync
+        self._lock = threading.Lock()
+
+    def write(self, envelope: Mapping[str, object]) -> None:
+        import json
+        import os
+
+        line = json.dumps(dict(envelope), sort_keys=True, ensure_ascii=False, default=str)
+        with self._lock, open(self._path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+            if self._fsync:
+                fh.flush()
+                os.fsync(fh.fileno())
+
+
+@dataclass
+class DecisionRefEmitter:
+    """Builds and writes a decision-ref envelope per payment (opt-in).
+
+    Construct with a signing key (Ed25519 hex or HMAC secret) plus emitter
+    identity, hand it to :class:`~presidio_x402.gateway.HardenedX402Client` (or
+    :class:`~presidio_x402.core.ScreeningPipeline`) as ``decision_ref_emitter``.
+    When present, the pipeline calls :meth:`emit` once per payment with the
+    gathered :class:`ControlResults`; when ``None`` (the default), no
+    decision-ref code path runs at all.
+
+    Signer independence is claim-critical (design note "Evidence envelope"): the
+    ``signer`` here should be a policy/approval identity distinct from the payment
+    wallet, or the record is only self-attested — :func:`verify_decision_ref`
+    fails closed on self-approval.
+    """
+
+    signing_key: str
+    signer: str = DEFAULT_DECISION_SIGNER
+    algorithm: str = "ed25519"
+    key_id: str | None = None
+    writer: DecisionRefWriter | None = None
+    policy_version: str = DEFAULT_POLICY_VERSION
+
+    def emit(
+        self,
+        *,
+        agent_id: str,
+        payment_signer: str,
+        network: str,
+        binding: str,
+        offer_hash: str | None = None,
+        offer_hash_absent: str | None = None,
+        details_hash: str,
+        pay_to: str,
+        amount: str,
+        currency: str,
+        resource_origin: str,
+        controls: ControlResults,
+        parents: Sequence[str] | None = None,
+        prior_decision_refs: Sequence[str] | None = None,
+    ) -> dict[str, object]:
+        """Build, sign, write (if a writer is set) and return one envelope.
+
+        No network I/O. Returns the envelope so a caller can archive it or attach
+        the ``decision_ref`` to an audit event.
+        """
+        content = build_payment_decision_content(
+            agent_id=agent_id,
+            payment_signer=payment_signer,
+            network=network,
+            binding=binding,
+            offer_hash=offer_hash,
+            offer_hash_absent=offer_hash_absent,
+            details_hash=details_hash,
+            pay_to=pay_to,
+            amount=amount,
+            currency=currency,
+            resource_origin=resource_origin,
+            controls=controls,
+            policy_version=self.policy_version,
+            parents=parents,
+            prior_decision_refs=prior_decision_refs,
+        )
+        envelope = build_decision_evidence(
+            content,
+            signing_key=self.signing_key,
+            algorithm=self.algorithm,
+            signer=self.signer,
+            key_id=self.key_id,
+            parents=parents,
+            prior_decision_refs=prior_decision_refs,
+        )
+        if self.writer is not None:
+            self.writer.write(envelope)
+        return envelope
+
+
+# ---------------------------------------------------------------------------
+# Minimal CLI verifier: ``python -m presidio_x402.decision_ref <env.json> <trust.json>``
+# Fully offline; exit 0 on verify, 1 on any fail-closed reason, 2 on usage error.
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify a decision-ref envelope (or a JSON-L set) against a trust store.
+
+    Usage::
+
+        python -m presidio_x402.decision_ref ENVELOPE.json TRUST.json [--parent P ...]
+
+    ENVELOPE.json is either one envelope object or a JSON-L file of envelopes (one
+    per line, as :class:`FileDecisionRefWriter` writes). Prints one line per
+    record with its ``decision_ref``, verdict, and pass/fail reason. Exit 0 iff
+    **every** record verifies; 1 if any fails; 2 on a usage error. No network I/O.
+    """
+    import argparse
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(prog="presidio_x402.decision_ref")
+    parser.add_argument("envelope", help="path to an envelope .json or JSON-L file")
+    parser.add_argument("trust_store", help="path to a trust-store@1 JSON file")
+    parser.add_argument(
+        "--parent",
+        action="append",
+        default=[],
+        help="a required provenance parent (repeatable); e.g. capability-grant:<hash>",
+    )
+    args = parser.parse_args(argv)
+
+    from pathlib import Path
+
+    try:
+        raw = Path(args.envelope).read_text(encoding="utf-8")
+        trust_text = Path(args.trust_store).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    stripped = raw.strip()
+    try:
+        first = json.loads(stripped)
+        envelopes = [first] if isinstance(first, dict) else list(first)
+    except json.JSONDecodeError:
+        envelopes = [json.loads(line) for line in stripped.splitlines() if line.strip()]
+
+    require_parents = args.parent or None
+    all_ok = True
+    for env in envelopes:
+        result = verify_decision_ref(env, trust_text, require_parents=require_parents)
+        status = "OK" if result.ok else f"FAIL({result.reason})"
+        print(f"{result.decision_ref or '<no-ref>'}  verdict={result.verdict}  {status}")
+        all_ok = all_ok and result.ok
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -78,6 +78,8 @@ if TYPE_CHECKING:
         PaymentResponse,
         PaymentSigner,
     )
+    from .capability import VerifiedGrantChain
+    from .decision_ref import DecisionRefEmitter
     from .metrics import MetricsCollector
     from .mpa import MPAEngine
     from .screening_client import ScreeningClient
@@ -99,6 +101,15 @@ _parse_402_header = parse_402_header
 _amount_to_usd = amount_to_usd
 _safe_exc_message = safe_exc_message
 _resource_origin = resource_origin
+
+
+def _raw_header_bytes(headers: httpx.Headers, header_name: str) -> bytes | None:
+    """Return one header value as transport bytes when httpx retained them."""
+    target = header_name.lower().encode("ascii")
+    for name, value in headers.raw:
+        if name.lower() == target:
+            return bytes(value)
+    return None
 
 
 class HardenedX402Client:
@@ -175,6 +186,19 @@ class HardenedX402Client:
         :class:`~presidio_x402.bindings.x402.X402Binding` (HTTP 402 +
         ``X-PAYMENT``). Supply a custom binding to reuse the screening core on
         a different payment rail.
+    decision_ref_emitter:
+        Optional :class:`~presidio_x402.decision_ref.DecisionRefEmitter`. When
+        set, one signed ``presidio-hardened-x402/payment-decision@1`` record is
+        emitted per payment (immediately before signing), binding the per-control
+        gate verdicts, hashed inputs, and the effective policy hash into a
+        portable, offline-verifiable proof (Pillar II). ``None`` (default)
+        disables emission entirely — behaviour is byte-identical to prior
+        releases. No network I/O is performed on the emit path.
+    capability_chain:
+        Optional verified :class:`~presidio_x402.capability.VerifiedGrantChain`.
+        When the spending policy was projected from a capability chain, pass it so
+        the emitted decision-ref links the chain's terminal ``grant_hash`` as a
+        provenance parent (does nothing unless ``decision_ref_emitter`` is set).
     """
 
     def __init__(
@@ -196,6 +220,8 @@ class HardenedX402Client:
         screening_client: ScreeningClient | None = None,
         remote_screening: bool = False,
         binding: PaymentProtocolBinding | None = None,
+        decision_ref_emitter: DecisionRefEmitter | None = None,
+        capability_chain: VerifiedGrantChain | None = None,
     ) -> None:
         if remote_screening and screening_client is None:
             raise ValueError("remote_screening=True requires a screening_client instance")
@@ -241,6 +267,9 @@ class HardenedX402Client:
             trusted_wallets=self._trusted_wallets,
             screening_client=screening_client,
             remote_screening=remote_screening,
+            decision_ref_emitter=decision_ref_emitter,
+            capability_chain=capability_chain,
+            agent_id=agent_id,
         )
         logger.info("Presidio hardening applied — HardenedX402Client initialized")
 
@@ -295,6 +324,12 @@ class HardenedX402Client:
                 safe_url,
             )
             return resp
+        raw_offer_hash = None
+        raw_offer_bytes = _raw_header_bytes(resp.headers, self._binding.header_name)
+        if raw_offer_bytes is not None:
+            from .decision_ref import offer_hash
+
+            raw_offer_hash = offer_hash(raw_offer_bytes)
 
         try:
             details = self._binding.parse_payment_required(offer)
@@ -312,7 +347,9 @@ class HardenedX402Client:
         # Apply security controls; get (possibly modified) details + the replay
         # fingerprint back so a signing failure can roll the commit back.
         secure_details, fingerprint = await self._pipeline.apply(
-            details, mpa_signatures=mpa_signatures
+            details,
+            mpa_signatures=mpa_signatures,
+            raw_offer_hash=raw_offer_hash,
         )
 
         # Sign and retry

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -1,0 +1,671 @@
+"""Tests for capability certificates (``presidio-hardened/capability-grant@1``).
+
+Covers: golden issue -> verify roundtrip, a 3-hop delegation happy path, every
+attenuation-violation class (budget raised, window widened, window_seconds
+widened, prefix broadened, sibling-prefix injection), tampered signature, expired
+grant, wrong trust-store key, exercise-time checks against the chain (amount over
+a hop's cap; URL outside the intersection), float-amount rejection, determinism of
+the canonical signing bytes, and the ``PolicyConfig`` bridge.
+
+Ed25519 keys are generated per-test via ``cryptography`` (the ``[evidence]``
+extra), mirroring the pattern in ``test_mica.py`` / ``test_evidence_conformance``.
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from presidio_x402.capability import (
+    CAPABILITY_SCHEMA_ID,
+    CapabilityError,
+    _signing_preimage,
+    delegate_grant,
+    issue_grant,
+    policy_config_from_chain,
+    verify_chain,
+)
+
+# ---------------------------------------------------------------------------
+# Key + trust-store helpers
+# ---------------------------------------------------------------------------
+
+
+def _keypair() -> tuple[str, str]:
+    """Return (private_hex, public_hex) for a fresh Ed25519 keypair."""
+    sk = ed25519.Ed25519PrivateKey.generate()
+    return (
+        sk.private_bytes_raw().hex(),
+        sk.public_key().public_bytes_raw().hex(),
+    )
+
+
+def _trust_store(operator_id: str, operator_pub: str) -> dict:
+    return {operator_id: {"alg": "ed25519", "public_key": operator_pub}}
+
+
+@pytest.fixture
+def operator() -> tuple[str, str, str]:
+    priv, pub = _keypair()
+    return ("acme-operator", priv, pub)
+
+
+# ---------------------------------------------------------------------------
+# 1. Golden roundtrip: issue -> verify
+# ---------------------------------------------------------------------------
+
+
+def test_issue_verify_roundtrip(operator):
+    op_id, op_priv, op_pub = operator
+    agent_priv, agent_pub = _keypair()
+    grant = issue_grant(
+        subject="agent-root",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=agent_pub,
+        caveats={
+            "max_per_call_usd": "0.05",
+            "daily_limit_usd": "2.00",
+            "endpoint_prefixes": ["https://api.foo.com/inference"],
+        },
+    )
+    assert grant["schema"] == CAPABILITY_SCHEMA_ID
+    assert grant["parent_hash"] is None
+    assert len(bytes.fromhex(grant["signature"])) == 64
+
+    vc = verify_chain([grant], _trust_store(op_id, op_pub))
+    assert vc.subject == "agent-root"
+    assert str(vc.effective.max_per_call_usd) == "0.05"
+    assert vc.effective.endpoint_prefixes == ("https://api.foo.com/inference",)
+
+
+def test_issue_with_integer_micro_usd(operator):
+    op_id, op_priv, op_pub = operator
+    # 50_000 micro-USD == 0.05 USD
+    grant = issue_grant(
+        subject="agent",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"max_per_call_usd": 50_000},
+    )
+    vc = verify_chain([grant], _trust_store(op_id, op_pub))
+    from decimal import Decimal
+
+    assert vc.effective.max_per_call_usd == Decimal("0.05")
+
+
+# ---------------------------------------------------------------------------
+# 2. Three-hop delegation happy path
+# ---------------------------------------------------------------------------
+
+
+def _three_hop(op_id, op_priv):
+    a_priv, a_pub = _keypair()
+    b_priv, b_pub = _keypair()
+    c_priv, c_pub = _keypair()
+    root = issue_grant(
+        subject="agent-A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={
+            "max_per_call_usd": "1.00",
+            "daily_limit_usd": "10.00",
+            "window_seconds": 86_400,
+            "endpoint_prefixes": ["https://api.foo.com/"],
+        },
+    )
+    child = delegate_grant(
+        root,
+        parent_private_key=a_priv,
+        subject="agent-B",
+        subject_public_key=b_pub,
+        caveats={
+            "max_per_call_usd": "0.50",
+            "daily_limit_usd": "5.00",
+            "window_seconds": 86_400,
+            "endpoint_prefixes": ["https://api.foo.com/inference"],
+        },
+    )
+    grand = delegate_grant(
+        child,
+        parent_private_key=b_priv,
+        subject="agent-C",
+        subject_public_key=c_pub,
+        caveats={
+            # Must carry through every axis the parent constrains (dropping one
+            # would be a broadening — see test_reject_unbounded_child_when_parent_caps).
+            "max_per_call_usd": "0.10",
+            "daily_limit_usd": "5.00",
+            "window_seconds": 86_400,
+            "endpoint_prefixes": ["https://api.foo.com/inference/v2"],
+        },
+    )
+    return [root, child, grand]
+
+
+def test_three_hop_delegation_happy_path(operator):
+    op_id, op_priv, op_pub = operator
+    chain = _three_hop(op_id, op_priv)
+    vc = verify_chain(chain, _trust_store(op_id, op_pub))
+    assert vc.subject == "agent-C"
+    # Effective = intersection: tightest cap 0.10, tightest daily 5.00 (from B),
+    # tightest rolling budget window 86400, deepest prefix set.
+    assert str(vc.effective.max_per_call_usd) == "0.10"
+    assert str(vc.effective.daily_limit_usd) == "5.00"
+    assert vc.effective.window_seconds == 86_400
+    assert vc.effective.endpoint_prefixes == ("https://api.foo.com/inference/v2",)
+    vc.check_payment(resource_url="https://api.foo.com/inference/v2/chat", amount_usd="0.05")
+
+
+# ---------------------------------------------------------------------------
+# 3. Attenuation-violation classes — every one must FAIL closed
+# ---------------------------------------------------------------------------
+
+
+def test_reject_budget_raised(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    with pytest.raises(CapabilityError, match="exceeds parent"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={"max_per_call_usd": "0.50"},  # raised — must fail
+        )
+
+
+def test_reject_unbounded_child_when_parent_caps(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    with pytest.raises(CapabilityError, match="unbounded"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={"daily_limit_usd": "1.00"},  # drops the per-call cap
+        )
+
+
+def test_reject_validity_window_widened(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={
+            "valid_from": "2026-01-01T00:00:00Z",
+            "valid_until": "2026-02-01T00:00:00Z",
+        },
+    )
+    with pytest.raises(CapabilityError, match="valid_until"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={
+                "valid_from": "2026-01-01T00:00:00Z",
+                "valid_until": "2026-03-01T00:00:00Z",  # widened later
+            },
+        )
+    assert now  # window fixture sanity
+
+
+def test_reject_window_seconds_shortened(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"window_seconds": 86_400},
+    )
+    with pytest.raises(CapabilityError, match="window_seconds"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={"window_seconds": 3_600},  # shorter window evicts spend sooner
+        )
+
+
+def test_reject_prefix_broadened_shortening(operator):
+    """Canonical broadening: parent .../inference, child .../ must FAIL."""
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"endpoint_prefixes": ["https://api.foo.com/inference"]},
+    )
+    with pytest.raises(CapabilityError, match="does not extend"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={"endpoint_prefixes": ["https://api.foo.com/"]},
+        )
+
+
+def test_reject_sibling_prefix_injection(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"endpoint_prefixes": ["https://api.foo.com/inference"]},
+    )
+    with pytest.raises(CapabilityError, match="does not extend"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={
+                "endpoint_prefixes": [
+                    "https://api.foo.com/inference/ok",  # legit
+                    "https://api.foo.com/admin",  # injected sibling — must fail whole set
+                ]
+            },
+        )
+
+
+def test_reject_prefix_segment_confusion(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"endpoint_prefixes": ["https://api.foo.com/inference"]},
+    )
+    with pytest.raises(CapabilityError, match="does not extend"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={"endpoint_prefixes": ["https://api.foo.com/inference-evil"]},
+        )
+
+
+def test_reject_prefix_host_confusion(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"endpoint_prefixes": ["https://api.foo.com"]},
+    )
+    with pytest.raises(CapabilityError, match="does not extend"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={"endpoint_prefixes": ["https://api.foo.com.evil/inference"]},
+        )
+
+
+def test_reject_prefix_dropped_when_parent_restricts(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"endpoint_prefixes": ["https://api.foo.com/inference"]},
+    )
+    with pytest.raises(CapabilityError, match="drops them"):
+        delegate_grant(
+            root,
+            parent_private_key=a_priv,
+            subject="B",
+            caveats={"max_per_call_usd": "0.01"},  # no prefixes -> unrestricted
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Tampered signature / broken chain / expired / wrong key
+# ---------------------------------------------------------------------------
+
+
+def test_tampered_signature_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    tampered = copy.deepcopy(grant)
+    # Flip one hex nibble of the signature.
+    sig = tampered["signature"]
+    flipped = ("0" if sig[0] != "0" else "1") + sig[1:]
+    tampered["signature"] = flipped
+    with pytest.raises(CapabilityError, match="does not verify"):
+        verify_chain([tampered], _trust_store(op_id, op_pub))
+
+
+def test_tampered_caveat_after_signing_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    tampered = copy.deepcopy(grant)
+    tampered["caveats"]["max_per_call_usd"] = "9.99"  # raise cap post-signature
+    with pytest.raises(CapabilityError, match="does not verify"):
+        verify_chain([tampered], _trust_store(op_id, op_pub))
+
+
+def test_child_hash_link_broken_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"max_per_call_usd": "1.00"},
+    )
+    child = delegate_grant(
+        root,
+        parent_private_key=a_priv,
+        subject="B",
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    child_bad = copy.deepcopy(child)
+    child_bad["parent_hash"] = "aa" * 32  # points at nothing
+    with pytest.raises(CapabilityError, match="does not verify|parent_hash"):
+        verify_chain([root, child_bad], _trust_store(op_id, op_pub))
+
+
+def test_expired_grant_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"valid_until": "2026-01-01T00:00:00Z"},
+    )
+    with pytest.raises(CapabilityError, match="expired"):
+        verify_chain(
+            [grant],
+            _trust_store(op_id, op_pub),
+            at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_not_yet_valid_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"valid_from": "2026-06-01T00:00:00Z"},
+    )
+    with pytest.raises(CapabilityError, match="not yet valid"):
+        verify_chain(
+            [grant],
+            _trust_store(op_id, op_pub),
+            at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_wrong_trust_store_key_rejected(operator):
+    op_id, op_priv, _op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    _, other_pub = _keypair()  # a different operator's public key
+    with pytest.raises(CapabilityError, match="does not verify"):
+        verify_chain([grant], _trust_store(op_id, other_pub))
+
+
+def test_unknown_issuer_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    with pytest.raises(CapabilityError, match="not in the trust store"):
+        verify_chain([grant], _trust_store("someone-else", op_pub))
+
+
+def test_leaf_cannot_delegate(operator):
+    op_id, op_priv, _ = operator
+    leaf = issue_grant(  # no subject_public_key
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"max_per_call_usd": "0.10"},
+    )
+    a_priv, _ = _keypair()
+    with pytest.raises(CapabilityError, match="cannot be delegated"):
+        delegate_grant(
+            leaf, parent_private_key=a_priv, subject="B", caveats={"max_per_call_usd": "0.01"}
+        )
+
+
+def test_unknown_schema_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A", issuer=op_id, issuer_private_key=op_priv, caveats={"max_per_call_usd": "0.10"}
+    )
+    grant["schema"] = "presidio-hardened/capability-grant@99"
+    with pytest.raises(CapabilityError, match="unsupported grant schema"):
+        verify_chain([grant], _trust_store(op_id, op_pub))
+
+
+def test_bad_hex_signature_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A", issuer=op_id, issuer_private_key=op_priv, caveats={"max_per_call_usd": "0.10"}
+    )
+    grant["signature"] = "zz" * 64
+    with pytest.raises(CapabilityError, match="hex"):
+        verify_chain([grant], _trust_store(op_id, op_pub))
+
+
+# ---------------------------------------------------------------------------
+# 5. Exercise-time checks against the chain
+# ---------------------------------------------------------------------------
+
+
+def test_exercise_amount_over_hop_cap_fails(operator):
+    op_id, op_priv, op_pub = operator
+    chain = _three_hop(op_id, op_priv)
+    vc = verify_chain(chain, _trust_store(op_id, op_pub))
+    # Deepest cap is 0.10; 0.50 would pass the root+child but not the grandchild.
+    with pytest.raises(CapabilityError, match="max_per_call_usd"):
+        vc.check_payment(resource_url="https://api.foo.com/inference/v2/x", amount_usd="0.50")
+
+
+def test_exercise_url_outside_intersection_fails(operator):
+    op_id, op_priv, op_pub = operator
+    chain = _three_hop(op_id, op_priv)
+    vc = verify_chain(chain, _trust_store(op_id, op_pub))
+    # /inference (child scope) is inside root but OUTSIDE grandchild's /inference/v2.
+    with pytest.raises(CapabilityError, match="outside the granted endpoint prefixes"):
+        vc.check_payment(resource_url="https://api.foo.com/inference/other", amount_usd="0.05")
+
+
+def test_exercise_url_segment_confusion_fails(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"endpoint_prefixes": ["https://api.foo.com/inference"]},
+    )
+    vc = verify_chain([grant], _trust_store(op_id, op_pub))
+    with pytest.raises(CapabilityError, match="outside the granted endpoint prefixes"):
+        vc.check_payment(resource_url="https://api.foo.com/inference-evil", amount_usd="0.05")
+
+
+def test_exercise_expired_at_fails(operator):
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"valid_until": "2026-02-01T00:00:00Z"},
+    )
+    vc = verify_chain(
+        [grant], _trust_store(op_id, op_pub), at=datetime(2026, 1, 1, tzinfo=timezone.utc)
+    )
+    with pytest.raises(CapabilityError, match="expired"):
+        vc.check_payment(
+            resource_url="https://x",
+            amount_usd="0.01",
+            at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Float rejection + determinism
+# ---------------------------------------------------------------------------
+
+
+def test_float_amount_rejected(operator):
+    op_id, op_priv, _ = operator
+    with pytest.raises(CapabilityError, match="never a float"):
+        issue_grant(
+            subject="A",
+            issuer=op_id,
+            issuer_private_key=op_priv,
+            caveats={"max_per_call_usd": 0.05},  # a float — must reject
+        )
+
+
+def test_signing_preimage_is_byte_stable():
+    """Canonical signing bytes must not depend on input key order."""
+    a = {
+        "schema": CAPABILITY_SCHEMA_ID,
+        "issuer": "op",
+        "subject": "A",
+        "caveats": {"daily_limit_usd": "2.00", "max_per_call_usd": "0.05"},
+        "parent_hash": None,
+        "issued_at": "2026-01-01T00:00:00Z",
+        "grant_id": "x",
+        "signature": "ignored",
+    }
+    b = {k: a[k] for k in reversed(list(a.keys()))}
+    b["caveats"] = {"max_per_call_usd": "0.05", "daily_limit_usd": "2.00"}
+    assert _signing_preimage(a) == _signing_preimage(b)
+    # And the signature field is excluded from the preimage.
+    assert b"ignored" not in _signing_preimage(a)
+
+
+def test_issue_is_deterministic_given_issued_at(operator):
+    op_id, op_priv, op_pub = operator
+    ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    kwargs = {
+        "subject": "A",
+        "issuer": op_id,
+        "issuer_private_key": op_priv,
+        "caveats": {"max_per_call_usd": "0.10"},
+        "issued_at": ts,
+    }
+    g1 = issue_grant(**kwargs)
+    g2 = issue_grant(**kwargs)
+    # Ed25519 is deterministic — identical inputs yield identical signatures.
+    assert g1 == g2
+
+
+# ---------------------------------------------------------------------------
+# 7. PolicyConfig bridge
+# ---------------------------------------------------------------------------
+
+
+def test_policy_config_bridge_uses_intersection(operator):
+    op_id, op_priv, op_pub = operator
+    chain = _three_hop(op_id, op_priv)
+    vc = verify_chain(chain, _trust_store(op_id, op_pub))
+    pc = policy_config_from_chain(vc)
+    # Bridge converts the exact Decimal caps to float at the runtime-config
+    # boundary (grant wire form stays float-free; PolicyConfig fields are float).
+    assert pc.max_per_call_usd == pytest.approx(0.10)
+    assert pc.daily_limit_usd == pytest.approx(5.00)
+    assert pc.window_seconds == 86_400
+    assert pc.agent_id == "agent-C"
+    # Endpoint scope becomes a per-endpoint cap at the effective per-call cap.
+    assert pc.per_endpoint == {"https://api.foo.com/inference/v2": pytest.approx(0.10)}
+
+
+def test_policy_config_bridge_feeds_policy_engine(operator):
+    """The bridged config drives a real PolicyEngine with no floats."""
+    from presidio_x402.policy_engine import PolicyEngine
+
+    op_id, op_priv, op_pub = operator
+    grant = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        caveats={"max_per_call_usd": "0.05", "daily_limit_usd": "0.10"},
+    )
+    vc = verify_chain([grant], _trust_store(op_id, op_pub))
+    engine = PolicyEngine(policy_config_from_chain(vc))
+    engine.check_and_record(resource_url="https://api.foo.com/x", amount_usd=0.04)
+    from presidio_x402.exceptions import PolicyViolationError
+
+    with pytest.raises(PolicyViolationError):
+        engine.check_and_record(resource_url="https://api.foo.com/x", amount_usd=0.06)
+
+
+def test_empty_chain_rejected(operator):
+    op_id, _, op_pub = operator
+    with pytest.raises(CapabilityError, match="non-empty"):
+        verify_chain([], _trust_store(op_id, op_pub))
+
+
+def test_second_grant_as_root_rejected(operator):
+    op_id, op_priv, op_pub = operator
+    a_priv, a_pub = _keypair()
+    root = issue_grant(
+        subject="A",
+        issuer=op_id,
+        issuer_private_key=op_priv,
+        subject_public_key=a_pub,
+        caveats={"max_per_call_usd": "1.00"},
+    )
+    # A second independent root (parent_hash None) is not a valid child.
+    other_root = issue_grant(
+        subject="B", issuer=op_id, issuer_private_key=op_priv, caveats={"max_per_call_usd": "0.10"}
+    )
+    with pytest.raises(CapabilityError, match="has no parent"):
+        verify_chain([root, other_root], _trust_store(op_id, op_pub))

--- a/tests/test_decision_ref.py
+++ b/tests/test_decision_ref.py
@@ -1,0 +1,505 @@
+"""Tests for decision-ref emission (``presidio-hardened-x402/payment-decision@1``).
+
+Covers, per the task brief:
+
+- roundtrip per gate/control type (build -> sign -> verify) with each verdict enum;
+- PII-freedom: no raw metadata string from a PII-bearing corpus ever appears in any
+  emitted record (only hashes + entity-type labels);
+- parent linkage to a REAL capability chain from ``capability.py``;
+- tamper detection (content, signature, verdict) and the two named fail-closed
+  negatives (self-approval ``signer_equals_runtime``, ``verdict_not_recomputable``);
+- default-off unchanged-behaviour: with no emitter the pipeline result is identical
+  and no record is written.
+
+Ed25519 keys are generated per-test via ``cryptography`` (the ``[evidence]`` extra),
+mirroring ``test_capability.py`` / ``test_mica.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from presidio_x402.capability import delegate_grant, issue_grant, verify_chain
+from presidio_x402.decision_ref import (
+    PAYMENT_DECISION_SCHEMA_ID,
+    REASON_BAD_SIGNATURE,
+    REASON_HASH_MISMATCH,
+    REASON_MALFORMED,
+    REASON_PARENT_LINKAGE,
+    REASON_SIGNER_EQUALS_RUNTIME,
+    REASON_UNKNOWN_SIGNER,
+    REASON_VERDICT_NOT_RECOMPUTABLE,
+    ControlResults,
+    DecisionRefEmitter,
+    DecisionRefError,
+    NullDecisionRefWriter,
+    build_decision_evidence,
+    build_payment_decision_content,
+    capability_parents,
+    compute_decision_ref,
+    f_controls,
+    verify_decision_ref,
+)
+
+
+def _keypair() -> tuple[str, str]:
+    sk = ed25519.Ed25519PrivateKey.generate()
+    return sk.private_bytes_raw().hex(), sk.public_key().public_bytes_raw().hex()
+
+
+@pytest.fixture
+def policy_signer():
+    """A policy-issuer keypair + trust store (distinct from any payment wallet)."""
+    priv, pub = _keypair()
+    signer = "presidio-hardened-x402-policy"
+    trust = {signer: {"alg": "ed25519", "public_key": pub}}
+    return signer, priv, pub, trust
+
+
+def _controls(**overrides) -> ControlResults:
+    base = {
+        "pii_verdict": "PII_REDACTED",
+        "pii_entities": ("EMAIL_ADDRESS",),
+        "pii_mutated": True,
+        "trusted_wallet_verdict": "TRUSTED",
+        "policy_verdict": "ALLOW",
+        "policy_snapshot_hash": "sha256:" + "a" * 64,
+        "policy_limit_hash": "sha256:" + "b" * 64,
+        "replay_verdict": "FRESH",
+        "replay_fingerprint_hash": "sha256:" + "c" * 64,
+        "mpa_verdict": "NOT_REQUIRED",
+        "mpa_required": False,
+    }
+    base.update(overrides)
+    return ControlResults(**base)
+
+
+def _content(controls: ControlResults, **overrides) -> dict:
+    kw = {
+        "agent_id": "did:presidio:x402:agent-7f3a9c",
+        "payment_signer": "wallet:evm:0xA11ce0000000000000000000000000000000dEaD",
+        "network": "eip155:8453",
+        "binding": "x402",
+        "offer_hash": "sha256:" + "1" * 64,
+        "details_hash": "sha256:" + "2" * 64,
+        "pay_to": "0x0273d0b906c9524dB2672318545aaDa1F478B1a1",
+        "amount": "10000",
+        "currency": "USDC",
+        "resource_origin": "https://api.merchant.example",
+        "controls": controls,
+    }
+    kw.update(overrides)
+    return build_payment_decision_content(**kw)
+
+
+def _resign_payment_decision(env: dict, signer: str, priv: str) -> None:
+    from presidio_x402.mica import sha256_hex, sign_evidence
+
+    new_hash = sha256_hex(env["payment_decision"])
+    env["artifact_hash"] = new_hash
+    env["evidence"][0]["content_hash"] = new_hash
+    env["evidence"][0]["signature"] = sign_evidence(new_hash, signer, key=priv)
+    env["decision_ref"] = compute_decision_ref(
+        artifact_hash=new_hash,
+        policy_version=env["payment_decision"]["policy_version"],
+        verdict=env["payment_decision"]["verdict"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. f(controls) — recomputable verdict, first-failure-wins.
+# ---------------------------------------------------------------------------
+
+
+def test_f_controls_allow():
+    assert f_controls(_controls().to_controls()) == "ALLOW"
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"pii_verdict": "PII_BLOCKED"},
+        {"trusted_wallet_verdict": "UNTRUSTED"},
+        {"policy_verdict": "VIOLATION"},
+        {"replay_verdict": "DUPLICATE"},
+        {"mpa_verdict": "DENIED", "mpa_required": True},
+    ],
+)
+def test_f_controls_deny(override):
+    assert f_controls(_controls(**override).to_controls()) == "DENY"
+
+
+@pytest.mark.parametrize("mpa", ["PENDING", "TIMEOUT"])
+def test_f_controls_refer_on_unanswered_mpa(mpa):
+    assert f_controls(_controls(mpa_verdict=mpa, mpa_required=True).to_controls()) == "REFER"
+
+
+def test_f_controls_first_failure_wins():
+    # PII blocked precedes a policy violation: DENY either way, but the point is
+    # precedence order matches the shipped gateway.
+    c = _controls(pii_verdict="PII_BLOCKED", policy_verdict="VIOLATION").to_controls()
+    assert f_controls(c) == "DENY"
+
+
+def test_invalid_verdict_fails_closed():
+    with pytest.raises(DecisionRefError):
+        _controls(policy_verdict="MAYBE").to_controls()
+
+
+def test_f_controls_missing_control_fails_closed():
+    controls = _controls().to_controls()
+    del controls["policy"]
+    with pytest.raises(DecisionRefError):
+        f_controls(controls)
+
+
+# ---------------------------------------------------------------------------
+# 2. Build -> sign -> verify roundtrip, per verdict.
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_allow(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    content = _content(_controls())
+    env = build_decision_evidence(content, signing_key=priv, signer=signer)
+    assert env["schema"] == "presidio-hardened/evidence-ref@1"
+    assert env["payment_decision"]["schema"] == PAYMENT_DECISION_SCHEMA_ID
+    result = verify_decision_ref(env, trust)
+    assert result.ok
+    assert result.verdict == "ALLOW" == result.recomputed_verdict
+    assert "signature" in result.checked
+
+
+def test_absent_offer_hash_is_explicit(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(
+        _content(_controls(), offer_hash=None, offer_hash_absent="not-retained"),
+        signing_key=priv,
+        signer=signer,
+    )
+    payment = env["payment_decision"]["payment"]
+    assert "offer_hash" not in payment
+    assert payment["offer_hash_absent"] == "not-retained"
+    assert verify_decision_ref(env, trust).ok
+
+
+@pytest.mark.parametrize(
+    "override,expected",
+    [
+        ({"policy_verdict": "VIOLATION"}, "DENY"),
+        ({"replay_verdict": "DUPLICATE"}, "DENY"),
+        ({"pii_verdict": "PII_BLOCKED"}, "DENY"),
+        ({"trusted_wallet_verdict": "UNTRUSTED"}, "DENY"),
+        ({"mpa_verdict": "PENDING", "mpa_required": True}, "REFER"),
+    ],
+)
+def test_roundtrip_each_gate(policy_signer, override, expected):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls(**override)), signing_key=priv, signer=signer)
+    result = verify_decision_ref(env, trust)
+    assert result.ok and result.verdict == expected
+
+
+def test_decision_ref_recomputes_from_preimage(policy_signer):
+    signer, priv, _pub, _trust = policy_signer
+    content = _content(_controls())
+    env = build_decision_evidence(content, signing_key=priv, signer=signer)
+    pre = env["decision_ref_preimage"]
+    assert set(env["decision_ref_preimage_fields"]) == set(pre.keys())
+    assert compute_decision_ref(**pre) == env["decision_ref"]
+    assert env["evidence"][0]["content_hash"] == env["artifact_hash"] == pre["artifact_hash"]
+
+
+def test_hmac_roundtrip():
+    signer = "policy-hmac"
+    content = _content(_controls())
+    env = build_decision_evidence(
+        content, signing_key="s3cr3t", algorithm="hmac-sha256", signer=signer
+    )
+    trust = {signer: {"alg": "hmac-sha256", "key": "s3cr3t"}}
+    assert verify_decision_ref(env, trust).ok
+
+
+# ---------------------------------------------------------------------------
+# 3. PII-freedom over a PII-bearing corpus.
+# ---------------------------------------------------------------------------
+
+_PII_STRINGS = [
+    "alice@example.com",
+    "bob.smith@corp.internal",
+    "4111111111111111",  # credit card
+    "123-45-6789",  # SSN
+    "+1-415-555-0132",  # phone
+    "Alice Wonderland",  # person
+    "GB33BUKB20201555555555",  # IBAN
+    "https://api.example.com/users/alice@example.com/invoice",
+    "Payment for Bob Smith, SSN 123-45-6789",
+]
+
+
+def test_no_raw_pii_string_in_record(policy_signer):
+    """No raw metadata string may appear in any emitted record; only its hash and
+    entity-type labels. The ControlResults dataclass has no field that accepts a
+    raw string, so this holds by construction — asserted here over a corpus."""
+    signer, priv, _pub, trust = policy_signer
+    # A record built as if screening those PII strings found these entity types.
+    controls = _controls(
+        pii_verdict="PII_REDACTED",
+        pii_entities=(
+            "EMAIL_ADDRESS",
+            "CREDIT_CARD",
+            "US_SSN",
+            "PHONE_NUMBER",
+            "PERSON",
+            "IBAN_CODE",
+        ),
+    )
+    env = build_decision_evidence(_content(controls), signing_key=priv, signer=signer)
+    blob = json.dumps(env, ensure_ascii=False)
+    for raw in _PII_STRINGS:
+        assert raw not in blob, f"raw PII leaked into record: {raw!r}"
+    # Entity-type labels ARE present (that is the allowed screening output).
+    assert "EMAIL_ADDRESS" in blob and "US_SSN" in blob
+    assert verify_decision_ref(env, trust).ok
+
+
+def test_control_results_has_no_raw_string_field():
+    """Structural guarantee: every string field is a hash or an enum label."""
+    fields = ControlResults.__dataclass_fields__
+    for name in ("policy_snapshot_hash", "policy_limit_hash", "replay_fingerprint_hash"):
+        assert name in fields  # the only free-form strings are hashes
+
+
+# ---------------------------------------------------------------------------
+# 4. Capability-chain parent linkage (real chain from capability.py).
+# ---------------------------------------------------------------------------
+
+
+def _real_chain():
+    op_priv, op_pub = _keypair()
+    agent_priv, agent_pub = _keypair()
+    sub_priv, sub_pub = _keypair()
+    root = issue_grant(
+        subject="agent-root",
+        issuer="acme-operator",
+        issuer_private_key=op_priv,
+        subject_public_key=agent_pub,
+        caveats={
+            "max_per_call_usd": "0.05",
+            "endpoint_prefixes": ["https://api.merchant.example"],
+        },
+    )
+    child = delegate_grant(
+        root,
+        parent_private_key=agent_priv,
+        subject="agent-sub",
+        subject_public_key=sub_pub,
+        caveats={
+            "max_per_call_usd": "0.02",
+            "endpoint_prefixes": ["https://api.merchant.example"],
+        },
+    )
+    trust = {"acme-operator": {"alg": "ed25519", "public_key": op_pub}}
+    chain = verify_chain([root, child], trust)
+    return chain
+
+
+def test_parent_links_to_real_capability_chain(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    chain = _real_chain()
+    parents = capability_parents(chain)
+    terminal_hash = chain.grants[-1].grant_hash
+    assert parents == [f"capability-grant:{terminal_hash}"]
+
+    env = build_decision_evidence(
+        _content(_controls()), signing_key=priv, signer=signer, parents=parents
+    )
+    assert env["provenance"]["parents"] == parents
+    assert env["payment_decision"]["provenance"]["parents"] == parents
+    # Verification succeeds and, when we require the real parent, still succeeds.
+    assert verify_decision_ref(env, trust, require_parents=parents).ok
+
+
+def test_missing_required_parent_fails_closed(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    # No parents recorded, but we require one -> parent_linkage failure.
+    result = verify_decision_ref(env, trust, require_parents=["capability-grant:" + "d" * 64])
+    assert not result.ok and result.reason == REASON_PARENT_LINKAGE
+
+
+def test_unsigned_envelope_parent_does_not_satisfy_required_parent(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    required = ["capability-grant:" + "d" * 64]
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    env["provenance"]["parents"] = required
+    result = verify_decision_ref(env, trust, require_parents=required)
+    assert not result.ok and result.reason == REASON_PARENT_LINKAGE
+
+
+def test_signed_parent_tamper_fails_hash(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    parents = ["capability-grant:" + "d" * 64]
+    env = build_decision_evidence(
+        _content(_controls()), signing_key=priv, signer=signer, parents=parents
+    )
+    env["payment_decision"]["provenance"]["parents"] = []
+    result = verify_decision_ref(env, trust, require_parents=parents)
+    assert not result.ok and result.reason == REASON_HASH_MISMATCH
+
+
+def test_capability_parents_none_is_empty():
+    assert capability_parents(None) == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Tamper detection + the two named fail-closed negatives.
+# ---------------------------------------------------------------------------
+
+
+def test_tamper_content_fails_hash(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    env["payment_decision"]["payment"]["amount"] = "99999999"  # mutate after signing
+    result = verify_decision_ref(env, trust)
+    assert not result.ok and result.reason == REASON_HASH_MISMATCH
+
+
+def test_tamper_signature_fails(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    sig = env["evidence"][0]["signature"]
+    env["evidence"][0]["signature"] = ("f" if sig[0] != "f" else "0") + sig[1:]
+    result = verify_decision_ref(env, trust)
+    assert not result.ok and result.reason == REASON_BAD_SIGNATURE
+
+
+def test_unknown_signer_fails(policy_signer):
+    signer, priv, _pub, _trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    result = verify_decision_ref(env, {"someone-else": {"alg": "ed25519", "public_key": "0" * 64}})
+    assert not result.ok and result.reason == REASON_UNKNOWN_SIGNER
+
+
+def test_self_approval_fails_closed(policy_signer):
+    """signer_equals_runtime: the record is signed by the actor's own wallet."""
+    _signer, priv, pub, _trust = policy_signer
+    wallet = "wallet:evm:0xA11ce0000000000000000000000000000000dEaD"
+    content = _content(_controls(), payment_signer=wallet)
+    env = build_decision_evidence(content, signing_key=priv, signer=wallet)
+    trust = {wallet: {"alg": "ed25519", "public_key": pub}}
+    result = verify_decision_ref(env, trust)
+    assert not result.ok and result.reason == REASON_SIGNER_EQUALS_RUNTIME
+
+
+def test_verdict_not_recomputable_refused_at_emit(policy_signer):
+    """build refuses to sign a content whose verdict != f(controls)."""
+    signer, priv, _pub, _trust = policy_signer
+    content = _content(_controls())
+    content["verdict"] = "DENY"  # forge: f(controls)=ALLOW
+    with pytest.raises(DecisionRefError):
+        build_decision_evidence(content, signing_key=priv, signer=signer)
+
+
+def test_verdict_not_recomputable_detected_on_verify(policy_signer):
+    """A forged verdict that slipped past emission is caught fail-closed on read."""
+    signer, priv, _pub, trust = policy_signer
+    content = _content(_controls())
+    env = build_decision_evidence(content, signing_key=priv, signer=signer)
+    # Tamper the verdict inside the (already-hashed) content AND fix the hash so it
+    # only fails at the recompute layer, not the hash layer.
+    env["payment_decision"]["verdict"] = "DENY"
+    _resign_payment_decision(env, signer, priv)
+    result = verify_decision_ref(env, trust)
+    assert not result.ok and result.reason == REASON_VERDICT_NOT_RECOMPUTABLE
+
+
+def test_missing_control_detected_on_verify(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    del env["payment_decision"]["controls"]["policy"]
+    _resign_payment_decision(env, signer, priv)
+    result = verify_decision_ref(env, trust)
+    assert not result.ok and result.reason == REASON_MALFORMED
+
+
+def test_unknown_control_detected_on_verify(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    env["payment_decision"]["controls"]["unknown"] = {"verdict": "ALLOW"}
+    _resign_payment_decision(env, signer, priv)
+    result = verify_decision_ref(env, trust)
+    assert not result.ok and result.reason == REASON_MALFORMED
+
+
+def test_invalid_control_verdict_detected_on_verify(policy_signer):
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    env["payment_decision"]["controls"]["policy"]["verdict"] = "MAYBE"
+    _resign_payment_decision(env, signer, priv)
+    result = verify_decision_ref(env, trust)
+    assert not result.ok and result.reason == REASON_MALFORMED
+
+
+def test_no_unsigned_output():
+    # Fail-closed via the family signing primitive (EvidenceError is the base of
+    # DecisionRefError): no key -> no envelope, never an unsigned record.
+    from presidio_x402.mica import EvidenceError
+
+    with pytest.raises(EvidenceError):
+        build_decision_evidence(_content(_controls()), signing_key="", signer="x")
+
+
+# ---------------------------------------------------------------------------
+# 6. Emitter + writer.
+# ---------------------------------------------------------------------------
+
+
+def test_emitter_writes_and_returns(policy_signer, tmp_path):
+    from presidio_x402.decision_ref import FileDecisionRefWriter
+
+    signer, priv, _pub, trust = policy_signer
+    path = tmp_path / "decisions.jsonl"
+    emitter = DecisionRefEmitter(
+        signing_key=priv, signer=signer, writer=FileDecisionRefWriter(str(path), fsync=False)
+    )
+    env = emitter.emit(
+        agent_id="agent-x",
+        payment_signer="0xpay",
+        network="eip155:8453",
+        binding="x402",
+        offer_hash="sha256:" + "1" * 64,
+        details_hash="sha256:" + "2" * 64,
+        pay_to="0xpay",
+        amount="10000",
+        currency="USDC",
+        resource_origin="https://api.merchant.example",
+        controls=_controls(),
+    )
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    on_disk = json.loads(lines[0])
+    assert on_disk["decision_ref"] == env["decision_ref"]
+    assert verify_decision_ref(on_disk, trust).ok
+
+
+def test_null_writer_discards(policy_signer):
+    signer, priv, _pub, _trust = policy_signer
+    emitter = DecisionRefEmitter(signing_key=priv, signer=signer, writer=NullDecisionRefWriter())
+    env = emitter.emit(
+        agent_id="a",
+        payment_signer="0xp",
+        network="n",
+        binding="x402",
+        offer_hash="sha256:" + "1" * 64,
+        details_hash="sha256:" + "2" * 64,
+        pay_to="0xp",
+        amount="1",
+        currency="USDC",
+        resource_origin="https://x",
+        controls=_controls(),
+    )
+    assert env["decision_ref"]

--- a/tests/test_decision_ref.py
+++ b/tests/test_decision_ref.py
@@ -17,7 +17,9 @@ mirroring ``test_capability.py`` / ``test_mica.py``.
 
 from __future__ import annotations
 
+import copy
 import json
+import runpy
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -503,3 +505,60 @@ def test_null_writer_discards(policy_signer):
         controls=_controls(),
     )
     assert env["decision_ref"]
+
+
+def test_cli_main_verifies_single_envelope(policy_signer, tmp_path, capsys):
+    from presidio_x402.decision_ref import main
+
+    signer, priv, _pub, trust = policy_signer
+    env = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    envelope_path = tmp_path / "decision.json"
+    envelope_path.write_text(json.dumps(env), encoding="utf-8")
+    trust_path = tmp_path / "trust.json"
+    trust_path.write_text(json.dumps(trust), encoding="utf-8")
+
+    assert main([str(envelope_path), str(trust_path)]) == 0
+    out = capsys.readouterr().out
+    assert env["decision_ref"] in out
+    assert "verdict=ALLOW" in out
+    assert "OK" in out
+
+
+def test_cli_main_reports_jsonl_failures(policy_signer, tmp_path, capsys):
+    from presidio_x402.decision_ref import main
+
+    signer, priv, _pub, trust = policy_signer
+    good = build_decision_evidence(_content(_controls()), signing_key=priv, signer=signer)
+    bad = copy.deepcopy(good)
+    sig = bad["evidence"][0]["signature"]
+    bad["evidence"][0]["signature"] = ("f" if sig[0] != "f" else "0") + sig[1:]
+    envelope_path = tmp_path / "decisions.jsonl"
+    envelope_path.write_text(
+        json.dumps(good) + "\n" + json.dumps(bad) + "\n", encoding="utf-8"
+    )
+    trust_path = tmp_path / "trust.json"
+    trust_path.write_text(json.dumps(trust), encoding="utf-8")
+
+    assert main([str(envelope_path), str(trust_path)]) == 1
+    out = capsys.readouterr().out
+    assert "FAIL(bad_signature)" in out
+    assert "OK" in out
+
+
+def test_cli_main_returns_usage_error_on_missing_file(tmp_path, capsys):
+    from presidio_x402.decision_ref import main
+
+    trust_path = tmp_path / "trust.json"
+    trust_path.write_text("{}", encoding="utf-8")
+
+    assert main([str(tmp_path / "missing.json"), str(trust_path)]) == 2
+    err = capsys.readouterr().err
+    assert "error:" in err
+
+
+def test_conformance_module_exits_with_runner_code(monkeypatch):
+    import presidio_x402.conformance.runner as runner
+
+    monkeypatch.setattr(runner, "main", lambda: 7)
+    with pytest.raises(SystemExit, match="7"):
+        runpy.run_module("presidio_x402.conformance.__main__", run_name="__main__")

--- a/tests/test_decision_ref.py
+++ b/tests/test_decision_ref.py
@@ -533,9 +533,7 @@ def test_cli_main_reports_jsonl_failures(policy_signer, tmp_path, capsys):
     sig = bad["evidence"][0]["signature"]
     bad["evidence"][0]["signature"] = ("f" if sig[0] != "f" else "0") + sig[1:]
     envelope_path = tmp_path / "decisions.jsonl"
-    envelope_path.write_text(
-        json.dumps(good) + "\n" + json.dumps(bad) + "\n", encoding="utf-8"
-    )
+    envelope_path.write_text(json.dumps(good) + "\n" + json.dumps(bad) + "\n", encoding="utf-8")
     trust_path = tmp_path / "trust.json"
     trust_path.write_text(json.dumps(trust), encoding="utf-8")
 

--- a/tests/test_gateway_decision_ref.py
+++ b/tests/test_gateway_decision_ref.py
@@ -1,0 +1,172 @@
+"""Gateway wiring of decision-ref emission (opt-in; default OFF).
+
+Asserts:
+- with no emitter, no decision-ref record is produced and the 402 flow is
+  unchanged (default-off, byte-identical behaviour);
+- with an emitter, exactly one signed payment-decision@1 record is emitted per
+  paid payment, it verifies against the policy trust store, and it carries no raw
+  metadata string (PII-freedom on the live path).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from presidio_x402 import HardenedX402Client
+from presidio_x402._types import PaymentDetails, PaymentResponse
+from presidio_x402.audit_log import NullAuditWriter
+from presidio_x402.decision_ref import (
+    DecisionRefEmitter,
+    offer_hash,
+    verify_decision_ref,
+)
+
+# A 402 offer whose resource URL and description carry PII (email + person).
+_PII_OFFER = json.dumps(
+    {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base-sepolia",
+                "maxAmountRequired": "0.01",
+                "resource": "https://api.example.com/users/alice@example.com/data",
+                "description": "Invoice for Alice Wonderland",
+                "reason": "research",
+                "mimeType": "application/json",
+                "payTo": "0xabcdef1234567890abcdef1234567890abcdef12",
+                "requiredDeadlineSeconds": 300,
+                "extra": {},
+            }
+        ]
+    }
+)
+
+
+async def _mock_signer(details: PaymentDetails) -> PaymentResponse:
+    return PaymentResponse(token="mock-signed-token", details=details)  # noqa: S106
+
+
+def _keypair():
+    sk = ed25519.Ed25519PrivateKey.generate()
+    return sk.private_bytes_raw().hex(), sk.public_key().public_bytes_raw().hex()
+
+
+class _ListWriter:
+    def __init__(self):
+        self.records = []
+
+    def write(self, envelope):
+        self.records.append(dict(envelope))
+
+
+@pytest.mark.asyncio
+async def test_default_off_emits_nothing():
+    """No emitter configured -> no record, payment still completes."""
+    with respx.mock:
+        route = respx.get("https://api.example.com/users/alice@example.com/data")
+        route.side_effect = [
+            httpx.Response(402, headers={"X-PAYMENT": _PII_OFFER}),
+            httpx.Response(200, text="paid"),
+        ]
+        client = HardenedX402Client(payment_signer=_mock_signer, audit_writer=NullAuditWriter())
+        # No _decision_emitter attribute leakage into behaviour:
+        assert client._pipeline._decision_emitter is None
+        async with client:
+            resp = await client.get("https://api.example.com/users/alice@example.com/data")
+        assert resp.status_code == 200 and resp.text == "paid"
+
+
+@pytest.mark.asyncio
+async def test_emitter_produces_one_verifiable_pii_free_record():
+    priv, pub = _keypair()
+    signer = "presidio-hardened-x402-policy"
+    trust = {signer: {"alg": "ed25519", "public_key": pub}}
+    writer = _ListWriter()
+    emitter = DecisionRefEmitter(signing_key=priv, signer=signer, writer=writer)
+
+    with respx.mock:
+        route = respx.get("https://api.example.com/users/alice@example.com/data")
+        route.side_effect = [
+            httpx.Response(402, headers={"X-PAYMENT": _PII_OFFER}),
+            httpx.Response(200, text="paid"),
+        ]
+        client = HardenedX402Client(
+            payment_signer=_mock_signer,
+            audit_writer=NullAuditWriter(),
+            agent_id="did:presidio:x402:agent-1",
+            decision_ref_emitter=emitter,
+            pii_action="redact",
+        )
+        async with client:
+            await client.get("https://api.example.com/users/alice@example.com/data")
+
+    assert len(writer.records) == 1
+    env = writer.records[0]
+    result = verify_decision_ref(env, trust)
+    assert result.ok, result.reason
+    assert result.verdict == "ALLOW"
+    # PII from the offer must not survive into the record.
+    blob = json.dumps(env, ensure_ascii=False)
+    assert "alice@example.com" not in blob
+    assert "Alice Wonderland" not in blob
+    assert _PII_OFFER not in blob
+    payment = env["payment_decision"]["payment"]
+    assert payment["offer_hash"] == offer_hash(_PII_OFFER.encode("utf-8"))
+    assert payment["offer_hash"] != payment["details_hash"]
+    assert "offer_hash_absent" not in payment
+    # The redaction verdict + entity label is what is recorded instead.
+    assert env["payment_decision"]["controls"]["pii"]["verdict"] == "PII_REDACTED"
+    assert "EMAIL_ADDRESS" in env["payment_decision"]["controls"]["pii"]["entities"]
+
+
+@pytest.mark.asyncio
+async def test_emit_failure_does_not_break_payment():
+    """A failing emitter must not undo a payment the gateway already decided."""
+
+    class _BoomWriter:
+        def write(self, envelope):
+            raise RuntimeError("sink down")
+
+    priv, _pub = _keypair()
+    emitter = DecisionRefEmitter(signing_key=priv, writer=_BoomWriter())
+    with respx.mock:
+        route = respx.get("https://api.example.com/v1/data")
+        route.side_effect = [
+            httpx.Response(
+                402,
+                headers={
+                    "X-PAYMENT": json.dumps(
+                        {
+                            "accepts": [
+                                {
+                                    "scheme": "exact",
+                                    "network": "base-sepolia",
+                                    "maxAmountRequired": "0.01",
+                                    "resource": "https://api.example.com/v1/data",
+                                    "description": "clean",
+                                    "reason": "r",
+                                    "mimeType": "application/json",
+                                    "payTo": "0xabcdef1234567890abcdef1234567890abcdef12",
+                                    "requiredDeadlineSeconds": 300,
+                                    "extra": {},
+                                }
+                            ]
+                        }
+                    )
+                },
+            ),
+            httpx.Response(200, text="paid"),
+        ]
+        client = HardenedX402Client(
+            payment_signer=_mock_signer,
+            audit_writer=NullAuditWriter(),
+            decision_ref_emitter=emitter,
+        )
+        async with client:
+            resp = await client.get("https://api.example.com/v1/data")
+        assert resp.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -1608,7 +1608,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Summary
- Release v0.9.0 proof-carrying x402 evidence.
- Add capability-grant@1 attenuable spending grants and opt-in payment-decision@1 decision refs.
- Bind offer_hash to the raw 402 offer bytes digest, omitting it with an explicit absence reason when raw bytes are unavailable.

Test plan
- [x] .venv/bin/python -m ruff check .
- [x] .venv/bin/python -m ruff format --check .
- [x] .venv/bin/python -m pytest tests/ -x -q --tb=short
- [x] .venv/bin/pip-audit
- [x] /Users/vstantch/.local/bin/uv build
