### PR TITLE
Remediate audit and log exposure findings

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,7 +104,7 @@ See `PRESIDIO-REQ.md` for the full threat model and security design rationale.
 |--------|-----------|
 | The high-accuracy engine silently misses structured identifiers | `mode="nlp"` registers the structural recognizers (`US_SSN`, `PHONE_NUMBER`, `CREDIT_CARD`, `EMAIL_ADDRESS`, `IBAN`, `IP_ADDRESS`) as a superset of regex on top of NER — no structured identifier scores below threshold and slips through |
 | Non-deterministic `action_ref` (replay / attribution ambiguity) | `action_ref` rejects empty entity-type sets and NFC-normalizes fields before hashing — the same action always yields the same ref |
-| PII-bearing resource URL reaching a log sink | The missing-payment-header warning redacts the URL before it is logged |
+| PII-bearing resource URL reaching a log sink | The missing-payment-header warning omits the request URL entirely |
 
 ## Dependency Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ dependencies = [
     # the fix; requests allows urllib3<3,>=1.26 so 2.7.0 resolves cleanly against
     # httpx>=0.27.0. Audit 2026-06-14 (F1).
     "urllib3>=2.7.0",
+    # Transitive of Typer-rich CLIs in the audit extra graph; pin minimum to
+    # evict PYSEC-2026-2132 (click < 8.3.3 vulnerable). Audit 2026-07-14.
+    "click>=8.3.3",
+    # Transitive of presidio-analyzer -> spaCy; pin minimum to evict
+    # PYSEC-2026-3447 (setuptools < 83.0.0 vulnerable). Audit 2026-07-14.
+    "setuptools>=83.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -316,12 +316,10 @@ class HardenedX402Client:
 
         offer = self._binding.payment_offer(resp.status_code, resp.headers)  # type: ignore[arg-type]
         if not offer:
-            safe_url, _ = self._pii_filter.scan_and_redact(url)
             logger.warning(
-                "%s response missing %s header from %s",
+                "%s response missing %s header; returning unpaid response",
                 self._binding.payment_required_status,
                 self._binding.header_name,
-                safe_url,
             )
             return resp
         raw_offer_hash = None

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import httpx
 import pytest
@@ -125,6 +126,24 @@ async def test_402_without_payment_header_returned_as_is():
         async with _make_client() as client:
             resp = await client.get("https://api.example.com/v1/data")
         assert resp.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_402_without_payment_header_warning_omits_request_url(caplog):
+    """Missing payment-header diagnostics must not emit PII-bearing request URLs."""
+    pii_url = "https://api.example.com/user/alice@example.com?token=secret-token"
+    with respx.mock:
+        respx.get(pii_url).mock(return_value=httpx.Response(402))
+        async with _make_client() as client:
+            with caplog.at_level(logging.WARNING, logger="presidio_x402.gateway"):
+                resp = await client.get(pii_url)
+
+    assert resp.status_code == 402
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "missing X-PAYMENT header" in messages
+    assert "alice@example.com" not in messages
+    assert "secret-token" not in messages
+    assert "https://api.example.com" not in messages
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -376,14 +376,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1611,11 +1611,13 @@ name = "presidio-hardened-x402"
 version = "0.9.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "cryptography" },
     { name = "httpx" },
     { name = "idna" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
+    { name = "setuptools" },
     { name = "urllib3" },
 ]
 
@@ -1662,6 +1664,7 @@ schema = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", marker = "extra == 'audit-s3'", specifier = ">=1.34" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "cryptography", marker = "extra == 'evidence'", specifier = ">=48.0.1" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.23" },
@@ -1683,6 +1686,7 @@ requires-dist = [
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "setuptools", specifier = ">=83.0.0" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
@@ -2332,11 +2336,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary
- Pin minimum-safe click and setuptools versions to clear current pip-audit CVEs.
- Stop logging request URLs on missing payment-header warnings.
- Update SECURITY.md and add regression coverage for the logging behavior.

Test plan
- [x] .venv/bin/python -m ruff check .
- [x] .venv/bin/python -m ruff format --check .
- [x] .venv/bin/python -m pytest tests/ -x -q --tb=short
- [x] uv run --extra audit --extra evidence --extra redis --extra audit-s3 --extra langchain --extra prometheus --extra otel --extra schema pip-audit --progress-spinner=off --skip-editable