### PR TITLE
Add per-file SPDX + copyright headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
       - run: pip install ruff
       - run: ruff check src/ tests/ fuzz/
       - run: ruff format --check src/ tests/ fuzz/
+      - name: Require SPDX + copyright header on every source file
+        run: |
+          missing=$(grep -rL "SPDX-License-Identifier" src/ fuzz/ --include='*.py' || true)
+          if [ -n "$missing" ]; then
+            echo "Source files missing an SPDX license header:"
+            echo "$missing"
+            exit 1
+          fi
 
   fuzz:
     name: Fuzz (Atheris)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Presidio Security
+Copyright (c) 2026 PRESIDIO Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fuzz/fuzz_action_ref.py
+++ b/fuzz/fuzz_action_ref.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Atheris property fuzzer for the action-ref-v1 derivation.
 
 Targets :func:`presidio_x402.action_ref.compute_action_ref` and

--- a/fuzz/fuzz_canonical_bytes.py
+++ b/fuzz/fuzz_canonical_bytes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Atheris property fuzzer for :func:`presidio_x402.mica.canonical_bytes`.
 
 ``canonical_bytes`` is the family strict-profile canonical JSON encoder (sorted

--- a/fuzz/fuzz_decision_ref.py
+++ b/fuzz/fuzz_decision_ref.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Atheris property fuzzer for :func:`presidio_x402.decision_ref.compute_decision_ref`.
 
 ``compute_decision_ref`` derives the thin, self-describing correlation id

--- a/fuzz/fuzz_replay_fingerprint.py
+++ b/fuzz/fuzz_replay_fingerprint.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Atheris property fuzzer for the x402 replay fingerprint canonicalisation.
 
 Targets :func:`presidio_x402.replay_guard._canonical_amount` and

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """
 presidio-hardened-x402
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/presidio_x402/_types.py
+++ b/src/presidio_x402/_types.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Shared data types for presidio-hardened-x402."""
 
 from __future__ import annotations

--- a/src/presidio_x402/action_ref.py
+++ b/src/presidio_x402/action_ref.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Content-addressed ``action_ref`` derivation (action-ref-v1).
 
 ``action_ref`` is a deterministic, content-addressed identifier for an agent

--- a/src/presidio_x402/adapters/__init__.py
+++ b/src/presidio_x402/adapters/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group

--- a/src/presidio_x402/adapters/crewai.py
+++ b/src/presidio_x402/adapters/crewai.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """CrewAI adapter for presidio-hardened-x402.
 
 Provides a drop-in :class:`HardenedX402CrewTool` that wraps

--- a/src/presidio_x402/adapters/langchain.py
+++ b/src/presidio_x402/adapters/langchain.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """LangChain adapter for presidio-hardened-x402.
 
 Provides a drop-in :class:`HardenedX402Tool` that wraps

--- a/src/presidio_x402/arch_translucency_adapter.py
+++ b/src/presidio_x402/arch_translucency_adapter.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Adapter: arch-translucency degradation signals → verified SLO triggers (v0.7.0).
 
 The :class:`~presidio_x402.slo_broker.SLOPaymentBroker` *moves money* on degradation

--- a/src/presidio_x402/audit_log.py
+++ b/src/presidio_x402/audit_log.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Structured, tamper-evident audit logging for x402 payment events.
 
 Emits JSON-L (newline-delimited JSON) audit events for every payment attempt.

--- a/src/presidio_x402/audit_sinks.py
+++ b/src/presidio_x402/audit_sinks.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Enterprise-tier remote audit sinks (v0.6.0).
 
 The base writers in :mod:`presidio_x402.audit_log` (``Null``/``Stream``/``File``)

--- a/src/presidio_x402/bindings/__init__.py
+++ b/src/presidio_x402/bindings/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Payment-rail bindings for the presidio-hardened screening core.
 
 The screening core (:mod:`presidio_x402.core`) is **rail-agnostic**: PII

--- a/src/presidio_x402/bindings/x402.py
+++ b/src/presidio_x402/bindings/x402.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """x402 protocol binding — HTTP 402 + ``X-PAYMENT`` header (x402 spec v1).
 
 This module owns every x402-specific assumption that used to live in the

--- a/src/presidio_x402/capability.py
+++ b/src/presidio_x402/capability.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Capability certificates — operator-signed, attenuable spending grants.
 
 Turns spending *authority* from configuration (``PolicyConfig`` read from env or

--- a/src/presidio_x402/compliance_report.py
+++ b/src/presidio_x402/compliance_report.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """SOC2/GDPR-friendly compliance report generator for x402 audit logs.
 
 Reads a JSON-L audit log produced by :class:`~presidio_x402.audit_log.AuditLog`

--- a/src/presidio_x402/conformance/__init__.py
+++ b/src/presidio_x402/conformance/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Partner-runnable conformance suite for presidio-hardened-x402 (OEM embed kit).
 
 Run against your installed environment with::

--- a/src/presidio_x402/conformance/__main__.py
+++ b/src/presidio_x402/conformance/__main__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """``python -m presidio_x402.conformance`` entry point."""
 
 from .runner import main

--- a/src/presidio_x402/conformance/runner.py
+++ b/src/presidio_x402/conformance/runner.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Conformance checks — see package docstring. No network; httpx.MockTransport only."""
 
 from __future__ import annotations

--- a/src/presidio_x402/core.py
+++ b/src/presidio_x402/core.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """ScreeningPipeline — the rail-agnostic screening core (v0.5.0, session-3 T2).
 
 The patent-relevant four-control sequence (PII filter → trusted-wallet check →

--- a/src/presidio_x402/decision_ref.py
+++ b/src/presidio_x402/decision_ref.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Decision-ref emission — per-payment proof-carrying decision records.
 
 A **decision-ref** is a signed, portable record of one gateway payment decision:

--- a/src/presidio_x402/exceptions.py
+++ b/src/presidio_x402/exceptions.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Exceptions raised by presidio-hardened-x402 security controls."""
 
 from __future__ import annotations

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """HardenedX402Client — async HTTP client with x402 payment support and Presidio security.
 
 Implements the x402 payment flow directly over httpx, with all security controls

--- a/src/presidio_x402/log_redaction.py
+++ b/src/presidio_x402/log_redaction.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Sink-level secret redaction for the ``presidio_x402`` logger.
 
 The gateway, audit log, replay guard, and MPA engine all emit structured log

--- a/src/presidio_x402/metrics.py
+++ b/src/presidio_x402/metrics.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Prometheus metrics exporter for presidio-hardened-x402.
 
 Exposes counters and histograms for every security control activation.

--- a/src/presidio_x402/mica.py
+++ b/src/presidio_x402/mica.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """MiCA/EU evidence module — signed compliance-supporting evidence (session-3 T3).
 
 Maps what the screening middleware **actually does** (audit-chained payment

--- a/src/presidio_x402/mpa.py
+++ b/src/presidio_x402/mpa.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Multi-party authorization (MPA) engine for high-value x402 payments.
 
 Enforces n-of-m approval requirements before large payments are executed.

--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """PII detection and redaction for x402 payment metadata.
 
 Scans payment metadata fields (resource URL, description, reason) using either:

--- a/src/presidio_x402/policy_engine.py
+++ b/src/presidio_x402/policy_engine.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Spending policy enforcement for x402 payment requests.
 
 Blocks or throttles payments before execution based on configurable per-agent,

--- a/src/presidio_x402/replay_guard.py
+++ b/src/presidio_x402/replay_guard.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Replay and duplicate payment detection for x402.
 
 Creates an HMAC-SHA256 fingerprint of the canonical payment fields and checks

--- a/src/presidio_x402/screening_client.py
+++ b/src/presidio_x402/screening_client.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Remote PII screening client — call the Presidio screening service instead of
 running the local :class:`~presidio_x402.pii_filter.PIIFilter`.
 

--- a/src/presidio_x402/slo_broker.py
+++ b/src/presidio_x402/slo_broker.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Market-based SLO enforcement — the SLO payment broker (v0.7.0).
 
 When infrastructure degrades, the agent autonomously pays for a capacity upgrade via

--- a/src/presidio_x402/slo_policy.py
+++ b/src/presidio_x402/slo_policy.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """SLO-payment spending policy (v0.7.0).
 
 :class:`SLOPaymentPolicy` extends :class:`~presidio_x402.policy_engine.PolicyConfig`

--- a/src/presidio_x402/telemetry.py
+++ b/src/presidio_x402/telemetry.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Optional OpenTelemetry helpers for presidio_x402 security controls."""
 
 from __future__ import annotations

--- a/src/presidio_x402/x402_policy_schema.py
+++ b/src/presidio_x402/x402_policy_schema.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
 """Policy-as-code schema validator for x402 spending policies.
 
 Validates policy configuration dicts against ``x402-policy-schema.json``


### PR DESCRIPTION
## Summary
- Add a two-line `SPDX-License-Identifier: MIT` + `Copyright (c) 2026 PRESIDIO Group` header to all 36 library and fuzz source files
- Align the `LICENSE` copyright holder to **PRESIDIO Group** (was "Presidio Security") so per-file and top-level notices agree
- Add a CI guard (in the lint job) that fails if any `src/`/`fuzz/` `*.py` lacks the SPDX header

Satisfies the OpenSSF **gold** `copyright_per_file` and `license_per_file` criteria. Scoped to `src/` + `fuzz/`; `tests/` headers can follow once #98 lands (avoids a merge collision).

## Test plan
- [x] ruff check + format clean; CI YAML valid; header guard passes locally
- [x] `import presidio_x402` OK, module docstrings intact, conformance suite passes
- [x] Full test suite green against the modified source