### PR TITLE
Fuzz the canonicalisation and digest layer with Atheris

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,27 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff check src/ tests/
-      - run: ruff format --check src/ tests/
+      - run: ruff check src/ tests/ fuzz/
+      - run: ruff format --check src/ tests/ fuzz/
+
+  fuzz:
+    name: Fuzz (Atheris)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          # Atheris 3.x ships no cp310 wheel; the test matrix is unaffected.
+          python-version: "3.12"
+      - name: Install package + fuzz extra
+        run: pip install -e ".[fuzz]"
+      - name: Run fuzz harnesses (time-boxed)
+        run: |
+          for f in fuzz/fuzz_*.py; do
+            echo "::group::$f"
+            python "$f" -atheris_runs=25000 -max_total_time=60
+            echo "::endgroup::"
+          done
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   across 20 000 randomised inputs, so existing fingerprints do not change.** Found by
   the Atheris `_canonical_amount` harness.
 
+### Added
+- **Coverage-guided fuzzing of the canonicalisation and digest layer (Atheris).**
+  Four property harnesses under `fuzz/`, exercised in CI on every push and pull
+  request, time-boxed per harness. They assert the byte-determinism contracts the
+  evidence layer rests on rather than merely reaching for coverage:
+  `canonical_bytes` (determinism, JSON round-trip, type-aware injectivity, NFC/NFD
+  non-collapse, float fail-closed via `EvidenceError`), `compute_fingerprint` and
+  `_canonical_amount` (replay-guard canonicalisation), `compute_decision_ref`, and
+  `compute_action_ref`. Fuzzing dependencies live in a separate `fuzz` extra —
+  `pip install -e ".[fuzz]"` — and are not pulled in by `dev`. Atheris 3.x ships no
+  cp310 wheel, so the fuzz job pins Python 3.12; the 3.10–3.13 test matrix is
+  unchanged. Ruff now also lints `fuzz/`.
+
 ## [0.9.1] — 2026-07-14
 
 ### Security

--- a/fuzz/fuzz_action_ref.py
+++ b/fuzz/fuzz_action_ref.py
@@ -1,0 +1,132 @@
+"""Atheris property fuzzer for the action-ref-v1 derivation.
+
+Targets :func:`presidio_x402.action_ref.compute_action_ref` and
+:func:`presidio_x402.action_ref.format_action_ref_timestamp`. ``compute_action_ref``
+is ``sha256`` over the JCS canonicalisation of an NFC-normalised four-field
+preimage (``agent_id``, ``action_type``, ``scope``, ``timestamp``);
+``format_action_ref_timestamp`` renders the single conformant timestamp form.
+Properties:
+
+* ``format_action_ref_timestamp`` rejects a naive datetime with
+  :class:`ValueError`, and its output for an aware datetime is always accepted by
+  ``compute_action_ref`` (any rejection would be a real format/verify mismatch);
+* ``compute_action_ref`` raises only :class:`ValueError` for a non-conformant
+  timestamp string;
+* on a conformant timestamp it is deterministic, returns 64 lowercase hex
+  characters, and is injective over the *NFC-normalised* preimage — changing any
+  field, or shifting a boundary character between fields, changes the ref exactly
+  when the NFC-normalised preimage changes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import unicodedata
+from datetime import datetime, timezone
+
+import atheris
+
+from presidio_x402.action_ref import compute_action_ref, format_action_ref_timestamp
+
+
+def _hex64(value: str) -> bool:
+    return len(value) == 64 and all(c in "0123456789abcdef" for c in value)
+
+
+def _txt(fdp: atheris.FuzzedDataProvider) -> str:
+    return fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+
+
+def _nfc_key(agent_id: str, action_type: str, scope: str, timestamp: str) -> tuple[str, ...]:
+    """The NFC-normalised preimage tuple the ref is injective over."""
+    return (
+        unicodedata.normalize("NFC", agent_id),
+        unicodedata.normalize("NFC", action_type),
+        unicodedata.normalize("NFC", scope),
+        timestamp,
+    )
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802 (Atheris entrypoint contract)
+    fdp = atheris.FuzzedDataProvider(data)
+
+    agent_id = _txt(fdp)
+    action_type = _txt(fdp)
+    scope = _txt(fdp)
+
+    # (a) An arbitrary timestamp string may only ever raise ValueError.
+    raw_ts = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 32))
+    with contextlib.suppress(ValueError):
+        compute_action_ref(agent_id, action_type, scope, raw_ts)
+
+    # A naive datetime must be rejected rather than silently assumed UTC.
+    naive = datetime(2026, 7, 20, 12, 0, 0)
+    try:
+        format_action_ref_timestamp(naive)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("format_action_ref_timestamp accepted a naive datetime")
+
+    # (b) A conformant timestamp built from a fuzzed aware datetime. Year bound to
+    # a range where strftime("%Y") is always four digits, keeping the output
+    # conformant across platforms.
+    aware = datetime(
+        fdp.ConsumeIntInRange(1000, 9999),
+        fdp.ConsumeIntInRange(1, 12),
+        fdp.ConsumeIntInRange(1, 28),
+        fdp.ConsumeIntInRange(0, 23),
+        fdp.ConsumeIntInRange(0, 59),
+        fdp.ConsumeIntInRange(0, 59),
+        fdp.ConsumeIntInRange(0, 999_999),
+        tzinfo=timezone.utc,
+    )
+    ts = format_action_ref_timestamp(aware)
+
+    # format -> compute contract: a formatted timestamp must never be rejected.
+    ref = compute_action_ref(agent_id, action_type, scope, ts)
+    if not _hex64(ref):
+        raise AssertionError(f"action_ref is not 64 lowercase hex chars: {ref!r}")
+    if ref != compute_action_ref(agent_id, action_type, scope, ts):
+        raise AssertionError("non-deterministic action_ref")
+
+    # Independent second preimage: shares a ref iff the NFC-normalised keys match.
+    other = (_txt(fdp), _txt(fdp), _txt(fdp))
+    ref2 = compute_action_ref(other[0], other[1], other[2], ts)
+    same = _nfc_key(*other, ts) == _nfc_key(agent_id, action_type, scope, ts)
+    if (ref2 == ref) != same:
+        raise AssertionError(
+            f"injectivity violated: {(agent_id, action_type, scope)!r} vs {other!r}"
+        )
+
+    base = [agent_id, action_type, scope]
+
+    # Single-field sensitivity: an ASCII append never NFC-merges, so the ref changes.
+    idx = fdp.ConsumeIntInRange(0, 2)
+    mutated = list(base)
+    mutated[idx] = mutated[idx] + "x"
+    if compute_action_ref(mutated[0], mutated[1], mutated[2], ts) == ref:
+        raise AssertionError(f"field {idx} change did not change ref: {base!r}")
+
+    # Boundary shift between adjacent fields, checked against the NFC-normalised
+    # keys so a legitimate combining-mark merge stays consistent (biconditional).
+    j = fdp.ConsumeIntInRange(0, 2)
+    if base[j]:
+        k = (j + 1) % 3
+        shifted = list(base)
+        shifted[j] = base[j][:-1]
+        shifted[k] = base[j][-1] + base[k]
+        got_same = compute_action_ref(shifted[0], shifted[1], shifted[2], ts) == ref
+        want_same = _nfc_key(*shifted, ts) == _nfc_key(*base, ts)
+        if got_same != want_same:
+            raise AssertionError(f"boundary-shift ambiguity: {base!r} -> {shifted!r}")
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_canonical_bytes.py
+++ b/fuzz/fuzz_canonical_bytes.py
@@ -1,0 +1,117 @@
+"""Atheris property fuzzer for :func:`presidio_x402.mica.canonical_bytes`.
+
+``canonical_bytes`` is the family strict-profile canonical JSON encoder (sorted
+keys, ``(",", ":")`` separators, UTF-8, ``ensure_ascii=False``, floats rejected).
+Every producer in the toolkit family must byte-match it, so its determinism and
+injectivity are load-bearing. This harness drives it with arbitrary JSON-safe
+payload trees (dict / list / str / int / bool / None, str keys only, bounded
+depth) built from ``FuzzedDataProvider``, and asserts:
+
+* determinism    — two encodings of one payload are byte-identical;
+* round-trip     — ``json.loads(canonical_bytes(p).decode())`` reproduces ``p``;
+* injectivity    — two payloads share canonical bytes iff they are equal in the
+                   canonical JSON data model (type-aware: ``True`` is not ``1``);
+* float guard    — a float anywhere raises exactly
+                   :class:`~presidio_x402.mica.EvidenceError` and nothing else;
+* normalisation  — NFC and NFD spellings of one string, being distinct
+                   code-point sequences the encoder does not fold, never collapse
+                   to equal bytes (a collapse would be a real canonicalisation
+                   defect, so it is asserted rather than tolerated).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unicodedata
+
+import atheris
+
+from presidio_x402.mica import EvidenceError, canonical_bytes
+
+#: Bounded recursion depth for generated payload trees.
+_MAX_DEPTH = 5
+
+
+def _build(fdp: atheris.FuzzedDataProvider, depth: int) -> object:
+    """Build one arbitrary, float-free, str-keyed JSON payload node."""
+    # Only scalars are permitted at the leaf level (depth exhausted).
+    max_choice = 5 if depth > 0 else 3
+    choice = fdp.ConsumeIntInRange(0, max_choice)
+    if choice == 0:
+        return fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+    if choice == 1:
+        return fdp.ConsumeInt(8)
+    if choice == 2:
+        return fdp.ConsumeBool()
+    if choice == 3:
+        return None
+    if choice == 4:
+        return [_build(fdp, depth - 1) for _ in range(fdp.ConsumeIntInRange(0, 4))]
+    # Dict keys are restricted to strings — the documented domain. json.dumps
+    # coerces non-str keys, which would break injectivity for reasons unrelated
+    # to the encoder under test.
+    return {
+        fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(1, 16)): _build(fdp, depth - 1)
+        for _ in range(fdp.ConsumeIntInRange(0, 4))
+    }
+
+
+def _typed_eq(a: object, b: object) -> bool:
+    """Equality in the canonical JSON data model (``True`` distinct from ``1``)."""
+    if type(a) is not type(b):
+        return False
+    if isinstance(a, dict):
+        return a.keys() == b.keys() and all(_typed_eq(a[k], b[k]) for k in a)
+    if isinstance(a, list):
+        return len(a) == len(b) and all(_typed_eq(x, y) for x, y in zip(a, b, strict=False))
+    return a == b
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802 (Atheris entrypoint contract)
+    fdp = atheris.FuzzedDataProvider(data)
+    payload = _build(fdp, _MAX_DEPTH)
+
+    encoded = canonical_bytes(payload)
+    if encoded != canonical_bytes(payload):
+        raise AssertionError(f"non-deterministic encoding for {payload!r}")
+
+    restored = json.loads(encoded.decode("utf-8"))
+    if restored != payload:
+        raise AssertionError(f"round-trip altered payload: {payload!r} -> {restored!r}")
+
+    other = _build(fdp, _MAX_DEPTH)
+    if (canonical_bytes(other) == encoded) != _typed_eq(other, payload):
+        raise AssertionError(f"injectivity violated: {payload!r} vs {other!r}")
+
+    # Distinct NFC/NFD spellings must not collapse to identical bytes.
+    text = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+    nfc = unicodedata.normalize("NFC", text)
+    nfd = unicodedata.normalize("NFD", text)
+    if nfc != nfd and canonical_bytes(nfc) == canonical_bytes(nfd):
+        raise AssertionError(f"NFC/NFD spellings collapsed to equal bytes: {text!r}")
+
+    # A float anywhere must fail closed with EvidenceError — nothing else escapes.
+    bad_float = fdp.ConsumeFloat()
+    where = fdp.ConsumeIntInRange(0, 2)
+    if where == 0:
+        bad_payload: object = bad_float
+    elif where == 1:
+        bad_payload = {"amount": bad_float}
+    else:
+        bad_payload = [payload, [bad_float]]
+    try:
+        canonical_bytes(bad_payload)
+    except EvidenceError:
+        pass
+    else:
+        raise AssertionError(f"float payload did not raise EvidenceError: {bad_payload!r}")
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_decision_ref.py
+++ b/fuzz/fuzz_decision_ref.py
@@ -1,0 +1,86 @@
+"""Atheris property fuzzer for :func:`presidio_x402.decision_ref.compute_decision_ref`.
+
+``compute_decision_ref`` derives the thin, self-describing correlation id
+``sha256(canonical_bytes({artifact_hash, artifact_type, policy_version, verdict}))``.
+Its four preimage fields are all strings, so the canonical encoder never sees a
+float and no exception should escape for any string inputs. This harness drives
+it with arbitrary Unicode field values and asserts:
+
+* determinism   — equal inputs give equal refs;
+* shape         — the ref is 64 lowercase hex characters;
+* injectivity   — two field tuples share a ref iff the tuples are equal, so
+                  appending to any single field, or shifting a boundary character
+                  from one field into the next, changes the ref;
+* totality      — no exception escapes for any string inputs (a raise from the
+                  canonical encoder over an all-string mapping is a real finding,
+                  so it is deliberately not caught).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+from presidio_x402.decision_ref import compute_decision_ref
+
+
+def _hex64(value: str) -> bool:
+    return len(value) == 64 and all(c in "0123456789abcdef" for c in value)
+
+
+def _txt(fdp: atheris.FuzzedDataProvider) -> str:
+    return fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+
+
+def _ref(fields: list[str]) -> str:
+    # fields = [artifact_hash, policy_version, verdict, artifact_type]
+    return compute_decision_ref(
+        artifact_hash=fields[0],
+        policy_version=fields[1],
+        verdict=fields[2],
+        artifact_type=fields[3],
+    )
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802 (Atheris entrypoint contract)
+    fdp = atheris.FuzzedDataProvider(data)
+    fields = [_txt(fdp) for _ in range(4)]
+
+    ref = _ref(fields)
+    if not _hex64(ref):
+        raise AssertionError(f"decision_ref is not 64 lowercase hex chars: {ref!r}")
+    if ref != _ref(fields):
+        raise AssertionError(f"non-deterministic decision_ref for {fields!r}")
+
+    # Independent second preimage: shares a ref iff the field tuples are equal.
+    other = [_txt(fdp) for _ in range(4)]
+    if (_ref(other) == ref) != (other == fields):
+        raise AssertionError(f"injectivity violated: {fields!r} vs {other!r}")
+
+    # Single-field sensitivity: any change to any field changes the ref.
+    idx = fdp.ConsumeIntInRange(0, 3)
+    mutated = list(fields)
+    mutated[idx] = mutated[idx] + "x"
+    if _ref(mutated) == ref:
+        raise AssertionError(f"field {idx} change did not change ref: {fields!r}")
+
+    # Boundary shift between adjacent fields — the fields are delimited, so the
+    # ref must change exactly when the (always different) tuples differ.
+    j = fdp.ConsumeIntInRange(0, 3)
+    if fields[j]:
+        k = (j + 1) % 4
+        shifted = list(fields)
+        shifted[j] = fields[j][:-1]
+        shifted[k] = fields[j][-1] + fields[k]
+        if (_ref(shifted) == ref) != (shifted == fields):
+            raise AssertionError(f"boundary-shift ambiguity: {fields!r} -> {shifted!r}")
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_replay_fingerprint.py
+++ b/fuzz/fuzz_replay_fingerprint.py
@@ -1,0 +1,146 @@
+"""Atheris property fuzzer for the x402 replay fingerprint canonicalisation.
+
+Targets :func:`presidio_x402.replay_guard._canonical_amount` and
+:func:`presidio_x402.replay_guard.compute_fingerprint` — the canonical decimal
+normalisation and HMAC fingerprint that back cross-process replay detection. A
+representation-level canonicalisation bug here is a replay-detection bypass, so
+the properties are:
+
+* ``_canonical_amount`` raises only :class:`ValueError` on bad input; on success
+  it is idempotent, value-preserving (``Decimal(out) == Decimal(in)``), and maps
+  equal decimal values to one string and unequal values to distinct strings;
+* ``compute_fingerprint`` is deterministic, returns 64 lowercase hex characters,
+  propagates only :class:`ValueError` (from the amount field), and is injective
+  over its case/decimal-normalised field tuple — in particular, shifting a
+  boundary character from one field into the next changes the fingerprint, since
+  the fields are delimited rather than concatenated.
+
+A fixed fingerprint key is pinned *before* importing the module so fingerprints
+are cross-run deterministic and the unset-key ERROR log the module emits at
+import time is silenced.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from decimal import Decimal
+
+import atheris
+
+# Pin a deterministic 64-hex-char (32-byte) key before importing replay_guard,
+# whose module-level key load reads this env var exactly once. The import is
+# deferred below the assignment on purpose (hence the E402 waiver).
+os.environ["PRESIDIO_X402_FINGERPRINT_KEY"] = "00" * 32
+
+from presidio_x402.replay_guard import _canonical_amount, compute_fingerprint  # noqa: E402
+
+
+def _hex64(value: str) -> bool:
+    return len(value) == 64 and all(c in "0123456789abcdef" for c in value)
+
+
+def _valid_amount(fdp: atheris.FuzzedDataProvider) -> str:
+    """A syntactically valid, non-negative decimal amount string."""
+    return f"{fdp.ConsumeIntInRange(0, 10**12)}.{fdp.ConsumeIntInRange(0, 10**9)}"
+
+
+def _check_canonical_amount(fdp: atheris.FuzzedDataProvider) -> None:
+    a = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 32))
+    b = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 32))
+    try:
+        ca = _canonical_amount(a)
+    except ValueError:
+        ca = None
+    try:
+        cb = _canonical_amount(b)
+    except ValueError:
+        cb = None
+
+    if ca is not None:
+        if _canonical_amount(ca) != ca:
+            raise AssertionError(f"_canonical_amount not idempotent: {a!r} -> {ca!r}")
+        if Decimal(ca) != Decimal(a):
+            raise AssertionError(f"_canonical_amount changed value: {a!r} -> {ca!r}")
+    if ca is not None and cb is not None:
+        same_value = Decimal(a) == Decimal(b)
+        if (ca == cb) != same_value:
+            raise AssertionError(
+                f"decimal equality not reflected in canonical form: "
+                f"{a!r}->{ca!r}, {b!r}->{cb!r} (same_value={same_value})"
+            )
+
+
+def _effective_fields(
+    url: str, pay_to: str, amount: str, currency: str, deadline: int, network: str
+) -> tuple[object, ...]:
+    """The normalised tuple the fingerprint is injective over (mirrors the module)."""
+    return (
+        url,
+        pay_to.lower(),
+        _canonical_amount(amount),
+        currency.upper(),
+        int(deadline),
+        network.lower(),
+    )
+
+
+def _check_fingerprint(fdp: atheris.FuzzedDataProvider) -> None:
+    url = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+    pay_to = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+    currency = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 8))
+    network = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 12))
+    deadline = fdp.ConsumeInt(4)
+
+    # An arbitrary (usually invalid) amount may only ever raise ValueError.
+    raw_amount = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 16))
+    with contextlib.suppress(ValueError):
+        compute_fingerprint(url, pay_to, raw_amount, currency, deadline, network)
+
+    # A guaranteed-valid amount lets us exercise shape and injectivity.
+    amount = _valid_amount(fdp)
+    fp1 = compute_fingerprint(url, pay_to, amount, currency, deadline, network)
+    if not _hex64(fp1):
+        raise AssertionError(f"fingerprint is not 64 lowercase hex chars: {fp1!r}")
+    if fp1 != compute_fingerprint(url, pay_to, amount, currency, deadline, network):
+        raise AssertionError("non-deterministic fingerprint")
+
+    eff1 = _effective_fields(url, pay_to, amount, currency, deadline, network)
+
+    # Independent second payment: shares a fingerprint iff normalised tuples match.
+    url2 = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+    pay_to2 = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 24))
+    currency2 = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 8))
+    network2 = fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(0, 12))
+    deadline2 = fdp.ConsumeInt(4)
+    amount2 = _valid_amount(fdp)
+    fp2 = compute_fingerprint(url2, pay_to2, amount2, currency2, deadline2, network2)
+    eff2 = _effective_fields(url2, pay_to2, amount2, currency2, deadline2, network2)
+    if (fp1 == fp2) != (eff1 == eff2):
+        raise AssertionError(f"fingerprint injectivity violated: eff1={eff1!r} eff2={eff2!r}")
+
+    # Boundary shift: move the last char of the URL to the front of pay_to. The
+    # normalised tuples differ (delimited fields), so the fingerprint must change.
+    if url:
+        url_s = url[:-1]
+        pay_to_s = url[-1] + pay_to
+        fp_s = compute_fingerprint(url_s, pay_to_s, amount, currency, deadline, network)
+        eff_s = _effective_fields(url_s, pay_to_s, amount, currency, deadline, network)
+        if (fp1 == fp_s) != (eff1 == eff_s):
+            raise AssertionError(f"boundary-shift ambiguity: eff1={eff1!r} eff_s={eff_s!r}")
+
+
+def TestOneInput(data: bytes) -> None:  # noqa: N802 (Atheris entrypoint contract)
+    fdp = atheris.FuzzedDataProvider(data)
+    _check_canonical_amount(fdp)
+    _check_fingerprint(fdp)
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,11 @@ otel = [
 schema = [
     "jsonschema>=4.21.0",
 ]
+fuzz = [
+    # Atheris 3.x dropped Python 3.10 (last 3.10 wheel: 2.3.0); marker keeps the
+    # extra resolvable on the full support matrix while fuzz CI pins 3.12.
+    'atheris>=3.0; python_version >= "3.11"',
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,16 @@ wheels = [
 ]
 
 [[package]]
+name = "atheris"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/88/fd6ad595dafa9c7ce56dbfcaff0c7244988dac3af86c771166c6516ccf6b/atheris-3.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ec5e11f21a4c197fe91f7aea2b2de88e623c73a21fc07b105ac6329a1588457b", size = 36875908, upload-time = "2026-06-17T00:04:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/18/e19718c384fd7d801d0da7485407daef9af6194b6d8c8818175bec5efec6/atheris-3.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8a9f51ce8369026e8eb7b7174835e8c4c85a1a6db5d9add36c15100779d2a39", size = 36800563, upload-time = "2026-06-17T00:04:04.559Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ff/ae7a5bfe99033e510bea4ed09934e636d93777317a48147369bc0dc2b71f/atheris-3.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:315a0b5c819852b1ffe1ca72efc389c7724881f2c33e4aacb8c6bcec49bd5011", size = 36772569, upload-time = "2026-06-17T00:04:07.702Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1642,6 +1652,9 @@ dev = [
 evidence = [
     { name = "cryptography" },
 ]
+fuzz = [
+    { name = "atheris", marker = "python_full_version >= '3.11'" },
+]
 langchain = [
     { name = "langchain-core" },
 ]
@@ -1663,6 +1676,7 @@ schema = [
 
 [package.metadata]
 requires-dist = [
+    { name = "atheris", marker = "python_full_version >= '3.11' and extra == 'fuzz'", specifier = ">=3.0" },
     { name = "boto3", marker = "extra == 'audit-s3'", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
@@ -1690,7 +1704,7 @@ requires-dist = [
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
-provides-extras = ["nlp", "evidence", "redis", "audit-s3", "audit", "langchain", "crewai", "prometheus", "otel", "schema", "dev"]
+provides-extras = ["nlp", "evidence", "redis", "audit-s3", "audit", "langchain", "crewai", "prometheus", "otel", "schema", "fuzz", "dev"]
 
 [[package]]
 name = "prometheus-client"


### PR DESCRIPTION
## Summary

- Adds four Atheris harnesses under `fuzz/` over the byte-determinism contracts the evidence layer rests on: `canonical_bytes`, `compute_fingerprint` / `_canonical_amount`, `compute_decision_ref`, and `compute_action_ref`. They assert properties — determinism, JSON round-trip, type-aware injectivity, NFC/NFD non-collapse, fail-closed float rejection — rather than chasing coverage. The NFC/NFD case is the non-ASCII field-name caveat raised in the upstream conformance review.
- Adds a time-boxed `Fuzz (Atheris)` CI job (SHA-pinned actions, read-only token) and extends ruff to lint `fuzz/`.
- Fuzzing deps live in a separate `fuzz` extra, out of `dev`. Atheris 3.x ships no cp310 wheel so the job pins 3.12; the 3.10–3.13 test matrix is unchanged. `uv.lock` was regenerated on this base — the diff adds only `atheris 3.1.0` and touches no existing pin.

Also moves Scorecard's Fuzzing check from 0 to 10 (binary check), though the harnesses were written to be worth having on their own terms.

## Test plan

- [ ] **`Fuzz (Atheris)` job green — this is the only real verification.** Atheris cannot build on macOS without a hand-compiled Clang, so the harnesses have never been executed under real atheris. Locally they were driven 300 inputs each through a stub `FuzzedDataProvider` against `main`'s source (clean), which checks signatures and assertion logic but gives no libFuzzer coverage guidance or mutation.
- [ ] Existing test matrix unaffected on all four Python versions
- [ ] `Lock drift` check passes with the regenerated `uv.lock`
- [ ] Confirm no existing pin changed in `uv.lock`

Note: the fuzz job is intentionally **not** in the required-checks list, so a red fuzz job will not block merge. Do not merge on red.