### PR TITLE
Add contribution guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,116 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race, caste,
+color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning
+  from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their
+  explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior that
+they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code
+of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual
+is officially representing the community in public spaces. Examples of representing our
+community include using an official email address, posting via an official social media
+account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+community leaders responsible for enforcement at **vladimir@presidio-group.eu**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences
+for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around
+the nature of the violation and an explanation of why the behavior was inappropriate. A public
+apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the
+people involved, including unsolicited interaction with those enforcing the Code of Conduct,
+for a specified period of time. This includes avoiding interactions in community spaces as well
+as external channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained
+inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. No public or private interaction with the people
+involved, including unsolicited interaction with those enforcing the Code of Conduct, is
+allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or
+disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to presidio-hardened-x402
+
+Thanks for your interest. This is security middleware for the x402 payment protocol, so
+contributions are held to a somewhat stricter bar than a typical library — the checklist
+below is what a change needs to clear before it can be merged.
+
+## Reporting a security vulnerability
+
+**Do not open a public issue for a security vulnerability.** Use the private reporting
+process in [SECURITY.md](SECURITY.md) — GitHub Security Advisories, via the repository's
+"Security" tab. You will get an acknowledgement within 5 business days.
+
+## Reporting bugs and requesting features
+
+Open a [GitHub issue](https://github.com/presidio-v/presidio-hardened-x402/issues). Search
+existing issues first. For a bug, include:
+
+- the library version (`pip show presidio-hardened-x402`) and Python version
+- what you expected to happen, and what happened instead
+- a minimal reproduction if you can produce one
+
+Please redact real payment metadata, wallet addresses, and personal data from anything you
+paste into a public issue.
+
+## How changes are made
+
+All changes go through a pull request against `main`. Direct pushes to `main` are blocked by
+branch protection, and every PR must pass the required status checks before it can merge.
+
+1. Fork the repository and create a branch off `main`.
+2. Make your change, with tests (see the test policy below).
+3. Run the local verification block until it is clean.
+4. Update `CHANGELOG.md` under `## [Unreleased]`.
+5. Open a PR describing what changed and why.
+
+## Requirements for acceptable contributions
+
+A change is merged when it meets all of the following.
+
+### Style
+
+Formatting and linting are enforced by [ruff](https://docs.astral.sh/ruff/) and are not a
+matter of taste — CI rejects anything that does not conform. The configuration lives in
+`pyproject.toml`; the settings that most often surprise people:
+
+- line length 99, target Python 3.10
+- lint rule sets `E, F, W, I, N, UP, S, B, A, C4, SIM, TCH` (`S` is bandit's security rules)
+
+Each module uses a single consistent import style. Do not mix `import x` and `from x import y`
+forms for the same dependency within one module.
+
+### Tests
+
+**Test policy: any change that adds or modifies functionality must ship with tests in the
+same pull request.** Bug fixes must include a regression test that fails before the fix and
+passes after it. This is enforced in review, and by the coverage gate.
+
+- coverage must stay at or above 90% (`--cov-fail-under=90`)
+- the partner conformance suite must pass: `python -m presidio_x402.conformance`
+
+### Security-sensitive changes
+
+This library's security controls are the product. If your change touches PII detection and
+redaction, spending-policy enforcement, replay fingerprinting, audit-log chaining,
+multi-party authorization, or evidence and canonicalisation code, then:
+
+- explain the security reasoning in the PR description, not only the mechanics
+- do not weaken a default. New controls are opt-in; relaxations of existing controls need
+  an explicit rationale
+- never re-implement cryptographic primitives — call `hashlib`, `hmac`, `secrets`, or
+  `cryptography`
+- canonicalisation and digest functions are byte-stability contracts. Changing their output
+  for existing input is a breaking change even if no signature changes
+
+### Public API and compatibility
+
+The public API surface and what counts as a breaking change are defined in
+[SEMVER.md](SEMVER.md). Read it before changing anything exported from
+`presidio_x402.__all__`, and note that audit event shapes and exception types are part of the
+contract that OEM partners depend on.
+
+### Dependencies
+
+New runtime dependencies are a high bar for a security library and need justification in the
+PR. Prefer the standard library. Optional functionality belongs in an
+`[project.optional-dependencies]` extra rather than the core dependency set.
+
+## Local verification
+
+Run this before opening a PR, and fix anything it reports:
+
+```bash
+cd tools
+python -m venv .venv && .venv/bin/pip install -e ".[dev]"
+.venv/bin/python -m ruff check . \
+  && .venv/bin/python -m ruff format --check . \
+  && .venv/bin/python -m pytest tests/ -x -q --tb=short
+```
+
+CI runs the test suite against Python 3.10, 3.11, 3.12, and 3.13. A change must pass on all
+four.
+
+## Commit messages
+
+Write in the imperative mood ("add replay TTL bound", not "added" or "adds"). Explain *why*
+the change is being made where that is not obvious from the diff.
+
+## Licensing
+
+The project is MIT licensed. By contributing, you agree that your contribution is licensed
+under the same terms, and you confirm you have the right to submit it.
+
+## Code of conduct
+
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -487,6 +487,21 @@ See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 
 ---
 
+## Contributing and support
+
+- **Bug reports and feature requests** — open a
+  [GitHub issue](https://github.com/presidio-v/presidio-hardened-x402/issues).
+- **Security vulnerabilities** — do *not* open a public issue; follow the private reporting
+  process in [SECURITY.md](SECURITY.md).
+- **Code contributions** — see [CONTRIBUTING.md](CONTRIBUTING.md) for the pull-request process,
+  coding standards, and the test policy. Participation is governed by the
+  [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Install from [PyPI](https://pypi.org/project/presidio-hardened-x402/):
+`pip install presidio-hardened-x402`.
+
+---
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md` documenting the PR process and the conventions CI already enforces — ruff config, the 90% coverage gate, the conformance suite, and the `SEMVER.md` public-API contract — which until now existed only as review comments.
- States the test policy explicitly: functional changes ship with tests, fixes ship with a regression test.
- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) and a README *Contributing and support* section routing security reports to `SECURITY.md` rather than public issues.

Docs only — no source, no workflow, no dependency changes.

Also closes the `contribution` MUST gap for the OpenSSF Best Practices badge (Scorecard CII-Best-Practices is currently 0).

## Test plan

- [ ] CI green (docs-only; no behaviour change expected)
- [ ] `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` render correctly on GitHub
- [ ] README links to both resolve once merged
- [ ] Verification block in `CONTRIBUTING.md` matches the project's actual commands