### PR TITLE
Enforce branch coverage; document code review (gold quick wins)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           python-version: "3.12"
       - name: Install package + fuzz extra
         run: pip install -e ".[fuzz]"
+      # Dynamic analysis runs with runtime assertions enabled: Python is invoked
+      # without -O and PYTHONOPTIMIZE is unset, so `assert` statements in the
+      # harnesses and library are checked during fuzzing.
       - name: Run fuzz harnesses (time-boxed)
         run: |
           for f in fuzz/fuzz_*.py; do
@@ -56,7 +59,28 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Run tests
-        run: pytest tests/ --cov=presidio_x402 --cov-report=xml --cov-fail-under=90
+        run: pytest tests/ --cov=presidio_x402 --cov-branch --cov-report=xml --cov-report=json --cov-report=term
+      - name: Enforce coverage floors (statement >= 90%, branch >= 80%)
+        run: |
+          python - <<'PY'
+          import json
+          import sys
+
+          totals = json.load(open("coverage.json"))["totals"]
+          statement = 100 * totals["covered_lines"] / totals["num_statements"]
+          branches = totals["num_branches"]
+          branch = 100 * totals["covered_branches"] / branches if branches else 100.0
+          print(f"statement coverage: {statement:.2f}%  (floor 90%)")
+          print(f"branch coverage:    {branch:.2f}%  (floor 80%)")
+
+          failures = []
+          if statement < 90:
+              failures.append(f"statement {statement:.2f}% < 90%")
+          if branch < 80:
+              failures.append(f"branch {branch:.2f}% < 80%")
+          if failures:
+              sys.exit("COVERAGE FAILURE: " + "; ".join(failures))
+          PY
       - name: Partner conformance suite (the OEM embed-kit guarantee, SEMVER.md)
         run: python -m presidio_x402.conformance
       - name: Upload coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ existing issues first. For a bug, include:
 Please redact real payment metadata, wallet addresses, and personal data from anything you
 paste into a public issue.
 
+## New to the project?
+
+Issues labelled [`good first issue`](https://github.com/presidio-v/presidio-hardened-x402/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+are scoped to be approachable without deep knowledge of the codebase and are a good place to
+start.
+
 ## How changes are made
 
 All changes go through a pull request against `main`. Direct pushes to `main` are blocked by
@@ -32,6 +38,27 @@ branch protection, and every PR must pass the required status checks before it c
 3. Run the local verification block until it is clean.
 4. Update `CHANGELOG.md` under `## [Unreleased]`.
 5. Open a PR describing what changed and why.
+
+## Code review
+
+Every pull request — including a maintainer's own — is reviewed before it merges. This is
+not advisory: `main` requires an approving review from a code owner
+([CODEOWNERS](.github/CODEOWNERS)) who is **not** the author of the change, enforced by
+branch protection (required review, code-owner review, stale-approval dismissal, and
+last-push re-approval; admins are included).
+
+What a reviewer confirms before approving:
+
+- **Tests** — new or changed functionality ships with tests; bug fixes include a regression
+  test; the coverage floors hold.
+- **Security reasoning** — for changes to a security control (see below), the PR explains the
+  reasoning, and no existing default is weakened without an explicit rationale.
+- **Compatibility** — changes to anything in `presidio_x402.__all__`, audit event shapes, or
+  exception types follow [SEMVER.md](SEMVER.md); breaking changes are called out.
+- **Style and scope** — ruff is clean, the change is focused, and `CHANGELOG.md` is updated.
+
+Reviewers approve via GitHub's review flow. A change that needs rework is returned with
+specific requested changes rather than merged with caveats.
 
 ## Requirements for acceptable contributions
 
@@ -55,7 +82,7 @@ forms for the same dependency within one module.
 same pull request.** Bug fixes must include a regression test that fails before the fix and
 passes after it. This is enforced in review, and by the coverage gate.
 
-- coverage must stay at or above 90% (`--cov-fail-under=90`)
+- coverage floors are enforced in CI: **statement coverage ≥ 90%** and **branch coverage ≥ 80%**
 - the partner conformance suite must pass: `python -m presidio_x402.conformance`
 
 ### Security-sensitive changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,11 @@ addopts = "--strict-markers --tb=short -q"
 
 [tool.coverage.run]
 source = ["src/presidio_x402"]
+branch = true
 
 [tool.coverage.report]
-fail_under = 90
+# Coverage floors are enforced in CI against explicit thresholds
+# (statement >= 90%, branch >= 80%) — see .github/workflows/ci.yml. With branch
+# coverage on, coverage's single blended fail_under would conflate the two, so
+# the per-metric gate lives in CI instead.
 show_missing = true


### PR DESCRIPTION
## Summary
- Add explicit CI coverage floors: **statement ≥ 90%** and **branch ≥ 80%** (enable branch coverage, enforce both per-metric from `coverage.json`)
- Document the code-review process and the `good first issue` entry point in `CONTRIBUTING.md`; note fuzzing runs with assertions enabled

First batch of OpenSSF **gold** quick wins: `test_branch_coverage80` (measured ~87% locally), `code_review_standards`, `small_tasks`, `dynamic_analysis_enable_assertions`. Tracked in the gold answer sheet.

## Test plan
- [x] CI YAML validated (parses; new enforcement step present)
- [x] Branch coverage measured locally ≈ 86.7% (over the 80% floor)
- [ ] CI confirms statement ≥ 90% and branch ≥ 80% on all Python versions