### PR TITLE
Add governance, architecture, and DCO docs (OpenSSF silver)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,104 @@
+# Architecture
+
+This document describes the high-level design of `presidio-hardened-x402`: its
+components, how a payment flows through them, and the trust boundaries the
+library is built to enforce. For the security requirements and threat model that
+motivate this design, see [SECURITY.md](SECURITY.md) and
+[PRESIDIO-REQ.md](PRESIDIO-REQ.md). For the stable public API surface, see
+[SEMVER.md](SEMVER.md).
+
+## What the library is
+
+`presidio-hardened-x402` is **pre-execution security middleware** for the x402
+agentic HTTP payment protocol. It sits between an AI agent (or any x402 client)
+and the payment rail, and applies a chain of security controls to each payment
+*before* the request is transmitted or committed on-chain. It is a Python
+library, not a service; the optional hosted screening endpoint is a separate
+deployment that the library can call but does not require.
+
+## Component overview
+
+The package (`src/presidio_x402/`) is organised as a set of single-responsibility
+modules. Implementation and dependency order runs from primitives outward:
+`exceptions` → `_types` → `pii_filter` → `policy_engine` → `replay_guard` →
+`audit_log` → `gateway`.
+
+| Module | Responsibility |
+|---|---|
+| `core.py` / `gateway.py` | `HardenedX402Client` — the entry point that composes the controls into one payment pipeline. |
+| `pii_filter.py` | Presidio-based detection and redaction of personal data in payment metadata. `regex` engine is the zero-setup default; `nlp` (spaCy NER) is an opt-in structural superset. |
+| `policy_engine.py` / `x402_policy_schema.py` / `slo_policy.py` | Spending-policy enforcement — per-agent, per-endpoint, per-time-window budget limits; policy-as-code JSON Schema. |
+| `replay_guard.py` | HMAC-SHA256 fingerprinting of canonical payment fields with TTL deduplication. In-memory by default; Redis backend for cross-process durability. |
+| `audit_log.py` / `audit_sinks.py` | HMAC-chained JSON-L audit trail; optional S3 / Splunk / Datadog sinks with bounded buffers and TLS enforcement. |
+| `mpa.py` | Multi-party authorization — n-of-m approvals above a threshold, via webhook or HMAC countersignature modes. |
+| `decision_ref.py` / `action_ref.py` / `capability.py` / `compliance_report.py` / `mica.py` | Proof-carrying evidence layer — signed, byte-deterministic, offline-verifiable records (`payment-decision@1`, `capability-grant@1`) and compliance reporting. |
+| `arch_translucency_adapter.py` / `slo_broker.py` | SLO payment broker — pays only on a fail-closed-verified signed degradation trigger. |
+| `screening_client.py` | Client for the optional hosted screening service (local regex still runs as a backstop). |
+| `bindings/x402.py` | `PaymentProtocolBinding` — rail-agnostic core with an x402 binding layer, hedging against rail fragmentation. |
+| `adapters/langchain.py`, `adapters/crewai.py` | Framework integrations. |
+| `metrics.py` / `telemetry.py` / `log_redaction.py` | Prometheus metrics, OpenTelemetry spans, and import-time log-sink redaction of secrets. |
+| `conformance/` | The partner conformance suite (`python -m presidio_x402.conformance`) that verifies the documented guarantees end-to-end. |
+
+## Payment flow
+
+A payment passes through the controls as a pipeline, and the pipeline
+**fails closed** — any control that raises blocks the payment rather than letting
+it through:
+
+1. **Spending-policy enforcement** — the payment is checked against the
+   configured budget limits first. Policy checks run *before* replay
+   fingerprinting by design, so a policy-rejected payment never consumes a
+   replay slot.
+2. **Replay fingerprinting** — a canonical, HMAC-fingerprinted representation of
+   the payment is checked against the TTL-bounded dedup store.
+3. **PII detection and redaction** — personal data in the payment metadata is
+   redacted (or the payment is blocked / warned, per `pii_action`) *before* it
+   can leave the process toward the network or the chain.
+4. **Multi-party authorization** (when configured) — high-value payments require
+   n-of-m approvals before proceeding.
+5. **Audit + evidence** — the attempt and its outcome are written to the
+   HMAC-chained audit log, and (opt-in) a signed, offline-verifiable evidence
+   record is emitted.
+
+Metrics and telemetry are emitted at each control activation for observability.
+
+## Trust boundaries
+
+The design treats the following as the boundaries where untrusted data enters or
+sensitive data leaves:
+
+- **Agent / caller → library (untrusted input).** All payment metadata arriving
+  from the calling agent is treated as untrusted and validated before use. This
+  is the primary input-validation boundary.
+- **Library → payment rail / blockchain (irreversible egress).** Once a payment
+  is committed on-chain it cannot be recalled, so PII redaction and policy
+  enforcement happen *before* this boundary is crossed — the whole point of the
+  "pre-execution" design.
+- **Library → hosted screening service and remote audit sinks (network egress).**
+  All network communication enforces TLS with certificate verification; local
+  regex screening still runs as a backstop so a remote failure fails safe.
+- **Signing key custody (out of scope, by contract).** The `PaymentSigner`
+  protocol is abstract — the library never holds wallet keys; the security of the
+  signing implementation is the caller's responsibility. Evidence-signing keys
+  are supplied by the deployment and never embedded in the library.
+
+## Extension points
+
+The library depends on protocols, not concrete vendor SDKs, so integrators can
+substitute their own implementations:
+
+- `PaymentSigner` — wallet/signing implementation (no bundled wallet dependency).
+- `PaymentProtocolBinding` — the payment rail (x402 today; the core is
+  rail-agnostic).
+- `CapacityProvider` — pluggable capacity source for the SLO broker.
+- Audit writers (`S3AuditWriter`, `SplunkAuditWriter`, `DatadogAuditWriter`, or a
+  custom writer via `MultiAuditWriter`).
+- Screening client — local, hosted, or custom.
+
+## Language and safety properties
+
+The library is pure Python (3.10+), which is memory-safe — there is no manual
+memory management, so the memory-safety class of vulnerabilities does not apply.
+Robustness of the canonicalisation and digest layer is checked with Atheris
+fuzzing in CI, and the security-relevant control paths are covered by the test
+suite (statement coverage is gated at ≥90% in CI).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,10 +105,24 @@ four.
 Write in the imperative mood ("add replay TTL bound", not "added" or "adds"). Explain *why*
 the change is being made where that is not obvious from the diff.
 
-## Licensing
+## Licensing and Developer Certificate of Origin (DCO)
 
-The project is MIT licensed. By contributing, you agree that your contribution is licensed
-under the same terms, and you confirm you have the right to submit it.
+The project is MIT licensed, and contributions are accepted under the same terms
+(inbound = outbound).
+
+To assert that you have the right to submit your contribution, every commit must
+be **signed off** under the [Developer Certificate of Origin](https://developercertificate.org/)
+1.1. Signing off means adding a `Signed-off-by` line to the commit message with
+your real name and email:
+
+```
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+`git commit -s` adds this line for you. By signing off you certify the DCO —
+in short, that you wrote the change or otherwise have the right to submit it
+under the project's MIT license. Pull requests whose commits are not signed off
+will be asked to amend before merge.
 
 ## Code of conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,77 @@
+# Project Governance
+
+`presidio-hardened-x402` is developed and maintained by **PRESIDIO**
+(<https://presidio-group.eu>) and published under the `presidio-v` GitHub
+organisation. This document describes how the project is governed, who holds
+which responsibilities, and how the project continues to function if any single
+individual becomes unavailable.
+
+## Governance model
+
+The project follows a **maintainer-led, single-steward** model. PRESIDIO is the
+steward organisation: it owns the repository, the release infrastructure, and
+the published artefacts, and it sets the security bar the project is held to.
+
+Day-to-day technical decisions are made by the maintainers by rough consensus:
+
+- **Ordinary changes** (bug fixes, tests, documentation, dependency floors) are
+  decided by the reviewing maintainer on the pull request.
+- **Security-relevant changes** (anything touching PII detection, spending-policy
+  enforcement, replay fingerprinting, audit-log chaining, multi-party
+  authorization, or evidence and canonicalisation code) require an explicit
+  security rationale in the pull request and must not weaken an existing default.
+  See [CONTRIBUTING.md](CONTRIBUTING.md#security-sensitive-changes).
+- **Public-API and compatibility changes** are governed by [SEMVER.md](SEMVER.md);
+  a breaking change requires a major/minor bump per the documented policy.
+- **Disagreements** that cannot be resolved on the pull request are escalated to
+  the steward organisation (PRESIDIO), whose decision is final.
+
+There is no pay-to-play influence: contribution weight is earned through review
+history and sustained, high-quality contribution, not funding.
+
+## Roles and responsibilities
+
+| Role | Held by | Responsibilities |
+|---|---|---|
+| **Steward organisation** | PRESIDIO (`presidio-v` GitHub org) | Owns the repository and release infrastructure; holds and can recover all release credentials; final escalation authority; ensures continuity (see below). |
+| **Maintainer** | PRESIDIO engineering | Reviews and merges pull requests; enforces the test, style, and security bars; cuts releases; triages issues; is the point of accountability for the codebase. |
+| **Security contact** | PRESIDIO security | Receives and triages private vulnerability reports (see [SECURITY.md](SECURITY.md)); coordinates fixes, advisories, and reporter credit. Reachable at `security@presidio-group.eu` and via GitHub Security Advisories. |
+| **Release manager** | PRESIDIO engineering | Owns the signed-tag → Trusted-Publishing release flow; verifies provenance and SBOM attach on each release. |
+| **Contributor** | Anyone | Opens issues and pull requests under [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md). |
+
+Roles are held by function within PRESIDIO rather than being tied to one named
+individual, so responsibilities transfer without a change to this document.
+
+## Becoming a maintainer
+
+A contributor with a sustained track record of merged, high-quality changes —
+particularly to the security-sensitive modules — may be invited by the steward
+organisation to become a maintainer. Maintainership is granted by PRESIDIO and
+recorded by adding the person to the `presidio-v` organisation with the
+appropriate repository role.
+
+## Project continuity
+
+The project is structured so that it continues to function — issues can be
+triaged and closed, contributions can be reviewed and accepted, and new versions
+can be released — within one week even if any single individual becomes
+unavailable. This is a property of the **organisation**, not of any one person:
+
+- **Repository ownership** is held by the `presidio-v` GitHub organisation, not
+  by a personal account. Organisation owners can grant repository and release
+  access to another member at any time.
+- **Release credentials are not personal.** Publishing to PyPI uses GitHub
+  **Trusted Publishing (OIDC)** bound to the `presidio-v/presidio-hardened-x402`
+  repository and a founder-gated `release` environment — there is no personal
+  API token that dies with an individual. The release signing key is held in the
+  organisation's password manager (custody ultimately with PRESIDIO's
+  leadership), not solely on any one contributor's machine, so it is recoverable.
+- **The release process is fully documented** — see the signed-tag → Trusted
+  Publishing flow in [SECURITY.md](SECURITY.md#supply-chain-provenance-slsa-build-l3)
+  and the `.github/workflows/publish.yml` workflow — so any authorised PRESIDIO
+  engineer can cut a release by following it.
+- **PRESIDIO is a staffed organisation** with more than one person able to assume
+  the maintainer, security-contact, and release-manager roles above.
+
+The project's bus factor is therefore backed by the steward organisation rather
+than a lone maintainer.

--- a/README.md
+++ b/README.md
@@ -484,6 +484,22 @@ All exceptions are importable from `presidio_x402`.
 | v0.9.0 | Proof-carrying x402 evidence — `capability-grant@1` attenuable spending grants + opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records |
 | Future | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
 
+### Planned direction (next 12 months)
+
+Intended direction, not a commitment — priorities shift with the ecosystem and
+security findings:
+
+- **Toward v1.0** — stabilise the public API under [SEMVER.md](SEMVER.md) and
+  clear the mainnet release gate (KYB / signing / legal controls) for the paid
+  screening route.
+- **Prompt-injection / agent-bound response scanning** (deferred issue #23) —
+  extend the threat model beyond outbound payment metadata to untrusted
+  agent-facing responses.
+- **Broader rail coverage** — additional `PaymentProtocolBinding` implementations
+  as agentic payment rails consolidate.
+- **Evidence and conformance** — grow the partner conformance suite and the
+  proof-carrying evidence vocabulary alongside upstream standardisation.
+
 See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 
 ---
@@ -497,6 +513,9 @@ See [PRESIDIO-REQ.md](PRESIDIO-REQ.md) for full deliberation and rationale.
 - **Code contributions** — see [CONTRIBUTING.md](CONTRIBUTING.md) for the pull-request process,
   coding standards, and the test policy. Participation is governed by the
   [Code of Conduct](CODE_OF_CONDUCT.md).
+- **Architecture and governance** — [ARCHITECTURE.md](ARCHITECTURE.md) describes the
+  components, payment flow, and trust boundaries; [GOVERNANCE.md](GOVERNANCE.md) covers the
+  governance model, roles, and project continuity.
 
 Install from [PyPI](https://pypi.org/project/presidio-hardened-x402/):
 `pip install presidio-hardened-x402`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,10 @@ Include:
 You will receive an acknowledgement within 5 business days. We aim to release a patch
 within 30 days of a confirmed vulnerability.
 
+**Credit.** We credit reporters of valid vulnerabilities by name in the published
+GitHub Security Advisory and in the `CHANGELOG.md` entry for the fix, unless the
+reporter asks to remain anonymous.
+
 ## Security Controls
 
 presidio-hardened-x402 provides the following security controls for x402 payments:
@@ -145,6 +149,23 @@ requirement-by-requirement mapping (and the caveat that self-hosted runners
 would cap the level at L2) is maintained in the SDLC supply-chain report. We do
 not yet claim hermetic or reproducible builds — that is a stretch target beyond
 the L3 baseline, not an L3 requirement.
+
+### Obtaining the public signing keys
+
+- **Release artefacts (wheels/sdists)** are verified with Sigstore-backed build
+  provenance — no key to fetch manually. Run
+  `gh attestation verify <artefact> --repo presidio-v/presidio-hardened-x402`
+  (shown above); the trusted identity is the repository's OIDC signer.
+- **Git release tags** are SSH-signed with the organisation's ed25519 release
+  signing key, which is registered as a **signing key** on the maintainer's
+  GitHub account — so GitHub shows each release tag as **Verified** on the
+  Releases page and via the API
+  (`gh api repos/presidio-v/presidio-hardened-x402/git/tags/<sha> --jq .verification.verified`).
+  The public key is published in the repository's
+  [`allowed_signers`](allowed_signers) file; to verify a tag locally, run
+  `git -c gpg.ssh.allowedSignersFile=allowed_signers verify-tag <tag>`.
+- **PyPI releases** carry PEP 740 attestations published via Trusted Publishing;
+  `pip`/`uv` and the PyPI UI surface these automatically.
 
 ## Known Limitations
 

--- a/allowed_signers
+++ b/allowed_signers
@@ -1,0 +1,11 @@
+# SSH allowed_signers for verifying presidio-hardened-x402 release tags.
+#
+# Release tags are SSH-signed with the presidio-v org release signing key.
+# To verify a tag locally:
+#
+#   git -c gpg.ssh.allowedSignersFile=allowed_signers verify-tag <tag>
+#
+# GitHub also shows each release tag as "Verified" because this same key is
+# registered as a signing key on the maintainer's GitHub account.
+
+vstantch@users.noreply.github.com,vladimir@presidio-group.eu namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILzAijdWkrW+yAhY6ZfjBqSs/1HWiGLJkhfHv2PX9JB5 presidio-v release signing


### PR DESCRIPTION
## Summary
- Add `GOVERNANCE.md` (governance model, roles, org-backed continuity) and `ARCHITECTURE.md` (components, payment flow, trust boundaries)
- Require DCO `Signed-off-by` on contributions; credit vulnerability reporters; document how to obtain the release signing keys and commit the public key as `allowed_signers`
- Add a 12-month roadmap section and link the new docs from the README

Closes the documentation gap to reach OpenSSF Best Practices **silver** (project 13675). Fill-out sheet tracked internally.

## Test plan
- [x] Docs-only change (no source/tests affected)
- [x] Internal Markdown anchors verified against headings
- [x] `allowed_signers` verified to match the org release signing key