### PR TITLE
Release v0.9.1 security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-07-14
+
+### Security
+- **Dependency audit remediation.** Added explicit minimum-safe floors for
+  `click>=8.3.3` (PYSEC-2026-2132) and `setuptools>=83.0.0`
+  (PYSEC-2026-3447), and refreshed `uv.lock` so the release-extra
+  `pip-audit` gate resolves a clean graph.
+- **Log exposure hardening.** The missing `X-PAYMENT` header warning no longer
+  includes the request URL, avoiding accidental clear-text logging of
+  PII-bearing paths or query strings. Regression coverage asserts that
+  email/token-shaped URL material is omitted.
+
+### Changed
+- Updated the pinned `astral-sh/setup-uv` GitHub Action from v8.3.0 to v8.3.2.
+
 ## [0.9.0] — 2026-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml/badge.svg)](https://github.com/presidio-v/presidio-hardened-x402/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/presidio-v/presidio-hardened-x402/badge)](https://securityscorecards.dev/viewer/?uri=github.com/presidio-v/presidio-hardened-x402)
 
-> v0.9.0 — proof-carrying x402 evidence: attenuable `capability-grant@1` spending grants plus opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records.
+> v0.9.1 — security patch: dependency-audit floors for `click`/`setuptools`, missing-payment-header log exposure hardening, and `setup-uv` v8.3.2 CI action pin.
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -479,7 +479,8 @@ All exceptions are importable from `presidio_x402`.
 | v0.6.0 | **Production hardening + evidence substrate** — multi-tenant replay namespaces · enterprise audit sinks (S3 / Splunk / Datadog) · signed `evidence-ref@1` verification · SLSA/OIDC release provenance · digest-pinned Docker base + hash-pinned spaCy model · latency SLO and all-matrix coverage CI gates · OTel spans · policy hot-reload · startup key gates · human-pentest retest closure |
 | v0.7.0 | **SLO payment broker (library)** — x402 micropayments as runtime infrastructure bids: `SLOPaymentBroker` + `SLOPaymentPolicy` + evidence-anchored `ArchTranslucencyAdapter` + provisioning PII entities; cross-repo validated against `presidio-hardened-arch-translucency`. cs.DC preprint + empirical eval tracked separately |
 | v0.8.0 | PII completeness + supply-chain hardening (library) — `nlp` mode is now a structural superset of `regex` (no structured-identifier misses) · composed-envelope `screen_ref` leg · `action_ref` byte-determinism (NFC + non-empty entity sets) · URL-redacted log hygiene · OpenSSF Scorecard workflow/badge + SLSA Build L3 provenance · independent multi-round security audit cleared |
-| **v0.9.0** | **Proof-carrying x402 evidence** — `capability-grant@1` attenuable spending grants + opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records — **latest release** |
+| **v0.9.1** | **Security patch** — dependency-audit floors for `click` / `setuptools`, missing-payment-header log exposure hardening, and `setup-uv` v8.3.2 CI action pin — **latest release** |
+| v0.9.0 | Proof-carrying x402 evidence — `capability-grant@1` attenuable spending grants + opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records |
 | Future | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
 
 See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.7.x   | ✓ (latest release) |
-| 0.6.x   | ✓ |
-| 0.5.x   | ✓ |
-| 0.4.x   | ✓ |
-| 0.3.x   | security fixes only |
+| 0.9.x   | ✓ (latest release) |
+| 0.8.x   | ✓ |
+| 0.7.x   | ✓ |
+| 0.6.x   | security fixes only |
+| 0.5.x and older | security fixes only |
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.9.0"
+version = "0.9.1"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -94,7 +94,7 @@ from .slo_broker import (
 )
 from .slo_policy import SLOPaymentPolicy
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __all__ = [
     # Primary public API
     "HardenedX402Client",

--- a/uv.lock
+++ b/uv.lock
@@ -1608,7 +1608,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Summary
- Bump package/runtime version to 0.9.1 and refresh uv.lock.
- Document the security patch in CHANGELOG.md, README.md, and SECURITY.md.
- Prepare v0.9.1 for a signed tag and release after protected-branch checks pass.

Test plan
- [x] .venv/bin/python -m ruff check .
- [x] .venv/bin/python -m ruff format --check .
- [x] .venv/bin/python -m pytest tests/ -x -q --tb=short
- [x] uv run --extra audit --extra evidence --extra redis --extra audit-s3 --extra langchain --extra prometheus --extra otel --extra schema pip-audit --progress-spinner=off --skip-editable
- [x] uv build
- [x] uv run --with twine twine check dist/*