### PR TITLE
Stop rounding high-precision amounts in the replay fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Replay-fingerprint collision on high-precision amounts.** `_canonical_amount`
+  stripped trailing zeros with `Decimal.normalize()`, a *context* operation bounded
+  by the default 28-significant-digit precision. Any amount longer than that was
+  silently rounded, so distinct amounts differing only past the 28th significant
+  digit canonicalised to the same string and produced the same replay fingerprint —
+  e.g. `…5555555` and `…5555556` (31 digits) both became
+  `5555555555555555555555555556000`. Across 5000 distinct 31-digit amounts, 4994
+  collided. `amount` originates in the server's 402 response and is therefore
+  attacker-influenced. Impact is fail-closed (a distinct payment could be rejected as
+  a duplicate) rather than a bypass. Canonicalisation is now context-free and exact.
+  **Amounts of 28 or fewer significant digits are unaffected — verified byte-identical
+  across 20 000 randomised inputs, so existing fingerprints do not change.** Found by
+  the Atheris `_canonical_amount` harness.
+
 ## [0.9.1] — 2026-07-14
 
 ### Security

--- a/src/presidio_x402/replay_guard.py
+++ b/src/presidio_x402/replay_guard.py
@@ -102,7 +102,16 @@ def _canonical_amount(amount: str) -> str:
         raise ValueError(f"Invalid payment amount {amount!r}: must be finite and non-negative")
     if value == 0:
         return "0"
-    return format(value.normalize(), "f")
+    # Strip trailing zeros without Decimal.normalize(). normalize() is a *context*
+    # operation bounded by the default 28-significant-digit precision, so an amount
+    # longer than that was silently rounded — distinct amounts differing only past
+    # the 28th digit canonicalised to the same string and therefore collided on the
+    # replay fingerprint. ``amount`` arrives from the server's 402 response, so it
+    # is attacker-influenced and must not be rounded. format(value, "f") is exact.
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
 
 
 def compute_fingerprint(

--- a/tests/test_replay_guard.py
+++ b/tests/test_replay_guard.py
@@ -7,7 +7,7 @@ import time
 import pytest
 
 from presidio_x402.exceptions import ReplayDetectedError
-from presidio_x402.replay_guard import ReplayGuard, compute_fingerprint
+from presidio_x402.replay_guard import ReplayGuard, _canonical_amount, compute_fingerprint
 
 
 class TestComputeFingerprint:
@@ -97,6 +97,55 @@ class TestComputeFingerprint:
         )
         fp_legit = compute_fingerprint("https://a.com/x", "0xLegit", "1.00", "USDC", 300)
         assert fp_attacker != fp_legit
+
+    def test_high_precision_amounts_do_not_collide(self):
+        # Fuzzing regression: `_canonical_amount` used Decimal.normalize(), a
+        # *context* operation bounded by the default 28-significant-digit
+        # precision. Amounts longer than that were silently rounded, so these two
+        # distinct values both canonicalised to '5555555555555555555555555556000'
+        # and shared a fingerprint. `amount` comes from the server's 402 response,
+        # so it is attacker-influenced.
+        fp_a = compute_fingerprint(
+            "https://api.example.com", "0xabc", "5555555555555555555555555555555", "USDC", 300
+        )
+        fp_b = compute_fingerprint(
+            "https://api.example.com", "0xabc", "5555555555555555555555555555556", "USDC", 300
+        )
+        assert fp_a != fp_b
+
+
+class TestCanonicalAmount:
+    def test_preserves_value_beyond_default_context_precision(self):
+        # 31 significant digits — must survive canonicalisation unrounded.
+        amount = "5555555555555555555555555555555"
+        assert _canonical_amount(amount) == amount
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("1", "1"),
+            ("1.0", "1"),
+            ("1.5000", "1.5"),
+            ("0.100", "0.1"),
+            ("000123", "123"),
+            ("1E+3", "1000"),
+            ("0", "0"),
+            ("0.0", "0"),
+            ("12.340", "12.34"),
+        ],
+    )
+    def test_trailing_zero_stripping_is_unchanged(self, raw, expected):
+        # These equivalences predate the precision fix and must not regress:
+        # semantically equal amounts still share one canonical form.
+        assert _canonical_amount(raw) == expected
+
+    def test_rejects_non_decimal(self):
+        with pytest.raises(ValueError, match="not a decimal value"):
+            _canonical_amount("not-a-number")
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError, match="finite and non-negative"):
+            _canonical_amount("-1.00")
 
 
 class TestReplayGuardMemory:


### PR DESCRIPTION
Found by the Atheris harnesses in #88 on their first CI run.

## Summary

- `_canonical_amount` stripped trailing zeros with `Decimal.normalize()`, a **context** operation bounded by the default 28-significant-digit precision. Amounts longer than that were silently rounded, so two distinct values differing only past the 28th digit collapsed to one canonical string and one replay fingerprint. `'…5555555'` and `'…5555556'` (31 digits) both became `5555555555555555555555555556000`; of 5000 distinct 31-digit amounts, **4994 collided**.
- `amount` originates in the server's 402 response, so it is attacker-influenced and must not be rounded. Impact is **fail-closed** — a distinct payment could be rejected as a duplicate — not a payment bypass.
- Canonicalisation is now context-free: `format(value, "f")` is exact, trailing zeros stripped textually. Single call site (`compute_fingerprint`); this was the only `normalize()` in the package.

## Compatibility

**Existing fingerprints do not change.** Amounts of 28 or fewer significant digits are byte-identical to the previous implementation, verified across 12 hand cases and 20 000 randomised inputs (0 differences). Only amounts exceeding 28 significant digits change — and those were being corrupted before.

## Test plan

- [x] Regression test: the two colliding 31-digit amounts now produce distinct fingerprints
- [x] `_canonical_amount` preserves a 31-digit value exactly
- [x] Parametrised test pins the pre-existing equivalences (`1.0`→`1`, `0.100`→`0.1`, `1E+3`→`1000`, …) so trailing-zero stripping cannot regress
- [x] Full suite green (615 passed, 1 skipped)
- [x] Conformance suite 7/7
- [x] ruff check + format clean
- [ ] CI green on all four Python versions

Merge before #88 — the fuzz job there stays red until this lands.