### PR TITLE
Add CODEOWNERS for two-person review gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for presidio-hardened-x402
+#
+# Every change to this repository requires review from a code owner other than
+# the author (enforced by branch protection: required review + code-owner
+# review). Listing two owners keeps the two-person gate robust — whoever is not
+# the author of a given pull request provides the required review.
+
+*       @vstantch @ceoofcyber


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` listing both maintainers, so every PR requires a code-owner review from someone other than the author

Pairs with enabling required PR reviews on `main` (code-owner review). Strengthens OpenSSF Scorecard Code-Review and Branch-Protection, and satisfies the Best Practices gold `two_person_review` criterion.

## Test plan
- [x] Config-only change (no source/tests affected)