### PR TITLE
Treasury binding — settlement-ref@1, bundle export/verify, cross-language vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   bound is re-applied on read, so a bundle from a laxer producer still fails.
   This replaces the overclaim that the record is PII-free: only the `controls{}`
   block is structurally PII-free.
+- **Bundle summary fields are cross-checked against the envelopes.** The
+  top-level `decision_ref`, `settlement_ref`, `settlement_key` and `verdict` are
+  a mirror of what the envelopes prove; verification never reads them and
+  re-derives everything. But a consumer enforcing "one settlement, one leg" reads
+  `settlement_key`, so a mirror that can disagree with what it mirrors is a trap
+  — swapping in a settlement-ref for another transaction leaves a stale key
+  naming the old one. A disagreement is now a distinct fail-closed reason
+  (`summary_mismatch`), not a warning.
 - **Cross-language conformance vectors** under
   `tests/conformance/treasury-binding/`, with `PROVENANCE.json` and a
   deterministic generator. They are the *normative* contract between this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,90 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+> Releases as **0.10.0**; `pyproject.toml` is bumped ahead of the tag.
+
+### Added
+- **Treasury binding — `settlement-ref@1`, a signed off-chain join record.** A
+  `payment-decision@1` record says *why* a payment was allowed but carries no
+  transaction hash, so it cannot be reconciled against the settlement it
+  authorized. The new artifact closes that gap: a signed `evidence-ref@1`
+  envelope, under the same policy signer, committing to `{decision_ref, chain
+  (CAIP-2), tx_hash, block_number, log_index}` and nothing else. It is
+  deliberately **not** the on-chain anchor an earlier design sketched — an
+  ERC-3009 settlement's calldata carries no decision digest, so a
+  `calldata_digest` check would verify nothing, and a "decision precedes
+  settlement" check compares the settlement's own block time with itself. The
+  record asserts only what the signer can: *this decision, that transaction,
+  signed*. The stronger pre-settlement on-chain commitment remains available as
+  a future opt-in mode; it costs an extra chain transaction per payment.
+- **`presidio_x402.treasury_binding` — fail-closed bundle export + offline
+  verify, with a CLI.** `export` re-runs the *whole* decision-ref verification —
+  signature included, which is why a trust store is a required argument rather
+  than an optional one — and refuses to emit a bundle for an envelope that does
+  not verify, a non-terminal `REFER` verdict, an out-of-bound caller identity
+  string, out-of-domain settlement facts, or a join that would be signed by an
+  identity other than the decision's own signer. `DENY` *is* exportable on
+  purpose: a settlement that happened despite a DENY is the anomaly an auditor
+  most needs to see. The bundle carries **no key material** — `trust_store_ref`
+  names the signer and key id, and the verifier resolves both against its own
+  pinned store, because a bundle-supplied public key would make verification
+  trust-on-first-use and defeat the pin. The signing key is read from a file or
+  `PRESIDIO_X402_EVIDENCE_KEY`, never from `argv`, which is world-readable in
+  `ps` output. Exit 0 verified / 1 fail-closed with a distinct reason / 2 usage.
+- **Client-side settlement-receipt capture (opt-in `settlement_writer=`).** The
+  paid response's `PAYMENT-RESPONSE` / `X-PAYMENT-RESPONSE` /
+  `X-PAYMENT-RECEIPT` echo is parsed into rail-agnostic settlement facts and
+  correlated with that payment's `decision_ref`. Documented honestly: **the echo
+  carries the transaction hash and the network, not a block number and not a log
+  index**, so those come back `null`, the record is flagged `"complete": false`,
+  and completing them from a chain or indexer lookup is an operator step. They
+  are required rather than optional because without a log index there is no key
+  on which a ledger can enforce one-settlement-one-leg. Capture is strictly
+  observational — it runs after the paid response is in hand, performs no
+  network I/O, and cannot change a payment outcome. The `decision_ref` is
+  captured through a request-local closure, never client state, so concurrent
+  requests through one client cannot correlate a receipt with each other's
+  decision.
+- **Caller-identity value bounds on the export and verify paths.** `agent_id`,
+  `actor.payment_signer`, `pay_to`, `resource_origin` and `mpa.approval_refs`
+  are caller-supplied strings, and a wallet address is pseudonymous personal
+  data to a GDPR-minded auditor. They are bounded by length and charset (no
+  control, format, surrogate, private-use or unassigned code point — a charset
+  bound, not an ASCII allowlist, so an international agent id stays legal). The
+  bound is re-applied on read, so a bundle from a laxer producer still fails.
+  This replaces the overclaim that the record is PII-free: only the `controls{}`
+  block is structurally PII-free.
+- **Cross-language conformance vectors** under
+  `tests/conformance/treasury-binding/`, with `PROVENANCE.json` and a
+  deterministic generator. They are the *normative* contract between this
+  repository's Python canonicaliser and the sibling Rust one — x402 is Python,
+  the ledger is Rust, and nothing is imported across that boundary, so the
+  contract is the bytes. Covers the axes that can actually diverge: non-ASCII
+  escaping (emoji, combining marks, U+007F, C0 controls), non-ASCII key ordering
+  (equal by construction — pinned so a toolchain change cannot break it
+  silently), lone surrogates, non-string object keys, integers past `i64::MAX`,
+  floats, and the depth boundary at 128/129 with the depth definition pinned
+  alongside it. Plus the two family negatives as complete signed envelopes: both
+  verify cryptographically and both must still be rejected.
+
+### Changed
+- **`mica.canonical_bytes` now fails closed across its whole input domain.** A
+  string carrying an unpaired surrogate raised a bare `UnicodeEncodeError` from
+  the UTF-8 encode step — an interpreter accident escaping a boundary whose
+  callers catch `EvidenceError` — and now raises `EvidenceError`. Non-string
+  object keys are also rejected: `json.dumps` sorts integer keys *numerically*
+  and only then stringifies them (`1, 2, 10`), while every sibling canonicaliser
+  sorts the strings (`"1", "10", "2"`), which is a silent cross-language hash
+  divergence. Neither change affects any valid input, so no emitted bytes move;
+  the float guard and the key guard now share one walk instead of two.
+- `ScreeningPipeline.apply()` accepts an optional `on_decision_ref` callback
+  (additive keyword) so a caller can correlate the emitted decision-ref with a
+  settlement observed later, without the pipeline holding per-payment state that
+  concurrent calls would race on.
+- `PaymentProtocolBinding` gains an *optional*, duck-typed
+  `settlement_receipt(headers)` method. The gateway probes for it with `getattr`
+  and skips capture when absent, so third-party bindings keep working unchanged.
+
 ### Fixed
 - **Replay-fingerprint collision on high-precision amounts.** `_canonical_amount`
   stripped trailing zeros with `Decimal.normalize()`, a *context* operation bounded

--- a/README.md
+++ b/README.md
@@ -419,6 +419,49 @@ format and `decision_ref` derivation are pinned by the conformance fixture under
 `tests/conformance/decision-ref/` and the design note
 `plan/presidio-evidence-decision-ref-design.md`.
 
+## Treasury binding (`settlement-ref@1`) — v0.10.0
+
+A decision-ref says *why* a payment was allowed. Reconciling it into a ledger's
+close also needs *which settlement it authorized* — and the shipped
+`payment-decision@1` record carries no transaction hash. **`settlement-ref@1`** is
+that join: a signed, off-chain statement, under the same policy signer, committing
+to `{decision_ref, chain (CAIP-2), tx_hash, block_number, log_index}`.
+
+```python
+from presidio_x402 import FileSettlementWriter, HardenedX402Client
+
+client = HardenedX402Client(
+    payment_signer=signer,
+    decision_ref_emitter=emitter,                       # as above
+    settlement_writer=FileSettlementWriter("settlements.jsonl"),
+)
+# The paid response's PAYMENT-RESPONSE echo is parsed and correlated with this
+# payment's decision_ref. It carries the tx hash and network — NOT a block number
+# or log index, so the record is written with "complete": false and those two
+# fields are completed by the operator from a chain lookup.
+```
+
+```bash
+python -m presidio_x402.treasury_binding export decision.json \
+    --settlement settle.json --trust trust.json --key-file policy.key > bundle.json
+python -m presidio_x402.treasury_binding verify bundle.json trust.json   # exit 0 iff verified
+```
+
+Export is fail-closed: it re-runs the full decision-ref verification (signature
+included — which is why `--trust` is required) and refuses a non-verifying
+envelope, a non-terminal `REFER` verdict, an out-of-bound identity string, or a
+join signed by an identity other than the decision's own signer. The bundle
+carries **no key material**: `trust_store_ref` names the signer and key id, and
+the verifier resolves both against its own pinned store — a bundle-supplied key
+would make verification trust-on-first-use.
+
+**Honest bound.** This is an off-chain join, not an on-chain anchor: an ERC-3009
+settlement's calldata carries no decision digest, so there is nothing on chain to
+check it against. It asserts only what the signer can — *this decision, that
+transaction, signed*. Bundle shape, ingest contract and residual risks:
+[`docs/treasury-binding.md`](docs/treasury-binding.md); the cross-language byte
+contract: `tests/conformance/treasury-binding/`.
+
 ### Provisioning Metadata Redaction
 
 Capacity-upgrade requests can reveal workload type, data classification, or access pattern.
@@ -482,6 +525,7 @@ All exceptions are importable from `presidio_x402`.
 | v0.8.0 | PII completeness + supply-chain hardening (library) — `nlp` mode is now a structural superset of `regex` (no structured-identifier misses) · composed-envelope `screen_ref` leg · `action_ref` byte-determinism (NFC + non-empty entity sets) · URL-redacted log hygiene · OpenSSF Scorecard workflow/badge + SLSA Build L3 provenance · independent multi-round security audit cleared |
 | **v0.9.1** | **Security patch** — dependency-audit floors for `click` / `setuptools`, missing-payment-header log exposure hardening, and `setup-uv` v8.3.2 CI action pin — **latest release** |
 | v0.9.0 | Proof-carrying x402 evidence — `capability-grant@1` attenuable spending grants + opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records |
+| v0.10.0 | **Treasury binding** — `settlement-ref@1` signed off-chain join record + fail-closed bundle export/verify CLI · client-side settlement-receipt capture · caller-identity value bounds · cross-language conformance vectors (non-ASCII escaping, lone surrogates, non-string keys, `i64` bounds, depth 128/129) |
 | Future | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
 
 ### Planned direction (next 12 months)

--- a/docs/treasury-binding.md
+++ b/docs/treasury-binding.md
@@ -152,7 +152,15 @@ python -m presidio_x402.treasury_binding verify bundle.json trust.json   # exit 
 
 Exit 0 verified, 1 fail-closed with a distinct reason, 2 usage error. Layers, in
 order, first failure wins: `structure → decision → terminal → identity →
-settlement → signer`.
+settlement → signer → summary`.
+
+The last layer is worth naming. The bundle's top-level `decision_ref`,
+`settlement_ref`, `settlement_key` and `verdict` are a convenience mirror of what
+the envelopes already prove, and verification never *reads* them — every value it
+reports is re-derived. But a consumer enforcing uniqueness reads
+`settlement_key`, so a mirror that can disagree with what it mirrors is a trap:
+swap in a settlement-ref for a different transaction and the stale key still
+names the old one. Disagreement is therefore a rejection, not a warning.
 
 ## Privacy bound, stated honestly
 

--- a/docs/treasury-binding.md
+++ b/docs/treasury-binding.md
@@ -88,6 +88,20 @@ that stops one settled payment from being counted into two closes.
 transaction hash, and including it would let a wrong-but-plausible height mint a
 second distinct key for one settlement.
 
+**The uniqueness invariant is the consumer's to enforce, and the key is only as
+trustworthy as `log_index`.** x402 does not — and cannot — enforce
+one-settlement-one-leg: that check lives in the treasury ledger
+(`presidio-hardened-treasury#49`, still pending, hence `treasury-ingest-pending`).
+And `log_index` is an *operator-supplied* fact — the on-wire settlement receipt
+carries only the transaction hash and network, not the log index — so a producer
+who is themselves inside the threat model (the operator, per the plan's L-layer
+mapping) can emit two valid bundles for one on-chain settlement under two
+different `log_index` values. The signature binds the *decision↔settlement*
+assertion; it does **not** attest that `log_index` is the real chain log index.
+A consuming ledger must therefore corroborate `log_index` against its own
+independent chain observation before treating the key as unique — never on the
+bundle's word alone. (Threat T-TB-2.)
+
 ## Producing a bundle
 
 ### 1. Capture the settlement facts

--- a/docs/treasury-binding.md
+++ b/docs/treasury-binding.md
@@ -1,0 +1,218 @@
+# Treasury binding — bundle shape and ingest contract
+
+How one x402 payment becomes something a ledger can reconcile into an
+audit-grade close: the signed record of *why* the payment was allowed, joined to
+the on-chain settlement that moved the money, both verifiable offline against a
+pinned trust store.
+
+Introduced in v0.10.0. The producing side is entirely in this repository; the
+consuming side is a companion change in the ledger repository and is **not
+merged yet**, so a bundle is marked `"ingest_status": "treasury-ingest-pending"`
+until that surface is agreed.
+
+## The two artifacts and the join
+
+```
+payment-decision@1   (v0.9.0)    "the library concluded ALLOW under predicate P"
+        │  decision_ref
+        ▼
+settlement-ref@1     (v0.10.0)   "that decision authorized THIS settlement"
+        │  chain + tx_hash + block_number + log_index
+        ▼
+the L1 chain observation the ledger ingests independently
+```
+
+`settlement-ref@1` commits to exactly five values:
+
+```json
+{
+  "schema": "presidio-hardened-x402/settlement-ref@1",
+  "issued_at": "2026-07-26T12:00:00.000Z",
+  "decision_ref": "<64 hex>",
+  "settlement": {
+    "block_number": 19284411,
+    "chain": "eip155:84532",
+    "log_index": 7,
+    "tx_hash": "0x…"
+  }
+}
+```
+
+…signed into the family `presidio-hardened/evidence-ref@1` envelope with the
+same primitives as the decision-ref, so one verifier handles both.
+
+### What the join is not
+
+It is **not** an on-chain anchor. An x402 payment settles via ERC-3009
+`transferWithAuthorization`, whose calldata carries no decision digest — there is
+nothing on chain to check a `calldata_digest` against. And if the committed
+`tx_hash` *is* the settlement, a "decision precedes settlement" timestamp check
+compares a value with itself. Rather than ship two fields that assert what they
+cannot prove, the record asserts only what the signer can: *this decision, that
+transaction, signed*. The auditor already trusts that signer for the decision;
+the join rides the same trust, and being signed is what lets a consumer reject a
+forged or swapped join at its boundary.
+
+The strictly stronger alternative — a pre-settlement commitment transaction
+carrying `sha256(decision_ref)`, making the join on-chain rather than
+signer-asserted — costs an extra chain transaction on every payment and changes
+the settle path. It is deferred as an opt-in "strong anchor" mode, not
+abandoned.
+
+## Bundle shape
+
+```json
+{
+  "schema": "presidio-hardened-x402/treasury-bundle@1",
+  "generated_at": "…", "source_version": "0.10.0",
+  "decision_ref": "<64 hex>", "settlement_ref": "<64 hex>",
+  "settlement_key": "eip155:84532|0x…|7",
+  "verdict": "ALLOW",
+  "decision_ref_envelope": { "…evidence-ref@1…" },
+  "settlement_ref_envelope": { "…evidence-ref@1…" },
+  "trust_store_ref": { "signer": "presidio-hardened-x402-policy",
+                       "algorithm": "ed25519", "key_id": "…" },
+  "ingest_status": "treasury-ingest-pending"
+}
+```
+
+**No key material travels in the bundle, by design.** `trust_store_ref` *names*
+the signer and key id; it never carries the public key. A bundle-supplied key
+would make verification trust-on-first-use and defeat the pin it exists to
+enforce. The consumer resolves the signer against its own store or rejects.
+
+`settlement_key` is `chain|tx_hash|log_index`. It is the value a ledger enforces
+"at most one settlement-ref per (period, key)" on — the uniqueness invariant
+that stops one settled payment from being counted into two closes.
+`block_number` is deliberately *not* part of the key: it is implied by the
+transaction hash, and including it would let a wrong-but-plausible height mint a
+second distinct key for one settlement.
+
+## Producing a bundle
+
+### 1. Capture the settlement facts
+
+```python
+from presidio_x402 import FileSettlementWriter, HardenedX402Client
+from presidio_x402.decision_ref import DecisionRefEmitter
+
+client = HardenedX402Client(
+    payment_signer=my_signer,
+    decision_ref_emitter=DecisionRefEmitter(signing_key=policy_key),
+    settlement_writer=FileSettlementWriter("settlements.jsonl"),
+)
+```
+
+The client parses the settlement echo (`PAYMENT-RESPONSE`,
+`X-PAYMENT-RESPONSE`, or `X-PAYMENT-RECEIPT`) on the paid response and writes one
+`settlement-facts@1` record per payment, correlated with that payment's
+`decision_ref`. Capture is strictly observational: it runs after the paid
+response is in hand, performs no network I/O, and cannot change a payment
+outcome.
+
+**The echo carries the transaction hash and the network — not a block number and
+not a log index.** Those two fields come back `null`, and the record says
+`"complete": false`. Completing them is an operator step:
+
+```bash
+# look the transaction up on the chain / your indexer, then fill in:
+#   "block_number": 19284411,
+#   "log_index": 7
+```
+
+They are required rather than optional because without a log index there is no
+key on which the ledger can enforce one-settlement-one-leg.
+
+### 2. Export
+
+```bash
+python -m presidio_x402.treasury_binding export decision.json \
+    --settlement settle.json --trust trust.json --key-file policy.key > bundle.json
+```
+
+The signing key is read from `--key-file` or `PRESIDIO_X402_EVIDENCE_KEY`, never
+from a command-line argument — a key in `argv` is visible in `ps` output to
+every user on the host.
+
+Export **refuses**, with a distinct error each time, when:
+
+| refusal | why |
+|---|---|
+| the decision-ref does not verify | every layer, signature included. A bundle whose signature was never checked is not evidence of anything — which is why `--trust` is required, not optional |
+| the verdict is `REFER` | an unresolved quorum is an interim state; export the terminal decision that supersedes it. `DENY` **is** exportable on purpose: a settlement that happened despite a DENY is the anomaly an auditor most needs to see |
+| an identity string is out of bounds | see below |
+| the settlement facts are out of domain | non-CAIP-2 chain, malformed transaction hash, index past `i64::MAX`, missing block/log index |
+| the join would be signed by another identity | the join is the *decision signer's* assertion. Otherwise any trust-store member could re-point any decision at any transaction |
+
+### 3. Verify (anyone, offline)
+
+```bash
+python -m presidio_x402.treasury_binding verify bundle.json trust.json   # exit 0 iff verified
+```
+
+Exit 0 verified, 1 fail-closed with a distinct reason, 2 usage error. Layers, in
+order, first failure wins: `structure → decision → terminal → identity →
+settlement → signer`.
+
+## Privacy bound, stated honestly
+
+The `controls{}` block of a decision-ref is *structurally* PII-free: every value
+is a hash, an entity-type label, an enum verdict, or a boolean, and there is no
+field that accepts a raw string.
+
+The top-level identity fields are **not**. `agent_id`, `pay_to`,
+`resource_origin` and `mpa.approval_refs` are caller-supplied strings, and a
+wallet address is pseudonymous personal data to a GDPR-minded auditor. They are
+present by design — a ledger cannot reconcile an anonymous payment — so the
+mitigation is a **value bound**, not a claim that no free text can appear:
+
+- length: `agent_id` ≤ 256, `pay_to` ≤ 128, `resource_origin` ≤ 256,
+  `approval_refs` ≤ 32 entries of ≤ 512 characters;
+- charset: no control, format, surrogate, private-use or unassigned code point.
+  A Cyrillic or CJK agent id is legitimate; a bidi override in an auditor's
+  disclosure pack is not.
+
+The bound is applied on **both** paths — a bundle from an older or laxer
+producer still fails on read. The settlement facts deliberately exclude the payer
+address even though the receipt carries it: the join needs the transaction, not
+the counterparty.
+
+## Ingest contract (for the consuming side)
+
+1. **Verify before storing.** Resolve `trust_store_ref.signer` against your own
+   pinned store, deny by default on an unknown signer. Nothing enters an evidence
+   store before its signature verifies.
+2. **Run the full decision semantics, not just the signature.** Recompute
+   `verdict == f(controls)` and re-apply the admission check (`signer` must not be
+   one of the actor's controllers). A signature-only verifier admits both of the
+   negatives shipped in the conformance vectors.
+3. **Enforce uniqueness on `settlement_key`.** At most one settlement-ref per
+   (period, key). Content-addressed storage does *not* give you this for free —
+   two refs differing only in `issued_at` are distinct blobs.
+4. **Treat the decision-ref as classification evidence feeding dual control,
+   never as a control in its own right.** It proves what the library concluded
+   under a *declared* predicate; it cannot prove the predicate was the real one,
+   and it cannot manufacture a settlement that did not happen. The chain
+   observation is independent evidence and the classification remains the
+   consumer's own judgment.
+5. **Bound the inbound volume.** Valid-but-irrelevant bundles are an
+   availability problem: evidence should be pulled for a settlement leg already
+   being classified, not pushed into a close.
+
+## Residual risks
+
+- **Stolen signer key.** Signature verification does not cover it. Mitigation is
+  operational: `key_id` pinning with a revocation path, short signer epochs, and
+  the fact that a full-semantics consumer still requires an independent L1
+  settlement to corroborate amount and counterparty.
+- **Cryptographically valid, semantically false verdict.** A record whose
+  `controls` were fabricated signs and recomputes correctly. This is the honesty
+  bound of the whole scheme; containment, not elimination, is the answer — see
+  ingest contract point 4.
+
+## See also
+
+- `tests/conformance/treasury-binding/README.md` — the cross-language vector set
+  and what each axis is actually at risk of.
+- `presidio_x402.decision_ref` — the `payment-decision@1` producer/verifier this
+  builds on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.9.1"
+version = "0.10.0"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -95,8 +95,18 @@ from .slo_broker import (
     X402CapacityProvider,
 )
 from .slo_policy import SLOPaymentPolicy
+from .treasury_binding import (
+    SETTLEMENT_REF_SCHEMA_ID,
+    TREASURY_BUNDLE_SCHEMA_ID,
+    FileSettlementWriter,
+    NullSettlementWriter,
+    SettlementFacts,
+    TreasuryBindingError,
+    export_bundle,
+    verify_bundle,
+)
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"
 __all__ = [
     # Primary public API
     "HardenedX402Client",
@@ -134,6 +144,15 @@ __all__ = [
     "verify_decision_ref",
     "f_controls",
     "PAYMENT_DECISION_SCHEMA_ID",
+    # Treasury binding (settlement-ref@1 + treasury-bundle@1) — v0.10.0
+    "SettlementFacts",
+    "export_bundle",
+    "verify_bundle",
+    "TreasuryBindingError",
+    "NullSettlementWriter",
+    "FileSettlementWriter",
+    "SETTLEMENT_REF_SCHEMA_ID",
+    "TREASURY_BUNDLE_SCHEMA_ID",
     # Multi-party authorization
     "MPAConfig",
     "MPAApproverConfig",

--- a/src/presidio_x402/_types.py
+++ b/src/presidio_x402/_types.py
@@ -55,6 +55,71 @@ class PaymentResponse:
     """The payment details that were signed."""
 
 
+@dataclass(frozen=True)
+class SettlementReceipt:
+    """On-chain settlement facts observed by the *client* after a paid retry.
+
+    The x402 settlement is executed by the facilitator on the payee side; the
+    paying client only ever sees what the resource server echoes back on the
+    paid response (``PAYMENT-RESPONSE`` / ``X-PAYMENT-RESPONSE`` /
+    ``X-PAYMENT-RECEIPT``). That echo carries the transaction hash and the
+    network — it does **not** carry a block number or a log index, so those two
+    fields are ``None`` unless the server volunteered them.
+
+    This is the honest half of the correlation input: everything here was
+    observed on the wire. Completing :attr:`block_number` and :attr:`log_index`
+    is an operator step (a chain/indexer lookup keyed by :attr:`tx_hash`) — see
+    :mod:`presidio_x402.treasury_binding`, which requires the completed tuple
+    before it will sign a ``settlement-ref@1``.
+    """
+
+    network: str
+    """The rail's own network identifier, verbatim as observed (e.g. ``"base-sepolia"``)."""
+
+    chain: str | None = None
+    """CAIP-2 chain id (e.g. ``"eip155:84532"``), or ``None`` if unmappable."""
+
+    tx_hash: str | None = None
+    """Settlement transaction hash, verbatim as observed."""
+
+    block_number: int | None = None
+    """Block height — ``None`` unless the server volunteered it (usually it does not)."""
+
+    log_index: int | None = None
+    """Transfer-log index within the block — ``None`` unless volunteered."""
+
+    payer: str | None = None
+    """Payer address as reported by the facilitator (may be absent)."""
+
+    success: bool = False
+    """The facilitator's own settlement outcome flag. ``False`` is not an error
+    here — an unsuccessful settlement is a fact worth recording."""
+
+    observed_at: str = ""
+    """RFC3339 UTC timestamp at which the client parsed the receipt."""
+
+    receipt_hash: str | None = None
+    """``sha256:<64hex>`` over the raw receipt header bytes, binding these parsed
+    facts to the exact transport bytes they came from (the header itself is not
+    retained: it can carry a payer address and is therefore PII-adjacent)."""
+
+    @property
+    def is_complete(self) -> bool:
+        """True iff this receipt alone identifies a settlement log entry.
+
+        The ``(chain, tx_hash, block_number, log_index)`` tuple is what a
+        downstream ledger needs to enforce "one settlement → one leg"; a receipt
+        that lacks any part of it must be completed by the operator before it can
+        be committed to.
+        """
+        return (
+            bool(self.chain)
+            and bool(self.tx_hash)
+            and self.block_number is not None
+            and self.log_index is not None
+        )
+
+
 @dataclass
 class AuditEvent:
     """A single audit log entry for a payment attempt."""
@@ -142,3 +207,9 @@ class PaymentProtocolBinding(Protocol):
     def token_headers(self, token: str) -> dict[str, str]:
         """Headers carrying the signed payment token on the retried request."""
         ...
+
+    # Optional (duck-typed, not part of the required surface): a binding MAY also
+    # implement ``settlement_receipt(headers) -> SettlementReceipt | None`` to
+    # expose the rail's settlement echo on the paid response. The gateway probes
+    # for it with ``getattr`` and skips capture when absent, so third-party
+    # bindings written against the pre-v0.10.0 protocol keep working unchanged.

--- a/src/presidio_x402/bindings/x402.py
+++ b/src/presidio_x402/bindings/x402.py
@@ -15,13 +15,56 @@ are unchanged.
 
 from __future__ import annotations
 
+import base64
+import binascii
+import contextlib
+import hashlib
 import json
+import logging
+from datetime import datetime, timezone
 
-from .._types import PaymentDetails
+from .._types import PaymentDetails, SettlementReceipt
 from ..exceptions import X402PaymentError
+
+logger = logging.getLogger("presidio_x402.bindings.x402")
 
 # Header name per x402 spec.
 HEADER_PAYMENT = "X-PAYMENT"
+
+#: Headers a resource server may echo the settlement outcome back on, most
+#: current first: ``PAYMENT-RESPONSE`` is the Coinbase x402 v2 spelling,
+#: ``X-PAYMENT-RESPONSE`` the v1 one, and ``X-PAYMENT-RECEIPT`` the name this
+#: library's own flow documentation has used since v0.1.0. All three carry the
+#: same payload shape, so all three are accepted on the read path (Postel on the
+#: receipt channel only — the *offer* channel stays strict).
+SETTLEMENT_RECEIPT_HEADERS = ("PAYMENT-RESPONSE", "X-PAYMENT-RESPONSE", "X-PAYMENT-RECEIPT")
+
+#: Max byte length of a settlement-receipt header before decoding. Same rationale
+#: as :data:`PAYMENT_HEADER_MAX_BYTES`, an order of magnitude tighter: the
+#: settle response is four short fields.
+SETTLEMENT_RECEIPT_MAX_BYTES = 8_192
+
+#: x402 rail network names → CAIP-2 chain ids. Deliberately small and explicit:
+#: an unmapped network yields ``chain=None`` (the raw name is still recorded) so
+#: the operator supplies the chain id rather than the library guessing one. A
+#: wrong chain id would silently correlate a decision to a transaction on another
+#: chain, which is worse than no chain id at all. Values already in CAIP-2 form
+#: (x402 v2 uses them natively) pass through unchanged.
+_CAIP2_BY_NETWORK = {
+    "base": "eip155:8453",
+    "base-mainnet": "eip155:8453",
+    "base-sepolia": "eip155:84532",
+    "ethereum": "eip155:1",
+    "ethereum-mainnet": "eip155:1",
+    "ethereum-sepolia": "eip155:11155111",
+    "sepolia": "eip155:11155111",
+    "polygon": "eip155:137",
+    "polygon-mainnet": "eip155:137",
+    "polygon-amoy": "eip155:80002",
+    "avalanche": "eip155:43114",
+    "avalanche-fuji": "eip155:43113",
+    "iotex": "eip155:4689",
+}
 
 # Supported x402 scheme (since v0.1.0).
 SUPPORTED_SCHEME = "exact"
@@ -110,6 +153,117 @@ def parse_402_header(header_value: str) -> PaymentDetails:
         raise X402PaymentError("Missing required field in X-PAYMENT entry") from None
 
 
+def caip2_for_network(network: str) -> str | None:
+    """Map an x402 network identifier to a CAIP-2 chain id, or ``None``.
+
+    Pass-through for values already in CAIP-2 form (``namespace:reference``,
+    per CAIP-2's own grammar), table lookup for the rail's short names, and
+    ``None`` for anything else — never a guess. ``None`` is a well-formed
+    outcome: the caller records the raw network string and the operator
+    supplies the chain id.
+    """
+    if not isinstance(network, str) or not network:
+        return None
+    candidate = network.strip()
+    namespace, sep, reference = candidate.partition(":")
+    if sep and _is_caip2(namespace, reference):
+        return candidate
+    return _CAIP2_BY_NETWORK.get(candidate.lower())
+
+
+def _is_caip2(namespace: str, reference: str) -> bool:
+    """CAIP-2 grammar: ``[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}``."""
+    return (
+        3 <= len(namespace) <= 8
+        and all(c.isdigit() or c.islower() or c == "-" for c in namespace)
+        and namespace.isascii()
+        and 1 <= len(reference) <= 32
+        and reference.isascii()
+        and all(c.isalnum() or c in "-_" for c in reference)
+    )
+
+
+def _coerce_index(value: object) -> int | None:
+    """A non-negative block height / log index, or ``None``.
+
+    ``bool`` is excluded explicitly (it is an ``int`` subclass, and ``True`` is
+    not a block number). A float is refused rather than truncated.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def parse_settlement_receipt(raw: str | bytes) -> SettlementReceipt | None:
+    """Parse an x402 settlement echo into rail-agnostic facts, or ``None``.
+
+    The payload is the facilitator's settle response, base64-encoded (the x402
+    convention) or bare JSON::
+
+        {"success": true, "transaction": "0x…", "network": "base-sepolia", "payer": "0x…"}
+
+    **Never raises and never affects the payment.** The paid response has already
+    been received by the time this runs; a hostile or broken server must not be
+    able to turn a successful payment into an exception, so every failure path
+    returns ``None``. ``block_number``/``log_index`` are read only if the server
+    volunteered them (most do not) — see :class:`~presidio_x402._types.SettlementReceipt`.
+    """
+    try:
+        raw_bytes = raw.encode("utf-8") if isinstance(raw, str) else bytes(raw)
+    except UnicodeEncodeError:
+        return None
+    if not raw_bytes or len(raw_bytes) > SETTLEMENT_RECEIPT_MAX_BYTES:
+        return None
+
+    data = _decode_receipt_payload(raw_bytes)
+    if data is None:
+        return None
+
+    network = data.get("network")
+    network = network.strip() if isinstance(network, str) else ""
+    tx_hash = data.get("transaction")
+    if not isinstance(tx_hash, str) or not tx_hash:
+        tx_hash = data.get("txHash") if isinstance(data.get("txHash"), str) else None
+    payer = data.get("payer") if isinstance(data.get("payer"), str) else None
+    block_number = _coerce_index(data.get("blockNumber", data.get("block_number")))
+    log_index = _coerce_index(data.get("logIndex", data.get("log_index")))
+
+    if not network and not tx_hash:
+        # Nothing correlatable was echoed — treat as "no receipt" rather than
+        # manufacturing an empty one.
+        return None
+
+    return SettlementReceipt(
+        network=network,
+        chain=caip2_for_network(network),
+        tx_hash=tx_hash or None,
+        block_number=block_number,
+        log_index=log_index,
+        payer=payer,
+        success=data.get("success") is True,
+        observed_at=datetime.now(tz=timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z"),
+        receipt_hash="sha256:" + hashlib.sha256(raw_bytes).hexdigest(),
+    )
+
+
+def _decode_receipt_payload(raw_bytes: bytes) -> dict | None:
+    """Base64-then-JSON, falling back to bare JSON. ``None`` on anything else."""
+    candidates: list[bytes] = []
+    with contextlib.suppress(binascii.Error, ValueError):
+        candidates.append(base64.b64decode(raw_bytes, validate=True))
+    candidates.append(raw_bytes)
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError, RecursionError, UnicodeDecodeError):
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
 class X402Binding:
     """The reference :class:`~presidio_x402._types.PaymentProtocolBinding`.
 
@@ -144,3 +298,40 @@ class X402Binding:
     def token_headers(self, token: str) -> dict[str, str]:
         """Headers carrying the signed payment token on the retried request."""
         return {self.header_name: token}
+
+    def settlement_receipt(self, headers: object) -> SettlementReceipt | None:
+        """Settlement facts echoed on the paid response, or ``None``.
+
+        Optional protocol extension (v0.10.0): the gateway probes for this method
+        with ``getattr`` and skips capture when a binding does not implement it.
+        Reads transport bytes via ``headers.raw`` when the client retained them,
+        so :attr:`~presidio_x402._types.SettlementReceipt.receipt_hash` binds the
+        parsed facts to the bytes actually received rather than to a re-encoding.
+        """
+        get = getattr(headers, "get", None)
+        if get is None:
+            return None
+        for name in SETTLEMENT_RECEIPT_HEADERS:
+            raw = _raw_header_value(headers, name)
+            if raw is None:
+                value = get(name)
+                if not isinstance(value, str) or not value:
+                    continue
+                raw = value
+            receipt = parse_settlement_receipt(raw)
+            if receipt is not None:
+                return receipt
+            logger.debug("settlement receipt header %s present but unparseable", name)
+        return None
+
+
+def _raw_header_value(headers: object, name: str) -> bytes | None:
+    """One header's transport bytes, when the HTTP client retained them."""
+    raw_pairs = getattr(headers, "raw", None)
+    if not raw_pairs:
+        return None
+    target = name.lower().encode("ascii")
+    for raw_name, raw_value in raw_pairs:
+        if bytes(raw_name).lower() == target:
+            return bytes(raw_value)
+    return None

--- a/src/presidio_x402/capability.py
+++ b/src/presidio_x402/capability.py
@@ -111,7 +111,7 @@ def _amount_decimal(value: object, field_name: str) -> Decimal:
     Integer inputs are interpreted as micro-USD (1e-6 USD) so a caveat can be
     expressed in atomic units without a float ever entering the wire form. A
     string is a plain decimal USD amount (``"0.05"``). This mirrors the
-    family float rule (``mica._reject_floats``) and ``policy_engine._decimal_usd``.
+    family float rule (``mica._reject_uncanonicalisable``) and ``policy_engine._decimal_usd``.
     """
     if isinstance(value, bool):  # bool is an int subclass — never an amount
         raise CapabilityError(f"{field_name} must not be a boolean")

--- a/src/presidio_x402/core.py
+++ b/src/presidio_x402/core.py
@@ -36,6 +36,8 @@ from .replay_guard import ReplayGuard, compute_fingerprint
 from .telemetry import security_control_span, set_span_attribute
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from ._types import PaymentDetails
     from .audit_log import AuditLog
     from .capability import VerifiedGrantChain
@@ -166,6 +168,7 @@ class ScreeningPipeline:
         *,
         mpa_signatures: dict[str, str] | None = None,
         raw_offer_hash: str | None = None,
+        on_decision_ref: Callable[[Mapping[str, object]], None] | None = None,
     ) -> tuple[PaymentDetails, str]:
         """Apply PIIFilter → PolicyEngine → ReplayGuard → MPAEngine → AuditLog.
 
@@ -174,6 +177,15 @@ class ScreeningPipeline:
         metadata fields if ``pii_action="redact"``, plus the replay fingerprint
         recorded for this payment so the caller can roll it back if signing
         fails.
+
+        ``on_decision_ref``, when given, is called once with the emitted
+        decision-ref envelope (nothing is called if emission is disabled or
+        fails). It exists so a caller can correlate *this* payment's decision-ref
+        with the settlement receipt it later observes, without the pipeline
+        holding per-payment state that concurrent calls would race on — the
+        caller's closure owns the value. Like the emitter itself it must not
+        perform network I/O and must not raise; a raising callback is caught and
+        logged with the emission.
 
         Raises on policy violation, replay, PII block, or MPA denial/timeout.
         On MPA denial/timeout the spend + replay commit is rolled back before
@@ -489,7 +501,12 @@ class ScreeningPipeline:
         # Emit the signed payment-decision@1 record immediately before returning
         # to the caller, which signs next. No network I/O on this path.
         if self._decision_emitter is not None and decision_controls is not None:
-            self._emit_decision_ref(details, decision_controls, raw_offer_hash=raw_offer_hash)
+            self._emit_decision_ref(
+                details,
+                decision_controls,
+                raw_offer_hash=raw_offer_hash,
+                on_decision_ref=on_decision_ref,
+            )
 
         return details, fingerprint
 
@@ -499,6 +516,7 @@ class ScreeningPipeline:
         controls: object,
         *,
         raw_offer_hash: str | None = None,
+        on_decision_ref: Callable[[Mapping[str, object]], None] | None = None,
     ) -> None:
         """Build and write one payment-decision@1 record (opt-in path only).
 
@@ -516,7 +534,7 @@ class ScreeningPipeline:
                 currency=details.currency,
                 network=details.network,
             )
-            self._decision_emitter.emit(  # type: ignore[union-attr]
+            envelope = self._decision_emitter.emit(  # type: ignore[union-attr]
                 agent_id=self._agent_id or "",
                 payment_signer=details.pay_to,
                 network=details.network,
@@ -531,5 +549,7 @@ class ScreeningPipeline:
                 controls=controls,  # type: ignore[arg-type]
                 parents=capability_parents(self._capability_chain),
             )
+            if on_decision_ref is not None:
+                on_decision_ref(envelope)
         except Exception:
             logger.exception("decision-ref emission failed (payment outcome unaffected)")

--- a/src/presidio_x402/gateway.py
+++ b/src/presidio_x402/gateway.py
@@ -73,6 +73,8 @@ from .policy_engine import PolicyConfig, PolicyEngine
 from .replay_guard import ReplayGuard
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from ._types import (
         AuditWriter,
         PaymentDetails,
@@ -85,6 +87,7 @@ if TYPE_CHECKING:
     from .metrics import MetricsCollector
     from .mpa import MPAEngine
     from .screening_client import ScreeningClient
+    from .treasury_binding import SettlementWriter
 
 logger = logging.getLogger("presidio_x402.gateway")
 
@@ -103,6 +106,23 @@ _parse_402_header = parse_402_header
 _amount_to_usd = amount_to_usd
 _safe_exc_message = safe_exc_message
 _resource_origin = resource_origin
+
+
+def _decision_ref_collector(sink: list[str]) -> Callable[[Mapping[str, object]], None]:
+    """A request-local callback that records the emitted ``decision_ref``.
+
+    Deliberately a closure over a caller-owned list rather than state on the
+    client: one :class:`HardenedX402Client` serves many concurrent requests, and
+    a shared "last decision-ref" attribute would let request A's settlement
+    receipt be signed against request B's decision.
+    """
+
+    def collect(envelope: Mapping[str, object]) -> None:
+        ref = envelope.get("decision_ref")
+        if isinstance(ref, str) and ref:
+            sink.append(ref)
+
+    return collect
 
 
 def _raw_header_bytes(headers: httpx.Headers, header_name: str) -> bytes | None:
@@ -201,6 +221,16 @@ class HardenedX402Client:
         When the spending policy was projected from a capability chain, pass it so
         the emitted decision-ref links the chain's terminal ``grant_hash`` as a
         provenance parent (does nothing unless ``decision_ref_emitter`` is set).
+    settlement_writer:
+        Optional :class:`~presidio_x402.treasury_binding.SettlementWriter`. When
+        set, the settlement facts the resource server echoes on the paid response
+        (``PAYMENT-RESPONSE``/``X-PAYMENT-RESPONSE``/``X-PAYMENT-RECEIPT``) are
+        parsed and written out, correlated with this payment's ``decision_ref``
+        when a ``decision_ref_emitter`` is also configured. That record is the
+        input to ``python -m presidio_x402.treasury_binding export``. ``None``
+        (default) skips capture entirely. Capture is strictly observational: it
+        runs *after* the paid response is in hand, performs no network I/O, and
+        can never change the payment outcome.
     """
 
     def __init__(
@@ -224,6 +254,7 @@ class HardenedX402Client:
         binding: PaymentProtocolBinding | None = None,
         decision_ref_emitter: DecisionRefEmitter | None = None,
         capability_chain: VerifiedGrantChain | None = None,
+        settlement_writer: SettlementWriter | None = None,
     ) -> None:
         if remote_screening and screening_client is None:
             raise ValueError("remote_screening=True requires a screening_client instance")
@@ -241,6 +272,7 @@ class HardenedX402Client:
         self._mpa = mpa_engine
         self._metrics = metrics_collector
         self._binding = binding or X402Binding()
+        self._settlement_writer = settlement_writer
         # Store allowlisted wallet addresses lower-cased: EVM addresses are
         # case-insensitive (EIP-55 checksum casing is optional), so comparing
         # verbatim would reject a valid checksummed/lower-case variant and cause
@@ -346,10 +378,19 @@ class HardenedX402Client:
 
         # Apply security controls; get (possibly modified) details + the replay
         # fingerprint back so a signing failure can roll the commit back.
+        # The decision-ref of *this* payment is captured into a request-local
+        # closure (never onto self) so concurrent requests through one client
+        # cannot correlate a settlement receipt with each other's decision.
+        decision_refs: list[str] = []
         secure_details, fingerprint = await self._pipeline.apply(
             details,
             mpa_signatures=mpa_signatures,
             raw_offer_hash=raw_offer_hash,
+            on_decision_ref=(
+                _decision_ref_collector(decision_refs)
+                if self._settlement_writer is not None
+                else None
+            ),
         )
 
         # Sign and retry
@@ -388,6 +429,11 @@ class HardenedX402Client:
         kwargs["headers"] = headers
         resp = await self._httpx.request(method, url, **kwargs)
 
+        # Observational only, strictly after the paid response: capture the
+        # settlement echo and correlate it with this payment's decision-ref.
+        if self._settlement_writer is not None:
+            self._record_settlement(resp.headers, decision_refs[0] if decision_refs else None)
+
         paid_usd = amount_to_usd(secure_details.amount, secure_details.currency)
         self._audit.emit(
             "PAYMENT_ALLOWED",
@@ -412,6 +458,29 @@ class HardenedX402Client:
 
     async def aclose(self) -> None:
         await self._httpx.aclose()
+
+    def _record_settlement(self, headers: httpx.Headers, decision_ref: str | None) -> None:
+        """Parse the settlement echo and hand it to the configured writer.
+
+        Best-effort by contract, exactly like decision-ref emission: the payment
+        has already completed, so a malformed receipt, an exotic binding, or a
+        writer that raises must never turn a successful payment into an
+        exception. The failure is logged and the response is returned unchanged.
+        """
+        try:
+            capture = getattr(self._binding, "settlement_receipt", None)
+            if capture is None:
+                return
+            receipt = capture(headers)
+            if receipt is None:
+                return
+            from .treasury_binding import settlement_facts_record
+
+            self._settlement_writer.write(  # type: ignore[union-attr]
+                settlement_facts_record(receipt, decision_ref=decision_ref)
+            )
+        except Exception:
+            logger.exception("settlement receipt capture failed (payment outcome unaffected)")
 
     async def _invoke_signer(self, details: PaymentDetails) -> PaymentResponse:
         """Call the signer, supporting both callables and objects with a ``sign`` method."""

--- a/src/presidio_x402/mica.py
+++ b/src/presidio_x402/mica.py
@@ -70,35 +70,68 @@ class EvidenceError(X402Error):
 # ---------------------------------------------------------------------------
 
 
-def _reject_floats(payload: object) -> None:
-    """Strict-profile guard (ADR-0001 D1): floats are non-deterministic across
-    encoders, so a hash over them is not portable between the family producers.
-    Reject any float anywhere in the structure rather than emit an unverifiable
-    ``content_hash``. ``bool`` is an ``int`` subclass and is allowed."""
+def _reject_uncanonicalisable(payload: object) -> None:
+    """Strict-profile domain guard (ADR-0001 D1) — one walk, fail-closed.
+
+    Rejects the two structural inputs that would otherwise produce bytes a
+    sibling family implementation cannot reproduce:
+
+    * **floats** — non-deterministic across encoders, so a hash over them is not
+      portable between the family producers. ``bool`` is an ``int`` subclass and
+      is allowed.
+    * **non-string object keys** — ``json.dumps`` sorts integer keys *numerically*
+      and only then stringifies them, while every sibling canonicaliser models
+      object keys as strings and sorts them lexicographically: ``{1: "a", 10:
+      "b", 2: "c"}`` would encode in a different order here than anywhere else.
+      That is a silent cross-language hash divergence, and the strict profile has
+      no non-string keys, so reject rather than emit an unverifiable
+      ``content_hash``.
+    """
     if isinstance(payload, float):
         raise EvidenceError(
             "canonical encoding rejects floats (treasury-strict profile); use "
             "integers or pre-formatted decimal strings so the hash stays portable"
         )
     if isinstance(payload, Mapping):
-        for value in payload.values():
-            _reject_floats(value)
+        for key, value in payload.items():
+            if not isinstance(key, str):
+                raise EvidenceError(
+                    "canonical encoding rejects non-string object keys "
+                    f"({type(key).__name__}); the strict profile models object keys as "
+                    "strings, and coercing them here would order differently than in a "
+                    "sibling implementation"
+                )
+            _reject_uncanonicalisable(value)
     elif isinstance(payload, (list, tuple)):
         for value in payload:
-            _reject_floats(value)
+            _reject_uncanonicalisable(value)
 
 
 def canonical_bytes(payload: object) -> bytes:
     """Deterministic canonical JSON — must byte-match every family producer.
 
     Strict profile (ADR-0001 D1): sorted keys, ``(",", ":")`` separators, UTF-8,
-    ``ensure_ascii=False``, **floats rejected**. Conformance-pinned to the vendored
-    golden vectors in ``tests/evidence-vectors/canonical-json/``.
+    ``ensure_ascii=False``, **floats and non-string object keys rejected**.
+    Conformance-pinned to the vendored golden vectors in
+    ``tests/evidence-vectors/canonical-json/``.
+
+    Fail-closed across the whole input domain: a string carrying an unpaired
+    surrogate (reachable from ``json.loads('"\\ud800"')``, or from a
+    ``surrogateescape`` decode) has no UTF-8 encoding and is rejected as an
+    :class:`EvidenceError` rather than escaping as a bare ``UnicodeEncodeError``.
+    A sibling implementation whose string type cannot hold a lone surrogate
+    rejects the same input, so this is *error parity*, not a local quirk.
     """
-    _reject_floats(payload)
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
-        "utf-8"
-    )
+    _reject_uncanonicalisable(payload)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    try:
+        return encoded.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise EvidenceError(
+            "canonical encoding rejects strings that are not valid Unicode "
+            f"(unpaired surrogate at position {exc.start}); the strict profile "
+            "encodes UTF-8 and has no representation for one"
+        ) from exc
 
 
 def sha256_hex(payload: object) -> str:

--- a/src/presidio_x402/treasury_binding.py
+++ b/src/presidio_x402/treasury_binding.py
@@ -558,8 +558,12 @@ def build_settlement_evidence(
         "generated_at": claimed_at,
         "attested_content": {"schema": SETTLEMENT_REF_SCHEMA_ID},
         "evidence": [ref],
-        # Companion data (ignored by generic evidence-ref@1 verifiers; consumed
-        # by verify_settlement_ref below):
+        # Companion mirrors of the signed join facts, for a consumer's
+        # convenience. They are UNSIGNED: a generic evidence-ref@1 verifier
+        # ignores them, and verify_settlement_ref treats envelope["settlement"]
+        # as the sole authority. verify_bundle re-derives each from the signed
+        # content and rejects any that is absent or disagrees (mirror-consistency
+        # check), so a consumer must never trust these in isolation.
         "signing_algorithm": algorithm,
         "settlement": dict(content),
         "artifact_hash": a_hash,
@@ -720,12 +724,14 @@ def verify_bundle(
        a *different* trusted party is not the decision signer's assertion, and
        admitting it would let any trust-store member re-point any decision at any
        transaction.
-    7. **summary consistency** — the bundle's top-level mirror fields
-       (``decision_ref``, ``settlement_ref``, ``settlement_key``, ``verdict``)
-       must agree with what the envelopes prove (``summary_mismatch``). Nothing
-       above reads them, but a consumer enforcing uniqueness on
-       ``settlement_key`` does, and a mirror that can disagree with what it
-       mirrors is a trap.
+    7. **mirror consistency** — every unsigned mirror of a join fact must be
+       *present and equal* to what the signed envelopes prove
+       (``summary_mismatch``): the bundle's top-level fields (``decision_ref``,
+       ``settlement_ref``, ``settlement_key``, ``verdict``) **and** the settlement
+       envelope's companion fields (``settlement_ref``, ``artifact_hash``,
+       ``settlement_key``, ``decision_ref``). Nothing above reads them, but a
+       consumer enforcing uniqueness on ``settlement_key`` does — and a mirror
+       that can disagree with, or go missing from, what it mirrors is a trap.
 
     Never raises to the caller.
     """
@@ -818,29 +824,44 @@ def verify_bundle(
         settlement_content.get("settlement") if isinstance(settlement_content, Mapping) else {}
     )
 
-    # The bundle's top-level summary fields are a convenience mirror of what the
-    # envelopes already prove, and nothing above reads them — every value this
-    # function reports is re-derived. But a consumer that *does* read them (the
-    # uniqueness invariant is enforced on settlement_key) would otherwise act on
-    # an unchecked string: swapping in a settlement-ref for a different
-    # transaction leaves a stale key that still names the old one. A mirror that
-    # can disagree with what it mirrors is a trap, so a disagreement is a
-    # rejection.
-    summary = {
+    # Every join fact is mirrored outside the signed content for a consumer's
+    # convenience — once at the bundle top level, and again as companion fields on
+    # the settlement envelope (settlement_ref/artifact_hash/settlement_key/
+    # decision_ref). None of these copies is signed, and nothing above reads them:
+    # every value this function reports is re-derived from the signed envelopes.
+    # But a mirror that can disagree with what it mirrors is a trap. An *absent*
+    # mirror a consumer reads as None and may skip its uniqueness dedupe on; a
+    # *swapped* one points a real settlement at the wrong transaction. So each
+    # mirror — on the bundle AND on the settlement envelope — must be present and
+    # equal to the derived truth; anything else is a rejection.
+    derived = {
         "decision_ref": decision.decision_ref,
         "settlement_ref": settlement_ref,
         "settlement_key": facts.settlement_key,
         "verdict": decision.verdict,
     }
-    stale = {
-        name: bundle.get(name)
-        for name, derived in summary.items()
-        if name in bundle and bundle.get(name) != derived
-    }
-    if stale:
+    # (field name on the object, the object, the derived key it must equal)
+    mirrors: list[tuple[str, Mapping[str, object], str]] = [
+        ("decision_ref", bundle, "decision_ref"),
+        ("settlement_ref", bundle, "settlement_ref"),
+        ("settlement_key", bundle, "settlement_key"),
+        ("verdict", bundle, "verdict"),
+        ("decision_ref", settlement_envelope, "decision_ref"),
+        ("settlement_ref", settlement_envelope, "settlement_ref"),
+        ("artifact_hash", settlement_envelope, "settlement_ref"),
+        ("settlement_key", settlement_envelope, "settlement_key"),
+    ]
+    bad: dict[str, object] = {}
+    for name, obj, key in mirrors:
+        where = "bundle" if obj is bundle else "settlement_ref_envelope"
+        if name not in obj:
+            bad[f"{where}.{name}"] = "<absent>"
+        elif obj.get(name) != derived[key]:
+            bad[f"{where}.{name}"] = obj.get(name)
+    if bad:
         return _fail(
             REASON_SUMMARY_MISMATCH,
-            detail=f"declared {stale} but derived {summary}",
+            detail=f"unsigned mirror disagrees with signed truth: {bad} vs derived {derived}",
             decision_ref=decision.decision_ref,
             settlement_ref=settlement_ref,
             settlement_key=facts.settlement_key,

--- a/src/presidio_x402/treasury_binding.py
+++ b/src/presidio_x402/treasury_binding.py
@@ -211,6 +211,10 @@ def check_identity_bounds(content: Mapping[str, object]) -> None:
     This does **not** claim the record is PII-free. It claims the record cannot
     carry an unbounded or non-printable caller string into an auditor's hands.
     """
+    if not isinstance(content, Mapping):
+        raise TreasuryBindingError(
+            f"decision content must be an object, got {type(content).__name__}"
+        )
     check_canonical_depth(content)
     _check_identity_string(
         content.get("agent_id"), "agent_id", IDENTITY_BOUNDS["agent_id"], allow_empty=True
@@ -595,6 +599,7 @@ REASON_JOIN_MISMATCH = "join_mismatch"
 REASON_SIGNER_MISMATCH = "signer_mismatch"
 REASON_NON_TERMINAL_VERDICT = "non_terminal_verdict"
 REASON_IDENTITY_BOUNDS = "identity_bounds"
+REASON_SUMMARY_MISMATCH = "summary_mismatch"
 
 
 @dataclass(frozen=True)
@@ -715,6 +720,12 @@ def verify_bundle(
        a *different* trusted party is not the decision signer's assertion, and
        admitting it would let any trust-store member re-point any decision at any
        transaction.
+    7. **summary consistency** — the bundle's top-level mirror fields
+       (``decision_ref``, ``settlement_ref``, ``settlement_key``, ``verdict``)
+       must agree with what the envelopes prove (``summary_mismatch``). Nothing
+       above reads them, but a consumer enforcing uniqueness on
+       ``settlement_key`` does, and a mirror that can disagree with what it
+       mirrors is a trap.
 
     Never raises to the caller.
     """
@@ -806,6 +817,38 @@ def verify_bundle(
     facts = SettlementFacts.from_mapping(
         settlement_content.get("settlement") if isinstance(settlement_content, Mapping) else {}
     )
+
+    # The bundle's top-level summary fields are a convenience mirror of what the
+    # envelopes already prove, and nothing above reads them — every value this
+    # function reports is re-derived. But a consumer that *does* read them (the
+    # uniqueness invariant is enforced on settlement_key) would otherwise act on
+    # an unchecked string: swapping in a settlement-ref for a different
+    # transaction leaves a stale key that still names the old one. A mirror that
+    # can disagree with what it mirrors is a trap, so a disagreement is a
+    # rejection.
+    summary = {
+        "decision_ref": decision.decision_ref,
+        "settlement_ref": settlement_ref,
+        "settlement_key": facts.settlement_key,
+        "verdict": decision.verdict,
+    }
+    stale = {
+        name: bundle.get(name)
+        for name, derived in summary.items()
+        if name in bundle and bundle.get(name) != derived
+    }
+    if stale:
+        return _fail(
+            REASON_SUMMARY_MISMATCH,
+            detail=f"declared {stale} but derived {summary}",
+            decision_ref=decision.decision_ref,
+            settlement_ref=settlement_ref,
+            settlement_key=facts.settlement_key,
+            verdict=decision.verdict,
+            checked=tuple(checked),
+        )
+    checked.append("summary")
+
     return BundleVerification(
         ok=True,
         decision_ref=decision.decision_ref,

--- a/src/presidio_x402/treasury_binding.py
+++ b/src/presidio_x402/treasury_binding.py
@@ -1,0 +1,1067 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
+"""Treasury binding — exporting one payment decision as an audit-grade bundle.
+
+A **treasury bundle** is the hand-off artifact that lets an agent payment
+reconcile into a ledger's close: the signed ``payment-decision@1`` record of
+*why* the payment was allowed, joined to the on-chain settlement that actually
+moved the money, both verifiable offline against a pinned trust store.
+
+Two artifacts, one join::
+
+    payment-decision@1  (v0.9.0, decision_ref.py)  "the library concluded ALLOW under P"
+             │
+             │  decision_ref
+             ▼
+    settlement-ref@1     (this module)                "that decision authorized THIS settlement"
+             │
+             │  chain + tx_hash + block_number + log_index
+             ▼
+    the L1 chain observation the ledger already ingests independently
+
+**What the join is, and what it is not.** ``settlement-ref@1`` is a *signed
+off-chain join record*: the x402 policy signer's statement that a named decision
+authorized a named settlement. It is not an on-chain anchor. An x402 payment
+settles via ERC-3009 ``transferWithAuthorization``, whose calldata carries no
+decision digest, so there is nothing on-chain to check a ``calldata_digest``
+against; and if the committed ``tx_hash`` *is* the settlement, a
+"decision precedes settlement" timestamp check compares a value with itself.
+Rather than ship two fields that assert what they cannot prove, this artifact
+asserts only what the signer can: *this decision, that transaction, signed*. The
+auditor already trusts that signer for the decision itself; the join rides the
+same trust, and being signed is what lets a consumer reject a forged or swapped
+join at its boundary.
+
+The strictly stronger alternative — a pre-settlement commitment transaction
+carrying ``sha256(decision_ref)``, making the join on-chain rather than
+signer-asserted — costs an extra chain transaction on every payment and changes
+the settle path. It is deliberately deferred as an opt-in "strong anchor" mode.
+
+**Fail-closed export.** :func:`export_bundle` re-runs the full
+:func:`~presidio_x402.decision_ref.verify_decision_ref` (structure, hash,
+``verdict == f(controls)``, self-approval admission, signature, parents) and
+refuses to emit a bundle for an envelope that does not verify. It additionally
+refuses a non-terminal (``REFER``) verdict, bounds the caller-supplied identity
+strings, and bounds canonical nesting depth. No network I/O on any path here —
+export and verify are both offline.
+
+**Privacy bound, stated honestly.** The ``controls{}`` block of a decision-ref is
+*structurally* PII-free (hashes, entity-type labels, enum verdicts — there is no
+field that accepts a raw string). The top-level identity fields are **not**:
+``agent_id``, ``pay_to``, ``resource_origin`` and ``mpa.approval_refs`` are
+caller-supplied strings, and a wallet address is pseudonymous personal data to a
+GDPR-minded auditor. They are present by design — a ledger cannot reconcile an
+anonymous payment — so the mitigation is a *value bound* (length + charset,
+:func:`check_identity_bounds`), not a claim that no free text can appear. The
+settlement facts committed to the chain-join deliberately exclude the payer
+address even though the receipt carries it: the join needs the transaction, not
+the counterparty.
+
+CLI (offline; exit 0 verified, 1 fail-closed, 2 usage)::
+
+    python -m presidio_x402.treasury_binding export ENVELOPE.json \\
+        --settlement settle.json --trust trust.json --key-file policy.key > bundle.json
+    python -m presidio_x402.treasury_binding verify bundle.json trust.json
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .decision_ref import (
+    DecisionRefError,
+    _utcnow_ms_z,  # deliberately shared: both artifacts must timestamp identically
+    verify_decision_ref,
+)
+from .mica import (
+    EVIDENCE_SCHEMA_ID,
+    EvidenceError,
+    load_trust_store,
+    sha256_hex,
+    sign_evidence,
+    verify_ed25519,
+    verify_hmac,
+)
+
+if TYPE_CHECKING:
+    from ._types import SettlementReceipt
+
+SETTLEMENT_REF_SCHEMA_ID = "presidio-hardened-x402/settlement-ref@1"
+SETTLEMENT_FACTS_SCHEMA_ID = "presidio-hardened-x402/settlement-facts@1"
+TREASURY_BUNDLE_SCHEMA_ID = "presidio-hardened-x402/treasury-bundle@1"
+
+#: Verdicts a bundle may carry. ``REFER`` is excluded: an unresolved quorum is
+#: an interim state, and reconciling against it would book the wrong conclusion
+#: when it later resolves (the terminal record links the interim one through
+#: ``prior_decision_refs``). ``DENY`` *is* exportable on purpose — a payment that
+#: settled despite a DENY is precisely the anomaly an auditor must be able to
+#: see, and refusing to export it would hide it.
+TERMINAL_VERDICTS = frozenset({"ALLOW", "DENY"})
+
+#: Maximum canonical nesting depth, matching the sibling Rust canonicaliser's
+#: ``MAX_DEPTH``. Depth is defined **exactly** as: the top-level value sits at
+#: depth 0, and every step into a nested object or array adds 1. A value at depth
+#: 128 is accepted; a value at depth 129 is rejected. Both sides must agree on
+#: this definition or the boundary vector grades differently in each language.
+MAX_CANONICAL_DEPTH = 128
+
+#: Upper bound for the integers a settlement-ref commits to. The sibling
+#: canonicaliser deserialises JSON numbers into ``i64``/``u64``, so an integer
+#: beyond ``i64::MAX`` is representable in Python and *not* in Rust — bounding it
+#: here by schema is what keeps "both sides accept, or both reject" true.
+I64_MAX = 2**63 - 1
+
+#: Length bounds for the caller-supplied identity strings (T-TB-3). Values, not
+#: field names: the point is to bound what a caller can put in a field that is
+#: known to be free text, not to pretend the fields do not exist.
+IDENTITY_BOUNDS = {
+    "agent_id": 256,
+    "actor.payment_signer": 128,
+    "payment.pay_to": 128,
+    "payment.resource_origin": 256,
+}
+#: ``mpa.approval_refs`` is a list; bound both its length and each element.
+MAX_APPROVAL_REFS = 32
+MAX_APPROVAL_REF_LEN = 512
+
+#: Unicode general categories rejected inside an identity string: control,
+#: format, surrogate, private-use and unassigned. This is a *charset* bound
+#: rather than an ASCII allowlist — a Cyrillic or CJK agent id is legitimate,
+#: a bidi-override or an unpaired surrogate in an auditor's disclosure pack is
+#: not.
+_FORBIDDEN_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Co", "Cn"})
+
+#: Separator for the settlement uniqueness key. ``|`` cannot occur in a CAIP-2
+#: chain id, a transaction hash, or a decimal index, so the key parses back
+#: unambiguously even though the chain id itself contains a colon.
+SETTLEMENT_KEY_SEP = "|"
+
+
+class TreasuryBindingError(DecisionRefError):
+    """Raised on any fail-closed refusal in the binding (export path).
+
+    Subclasses :class:`~presidio_x402.decision_ref.DecisionRefError` (and through
+    it :class:`~presidio_x402.mica.EvidenceError`), so a caller already handling
+    evidence failures also handles these.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Canonical-domain bounds enforced on the export path.
+# ---------------------------------------------------------------------------
+
+
+def check_canonical_depth(payload: object, *, max_depth: int = MAX_CANONICAL_DEPTH) -> None:
+    """Reject a payload nested deeper than the shared canonical bound.
+
+    Iterative by design: a recursive walk over a hostile 10 000-deep structure
+    raises ``RecursionError`` (an interpreter accident) instead of the typed
+    refusal a fail-closed boundary owes its caller.
+    """
+    stack: list[tuple[object, int]] = [(payload, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if isinstance(node, Mapping):
+            children: Sequence[object] = list(node.values())
+        elif isinstance(node, (list, tuple)):
+            children = list(node)
+        else:
+            continue
+        if depth + 1 > max_depth and children:
+            raise TreasuryBindingError(
+                f"canonical nesting exceeds the shared depth bound of {max_depth} "
+                "(top-level value at depth 0); a sibling canonicaliser rejects it, "
+                "so this side must reject it identically"
+            )
+        stack.extend((child, depth + 1) for child in children)
+
+
+def _check_identity_string(value: object, label: str, max_len: int, *, allow_empty: bool) -> None:
+    if not isinstance(value, str):
+        raise TreasuryBindingError(
+            f"identity field {label!r} must be a string, got {type(value).__name__}"
+        )
+    if not value and not allow_empty:
+        raise TreasuryBindingError(f"identity field {label!r} must not be empty")
+    if len(value) > max_len:
+        raise TreasuryBindingError(
+            f"identity field {label!r} exceeds {max_len} characters ({len(value)})"
+        )
+    for index, char in enumerate(value):
+        if unicodedata.category(char) in _FORBIDDEN_CATEGORIES:
+            raise TreasuryBindingError(
+                f"identity field {label!r} carries a disallowed character at position "
+                f"{index} (Unicode category {unicodedata.category(char)}): control, format, "
+                "surrogate, private-use and unassigned code points are refused"
+            )
+
+
+def check_identity_bounds(content: Mapping[str, object]) -> None:
+    """Bound every caller-supplied identity string in a decision-ref's content.
+
+    The five values a caller controls verbatim — ``agent_id``,
+    ``actor.payment_signer``, ``payment.pay_to``, ``payment.resource_origin`` and
+    each ``controls.mpa.approval_refs`` entry — are checked for length and
+    charset. ``agent_id`` may be empty (the pipeline emits ``""`` when no agent
+    id is configured); the others may not.
+
+    This does **not** claim the record is PII-free. It claims the record cannot
+    carry an unbounded or non-printable caller string into an auditor's hands.
+    """
+    check_canonical_depth(content)
+    _check_identity_string(
+        content.get("agent_id"), "agent_id", IDENTITY_BOUNDS["agent_id"], allow_empty=True
+    )
+
+    actor = content.get("actor")
+    if not isinstance(actor, Mapping):
+        raise TreasuryBindingError("decision content must carry an actor{} block")
+    _check_identity_string(
+        actor.get("payment_signer"),
+        "actor.payment_signer",
+        IDENTITY_BOUNDS["actor.payment_signer"],
+        allow_empty=False,
+    )
+
+    payment = content.get("payment")
+    if not isinstance(payment, Mapping):
+        raise TreasuryBindingError("decision content must carry a payment{} block")
+    for name in ("pay_to", "resource_origin"):
+        _check_identity_string(
+            payment.get(name),
+            f"payment.{name}",
+            IDENTITY_BOUNDS[f"payment.{name}"],
+            allow_empty=False,
+        )
+
+    controls = content.get("controls")
+    mpa = controls.get("mpa") if isinstance(controls, Mapping) else None
+    refs = mpa.get("approval_refs") if isinstance(mpa, Mapping) else None
+    if refs is None:
+        return
+    if not isinstance(refs, list):
+        raise TreasuryBindingError("controls.mpa.approval_refs must be a list when present")
+    if len(refs) > MAX_APPROVAL_REFS:
+        raise TreasuryBindingError(
+            f"controls.mpa.approval_refs carries {len(refs)} entries (max {MAX_APPROVAL_REFS})"
+        )
+    for index, ref in enumerate(refs):
+        _check_identity_string(
+            ref, f"controls.mpa.approval_refs[{index}]", MAX_APPROVAL_REF_LEN, allow_empty=False
+        )
+
+
+# ---------------------------------------------------------------------------
+# Settlement facts — the operator-completable input to the join.
+# ---------------------------------------------------------------------------
+
+
+def _validate_caip2(chain: object) -> str:
+    if not isinstance(chain, str) or not chain:
+        raise TreasuryBindingError("settlement 'chain' must be a non-empty CAIP-2 chain id")
+    namespace, sep, reference = chain.partition(":")
+    ok = (
+        sep
+        and chain.isascii()
+        and 3 <= len(namespace) <= 8
+        and all(c.isdigit() or (c.islower() and c.isalpha()) or c == "-" for c in namespace)
+        and 1 <= len(reference) <= 32
+        and all(c.isalnum() or c in "-_" for c in reference)
+    )
+    if not ok:
+        raise TreasuryBindingError(
+            f"settlement 'chain' {chain!r} is not a CAIP-2 chain id "
+            "([-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}), e.g. 'eip155:8453'"
+        )
+    return chain
+
+
+def _validate_tx_hash(tx_hash: object, chain: str) -> str:
+    if not isinstance(tx_hash, str) or not tx_hash:
+        raise TreasuryBindingError("settlement 'tx_hash' must be a non-empty string")
+    if chain.startswith("eip155:"):
+        # Canonical form for EVM: 0x + 64 lowercase hex. Case is normalised (not
+        # merely accepted) so two operators exporting the same settlement produce
+        # byte-identical join records — an id that differs by case would defeat
+        # the one-settlement-one-leg uniqueness check downstream.
+        candidate = tx_hash.lower()
+        body = candidate[2:] if candidate.startswith("0x") else ""
+        if (
+            not candidate.startswith("0x")
+            or len(body) != 64
+            or not all(c in "0123456789abcdef" for c in body)
+        ):
+            raise TreasuryBindingError(
+                f"settlement 'tx_hash' {tx_hash!r} is not an EVM transaction hash "
+                "(0x + 64 hex) for an eip155 chain"
+            )
+        return candidate
+    if (
+        len(tx_hash) > 128
+        or not tx_hash.isascii()
+        or not all(c.isalnum() or c in "-_:" for c in tx_hash)
+    ):
+        raise TreasuryBindingError(
+            f"settlement 'tx_hash' {tx_hash!r} is not a bounded ASCII transaction id"
+        )
+    return tx_hash
+
+
+def _validate_index(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TreasuryBindingError(
+            f"settlement {label!r} must be an integer (got {type(value).__name__}); "
+            "the operator supplies it from a chain lookup keyed by tx_hash"
+        )
+    if not 0 <= value <= I64_MAX:
+        raise TreasuryBindingError(
+            f"settlement {label!r} must be within [0, {I64_MAX}] (i64::MAX); a sibling "
+            "canonicaliser cannot represent a larger integer, so this side rejects it too"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class SettlementFacts:
+    """The four chain facts a settlement-ref commits to, validated.
+
+    ``chain`` and ``tx_hash`` are observable by the paying client on the paid
+    response; ``block_number`` and ``log_index`` are **not** — the x402
+    settlement echo carries neither, so the operator completes them from a chain
+    or indexer lookup keyed by the transaction hash. That is the documented
+    correlation procedure, and it is required rather than optional: without a log
+    index there is no key on which a downstream ledger can enforce "one
+    settlement → one leg".
+    """
+
+    chain: str
+    tx_hash: str
+    block_number: int
+    log_index: int
+
+    def __post_init__(self) -> None:
+        chain = _validate_caip2(self.chain)
+        object.__setattr__(self, "chain", chain)
+        object.__setattr__(self, "tx_hash", _validate_tx_hash(self.tx_hash, chain))
+        object.__setattr__(
+            self, "block_number", _validate_index(self.block_number, "block_number")
+        )
+        object.__setattr__(self, "log_index", _validate_index(self.log_index, "log_index"))
+
+    @property
+    def settlement_key(self) -> str:
+        """``chain|tx_hash|log_index`` — the uniqueness key for the join.
+
+        A downstream ledger enforces "at most one settlement-ref per (period,
+        chain, tx_hash, log_index)" on this value. ``block_number`` is
+        deliberately absent: it is implied by the transaction hash, and including
+        it would let a wrong-but-plausible height mint a second distinct key for
+        one settlement.
+        """
+        return SETTLEMENT_KEY_SEP.join((self.chain, self.tx_hash, str(self.log_index)))
+
+    def to_dict(self) -> dict[str, object]:
+        """The committed block, in canonical field order (sorted on encode)."""
+        return {
+            "block_number": self.block_number,
+            "chain": self.chain,
+            "log_index": self.log_index,
+            "tx_hash": self.tx_hash,
+        }
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, object]) -> SettlementFacts:
+        """Build from an operator settlement file (or any of its supersets).
+
+        Accepts the record :func:`settlement_facts_record` writes — including the
+        ``payer`` and ``receipt_hash`` fields, which are read and *dropped*: the
+        join commits to the transaction, never to the counterparty.
+        """
+        if not isinstance(raw, Mapping):
+            raise TreasuryBindingError("settlement facts must be a JSON object")
+        required = ("chain", "tx_hash", "block_number", "log_index")
+        missing = [k for k in required if raw.get(k) is None]
+        if missing:
+            raise TreasuryBindingError(
+                f"settlement facts missing {', '.join(missing)}; block_number and log_index "
+                "are not echoed by the x402 settlement receipt and must be completed by the "
+                "operator from a chain lookup keyed by tx_hash"
+            )
+        return cls(
+            chain=raw["chain"],  # type: ignore[arg-type]
+            tx_hash=raw["tx_hash"],  # type: ignore[arg-type]
+            block_number=raw["block_number"],  # type: ignore[arg-type]
+            log_index=raw["log_index"],  # type: ignore[arg-type]
+        )
+
+
+def settlement_facts_record(
+    receipt: SettlementReceipt, *, decision_ref: str | None = None
+) -> dict[str, object]:
+    """Render an observed receipt as the operator-completable settlement file.
+
+    This is what a :class:`SettlementWriter` persists and what
+    ``export --settlement`` consumes once ``block_number`` and ``log_index`` are
+    filled in. ``complete`` says whether that step is still outstanding, so the
+    gap is visible in the file itself rather than discovered at export time.
+    """
+    return {
+        "schema": SETTLEMENT_FACTS_SCHEMA_ID,
+        "decision_ref": decision_ref,
+        "chain": receipt.chain,
+        "network": receipt.network,
+        "tx_hash": receipt.tx_hash,
+        "block_number": receipt.block_number,
+        "log_index": receipt.log_index,
+        "payer": receipt.payer,
+        "success": receipt.success,
+        "observed_at": receipt.observed_at,
+        "receipt_hash": receipt.receipt_hash,
+        "complete": receipt.is_complete,
+        "note": (
+            "block_number and log_index are not carried by the x402 settlement echo; "
+            "complete them from a chain/indexer lookup keyed by tx_hash before export."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Settlement sinks — mirrors the audit-log / decision-ref writer conventions.
+# ---------------------------------------------------------------------------
+
+
+class SettlementWriter:
+    """Sink protocol for observed settlement records (structural).
+
+    Any object with a ``write(record: Mapping) -> None`` method qualifies. A
+    writer MUST NOT perform network I/O on the capture path — it runs inline on
+    the client's paid response.
+    """
+
+    def write(self, record: Mapping[str, object]) -> None:  # pragma: no cover - protocol
+        raise NotImplementedError
+
+
+class NullSettlementWriter(SettlementWriter):
+    """Discards records. The explicit off-switch used in tests."""
+
+    def write(self, record: Mapping[str, object]) -> None:
+        return
+
+
+class FileSettlementWriter(SettlementWriter):
+    """Appends one JSON record per line to a file (JSON-L), fsync by default.
+
+    Mirrors :class:`~presidio_x402.decision_ref.FileDecisionRefWriter`: per-write
+    fsync so the record survives a kernel-level process death, a lock for
+    thread-safety, UTF-8, ``ensure_ascii`` off for byte-parity with the family
+    canonical form.
+    """
+
+    def __init__(self, path: str, *, fsync: bool = True) -> None:
+        import threading
+
+        self._path = path
+        self._fsync = fsync
+        self._lock = threading.Lock()
+
+    def write(self, record: Mapping[str, object]) -> None:
+        import json
+        import os
+
+        line = json.dumps(dict(record), sort_keys=True, ensure_ascii=False, default=str)
+        with self._lock, open(self._path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+            if self._fsync:
+                fh.flush()
+                os.fsync(fh.fileno())
+
+
+# ---------------------------------------------------------------------------
+# settlement-ref@1 — the signed off-chain join record.
+# ---------------------------------------------------------------------------
+
+
+def build_settlement_ref_content(
+    *, decision_ref: str, facts: SettlementFacts, issued_at: str | None = None
+) -> dict[str, object]:
+    """The attested ``settlement-ref@1`` content.
+
+    Commits to exactly five values: the decision it joins, and the four chain
+    facts that identify the settlement log entry. Nothing else — no calldata
+    digest, no precedence timestamp, no payer.
+    """
+    if not (isinstance(decision_ref, str) and len(decision_ref) == 64):
+        raise TreasuryBindingError("decision_ref must be the 64-hex thin decision id")
+    if not all(c in "0123456789abcdef" for c in decision_ref):
+        raise TreasuryBindingError("decision_ref must be lowercase hex")
+    return {
+        "schema": SETTLEMENT_REF_SCHEMA_ID,
+        "issued_at": issued_at or _utcnow_ms_z(),
+        "decision_ref": decision_ref,
+        "settlement": facts.to_dict(),
+    }
+
+
+def build_settlement_evidence(
+    content: Mapping[str, object],
+    *,
+    signing_key: str,
+    algorithm: str = "ed25519",
+    signer: str,
+    key_id: str | None = None,
+    source_version: str | None = None,
+) -> dict[str, object]:
+    """Sign a ``settlement-ref@1`` content into a family ``evidence-ref@1`` envelope.
+
+    Same primitives as the decision-ref envelope
+    (:func:`~presidio_x402.mica.sign_evidence` over
+    ``canonical({content_hash, signer})``) so one verifier handles both. The
+    ``settlement_ref`` id is the content hash itself: unlike the decision-ref
+    there is no thin four-field preimage, because every field of this content is
+    already part of the join and nothing would be abbreviated away.
+
+    **No network I/O.**
+    """
+    if content.get("schema") != SETTLEMENT_REF_SCHEMA_ID:
+        raise TreasuryBindingError(
+            f"attested content schema must be {SETTLEMENT_REF_SCHEMA_ID!r}; "
+            f"got {content.get('schema')!r}"
+        )
+    facts = SettlementFacts.from_mapping(content.get("settlement") or {})
+    a_hash = sha256_hex(content)
+    signature = sign_evidence(a_hash, signer, algorithm=algorithm, key=signing_key)
+    version = source_version or _library_version()
+    claimed_at = _utcnow_ms_z()
+    ref: dict[str, object] = {
+        "item_id": a_hash,
+        "source": signer,
+        "source_version": version,
+        "ledger_ref": f"x402-settlement:{a_hash}",
+        "content_hash": a_hash,
+        "signer": signer,
+        "signature": signature,
+        "claimed_at": claimed_at,
+    }
+    envelope: dict[str, object] = {
+        "schema": EVIDENCE_SCHEMA_ID,
+        "use_case": "x402-settlement-join",
+        "source": signer,
+        "source_version": version,
+        "generated_at": claimed_at,
+        "attested_content": {"schema": SETTLEMENT_REF_SCHEMA_ID},
+        "evidence": [ref],
+        # Companion data (ignored by generic evidence-ref@1 verifiers; consumed
+        # by verify_settlement_ref below):
+        "signing_algorithm": algorithm,
+        "settlement": dict(content),
+        "artifact_hash": a_hash,
+        "settlement_ref": a_hash,
+        "decision_ref": content["decision_ref"],
+        "settlement_key": facts.settlement_key,
+        "disclaimer": (
+            "Signed off-chain join record: the x402 policy signer asserts that the named "
+            "decision authorized the named settlement. It is NOT an on-chain anchor and "
+            "proves nothing about the transaction beyond the signer's assertion; the "
+            "transaction itself must be observed independently on the chain."
+        ),
+    }
+    if key_id is not None:
+        ref["key_id"] = key_id
+        envelope["key_id"] = key_id
+    return envelope
+
+
+def _library_version() -> str:
+    from . import __version__
+
+    return __version__
+
+
+# ---------------------------------------------------------------------------
+# Verification (read path) — offline, fail-closed, distinct reasons.
+# ---------------------------------------------------------------------------
+
+REASON_MALFORMED = "malformed"
+REASON_DECISION = "decision"
+REASON_SETTLEMENT_MALFORMED = "settlement_malformed"
+REASON_SETTLEMENT_HASH_MISMATCH = "settlement_hash_mismatch"
+REASON_SETTLEMENT_UNKNOWN_SIGNER = "settlement_unknown_signer"
+REASON_SETTLEMENT_BAD_SIGNATURE = "settlement_bad_signature"
+REASON_JOIN_MISMATCH = "join_mismatch"
+REASON_SIGNER_MISMATCH = "signer_mismatch"
+REASON_NON_TERMINAL_VERDICT = "non_terminal_verdict"
+REASON_IDENTITY_BOUNDS = "identity_bounds"
+
+
+@dataclass(frozen=True)
+class BundleVerification:
+    """The outcome of verifying one treasury bundle (never raises to the caller).
+
+    ``ok`` is the fail-closed conjunction of every layer. On failure ``reason``
+    carries exactly one code — the first layer that failed, in verification
+    order — and ``detail`` carries the underlying decision-ref reason when the
+    failure was inside the decision envelope.
+    """
+
+    ok: bool
+    reason: str | None = None
+    detail: str | None = None
+    decision_ref: str | None = None
+    settlement_ref: str | None = None
+    settlement_key: str | None = None
+    verdict: str | None = None
+    checked: tuple[str, ...] = field(default_factory=tuple)
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def _fail(reason: str, **kw: object) -> BundleVerification:
+    return BundleVerification(ok=False, reason=reason, **kw)  # type: ignore[arg-type]
+
+
+def verify_settlement_ref(
+    envelope: Mapping[str, object],
+    trust: Mapping[str, object],
+    *,
+    expected_decision_ref: str | None = None,
+) -> tuple[bool, str | None, str | None]:
+    """Verify a settlement-ref envelope: ``(ok, reason, settlement_ref)``.
+
+    Layers: structure → content-hash recompute → schema/field revalidation →
+    join match (when ``expected_decision_ref`` is given) → signature against the
+    pinned trust store. ``trust`` is an already-normalised trust store.
+    """
+    if not isinstance(envelope, Mapping):
+        return False, REASON_SETTLEMENT_MALFORMED, None
+    evidence = envelope.get("evidence")
+    content = envelope.get("settlement")
+    if (
+        not isinstance(evidence, list)
+        or len(evidence) != 1
+        or not isinstance(evidence[0], Mapping)
+        or not isinstance(content, Mapping)
+        or content.get("schema") != SETTLEMENT_REF_SCHEMA_ID
+    ):
+        return False, REASON_SETTLEMENT_MALFORMED, None
+    ref = evidence[0]
+    content_hash = ref.get("content_hash")
+    signer = ref.get("signer")
+    signature = ref.get("signature")
+    if not (
+        isinstance(content_hash, str) and isinstance(signer, str) and isinstance(signature, str)
+    ):
+        return False, REASON_SETTLEMENT_MALFORMED, None
+
+    try:
+        recomputed = sha256_hex(content)
+    except EvidenceError:
+        return False, REASON_SETTLEMENT_MALFORMED, None
+    if recomputed != content_hash:
+        return False, REASON_SETTLEMENT_HASH_MISMATCH, recomputed
+
+    # Revalidate the committed fields rather than trusting that whoever signed
+    # them applied the schema: a signed-but-out-of-domain integer is exactly the
+    # input a sibling canonicaliser would reject, and admitting it here would
+    # move the divergence downstream.
+    try:
+        SettlementFacts.from_mapping(content.get("settlement") or {})
+    except (TreasuryBindingError, EvidenceError):
+        return False, REASON_SETTLEMENT_MALFORMED, recomputed
+    joined = content.get("decision_ref")
+    if not isinstance(joined, str) or not joined:
+        return False, REASON_SETTLEMENT_MALFORMED, recomputed
+    if expected_decision_ref is not None and joined != expected_decision_ref:
+        return False, REASON_JOIN_MISMATCH, recomputed
+
+    entry = trust.get(signer)
+    if not isinstance(entry, Mapping):
+        return False, REASON_SETTLEMENT_UNKNOWN_SIGNER, recomputed
+    verify = verify_ed25519 if entry.get("alg") == "ed25519" else verify_hmac
+    keys = entry.get("keys")
+    if not (
+        isinstance(keys, list)
+        and any(isinstance(k, str) and verify(content_hash, signer, signature, k) for k in keys)
+    ):
+        return False, REASON_SETTLEMENT_BAD_SIGNATURE, recomputed
+    return True, None, recomputed
+
+
+def verify_bundle(
+    bundle: Mapping[str, object],
+    trust_store: str | Mapping[str, object],
+    *,
+    actor_controllers: Sequence[str] | None = None,
+) -> BundleVerification:
+    """Verify a treasury bundle offline, fail-closed, one distinct reason.
+
+    Order (first failure wins):
+
+    1. **structure** — bundle schema, both envelopes present (``malformed``).
+    2. **decision** — the full :func:`verify_decision_ref` chain; its reason code
+       is surfaced in ``detail`` (``decision``).
+    3. **terminal verdict** — ``REFER`` is refused (``non_terminal_verdict``).
+    4. **identity bounds** — the caller-supplied strings are re-bounded on the
+       read path, so a bundle built by an older or laxer producer still fails
+       here (``identity_bounds``).
+    5. **settlement** — content hash, field domain, and signature
+       (``settlement_*``), plus the join to the decision (``join_mismatch``).
+    6. **signer pinning** — both envelopes must be signed by the signer the
+       bundle's ``trust_store_ref`` names (``signer_mismatch``). A join signed by
+       a *different* trusted party is not the decision signer's assertion, and
+       admitting it would let any trust-store member re-point any decision at any
+       transaction.
+
+    Never raises to the caller.
+    """
+    checked: list[str] = []
+    if not isinstance(bundle, Mapping) or bundle.get("schema") != TREASURY_BUNDLE_SCHEMA_ID:
+        return _fail(REASON_MALFORMED)
+    decision_envelope = bundle.get("decision_ref_envelope")
+    settlement_envelope = bundle.get("settlement_ref_envelope")
+    trust_ref = bundle.get("trust_store_ref")
+    if not (
+        isinstance(decision_envelope, Mapping)
+        and isinstance(settlement_envelope, Mapping)
+        and isinstance(trust_ref, Mapping)
+    ):
+        return _fail(REASON_MALFORMED)
+    checked.append("structure")
+
+    try:
+        trust = load_trust_store(trust_store)
+    except EvidenceError:
+        return _fail(REASON_MALFORMED, checked=tuple(checked))
+
+    decision = verify_decision_ref(
+        decision_envelope, trust_store, actor_controllers=actor_controllers
+    )
+    if not decision.ok:
+        return _fail(
+            REASON_DECISION,
+            detail=decision.reason,
+            decision_ref=decision.decision_ref,
+            checked=tuple(checked),
+        )
+    checked.append("decision")
+
+    if decision.verdict not in TERMINAL_VERDICTS:
+        return _fail(
+            REASON_NON_TERMINAL_VERDICT,
+            detail=decision.verdict,
+            decision_ref=decision.decision_ref,
+            verdict=decision.verdict,
+            checked=tuple(checked),
+        )
+    checked.append("terminal")
+
+    content = decision_envelope.get("payment_decision")
+    try:
+        check_identity_bounds(content)  # type: ignore[arg-type]
+    except (TreasuryBindingError, EvidenceError) as exc:
+        return _fail(
+            REASON_IDENTITY_BOUNDS,
+            detail=str(exc),
+            decision_ref=decision.decision_ref,
+            verdict=decision.verdict,
+            checked=tuple(checked),
+        )
+    checked.append("identity")
+
+    ok, reason, settlement_ref = verify_settlement_ref(
+        settlement_envelope, trust, expected_decision_ref=decision.decision_ref
+    )
+    if not ok:
+        return _fail(
+            reason or REASON_SETTLEMENT_MALFORMED,
+            decision_ref=decision.decision_ref,
+            settlement_ref=settlement_ref,
+            verdict=decision.verdict,
+            checked=tuple(checked),
+        )
+    checked.append("settlement")
+
+    pinned = trust_ref.get("signer")
+    decision_signer = _envelope_signer(decision_envelope)
+    settlement_signer = _envelope_signer(settlement_envelope)
+    if not (isinstance(pinned, str) and pinned and pinned == decision_signer == settlement_signer):
+        return _fail(
+            REASON_SIGNER_MISMATCH,
+            detail=(
+                f"trust_store_ref={pinned!r} decision={decision_signer!r} "
+                f"settlement={settlement_signer!r}"
+            ),
+            decision_ref=decision.decision_ref,
+            settlement_ref=settlement_ref,
+            verdict=decision.verdict,
+            checked=tuple(checked),
+        )
+    checked.append("signer")
+
+    settlement_content = settlement_envelope.get("settlement")
+    facts = SettlementFacts.from_mapping(
+        settlement_content.get("settlement") if isinstance(settlement_content, Mapping) else {}
+    )
+    return BundleVerification(
+        ok=True,
+        decision_ref=decision.decision_ref,
+        settlement_ref=settlement_ref,
+        settlement_key=facts.settlement_key,
+        verdict=decision.verdict,
+        checked=tuple(checked),
+    )
+
+
+def _envelope_signer(envelope: Mapping[str, object]) -> str | None:
+    evidence = envelope.get("evidence")
+    if isinstance(evidence, list) and len(evidence) == 1 and isinstance(evidence[0], Mapping):
+        signer = evidence[0].get("signer")
+        return signer if isinstance(signer, str) else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The adapter — export a verified decision + settlement as one bundle.
+# ---------------------------------------------------------------------------
+
+
+def export_bundle(
+    decision_envelope: Mapping[str, object],
+    facts: SettlementFacts,
+    *,
+    trust_store: str | Mapping[str, object],
+    signing_key: str,
+    algorithm: str = "ed25519",
+    signer: str | None = None,
+    key_id: str | None = None,
+    actor_controllers: Sequence[str] | None = None,
+    issued_at: str | None = None,
+) -> dict[str, object]:
+    """Build the treasury-ingest bundle for one verified decision. Fail-closed.
+
+    Refuses, with a distinct :class:`TreasuryBindingError` each time, when: the
+    decision envelope does not self-verify against ``trust_store`` (every layer,
+    including the signature — a bundle whose signature was never checked is not
+    evidence of anything); the verdict is non-terminal; an identity string is
+    out of bounds; the settlement facts are out of domain; or the settlement-ref
+    would be signed by an identity other than the decision's signer.
+
+    ``trust_store`` is required rather than optional on purpose. "Refuses to
+    export a non-verifying envelope" is a claim about the *signature* too, and
+    an exporter that skipped it would emit bundles whose central promise had
+    never been tested.
+
+    **No network I/O.**
+    """
+    result = verify_decision_ref(
+        decision_envelope, trust_store, actor_controllers=actor_controllers
+    )
+    if not result.ok:
+        raise TreasuryBindingError(
+            f"refusing to export a decision-ref that does not verify: {result.reason} "
+            "(fail-closed)"
+        )
+    if result.verdict not in TERMINAL_VERDICTS:
+        raise TreasuryBindingError(
+            f"refusing to export a non-terminal verdict {result.verdict!r}: an unresolved "
+            "quorum is an interim state; export the terminal decision that supersedes it"
+        )
+    content = decision_envelope.get("payment_decision")
+    if not isinstance(content, Mapping):
+        raise TreasuryBindingError("decision envelope carries no payment_decision content")
+    check_identity_bounds(content)
+
+    decision_signer = _envelope_signer(decision_envelope)
+    effective_signer = signer or decision_signer
+    if not effective_signer:
+        raise TreasuryBindingError("decision envelope carries no signer")
+    if decision_signer != effective_signer:
+        raise TreasuryBindingError(
+            f"refusing to sign the join as {effective_signer!r} when the decision was signed "
+            f"by {decision_signer!r}: the join is the decision signer's own assertion"
+        )
+
+    decision_ref = result.decision_ref
+    if not isinstance(decision_ref, str):  # pragma: no cover - verify_decision_ref guarantees it
+        raise TreasuryBindingError("decision envelope carries no recomputable decision_ref")
+
+    settlement_content = build_settlement_ref_content(
+        decision_ref=decision_ref, facts=facts, issued_at=issued_at
+    )
+    settlement_envelope = build_settlement_evidence(
+        settlement_content,
+        signing_key=signing_key,
+        algorithm=algorithm,
+        signer=effective_signer,
+        key_id=key_id,
+    )
+
+    return {
+        "schema": TREASURY_BUNDLE_SCHEMA_ID,
+        "generated_at": settlement_envelope["generated_at"],
+        "source_version": settlement_envelope["source_version"],
+        "decision_ref": decision_ref,
+        "settlement_ref": settlement_envelope["settlement_ref"],
+        "settlement_key": settlement_envelope["settlement_key"],
+        "verdict": result.verdict,
+        "decision_ref_envelope": dict(decision_envelope),
+        "settlement_ref_envelope": settlement_envelope,
+        "trust_store_ref": {
+            "signer": effective_signer,
+            "algorithm": algorithm,
+            "key_id": key_id,
+            "note": (
+                "Resolve this signer against your own pinned trust store. No key material "
+                "travels in this bundle by design: a bundle-supplied public key would make "
+                "verification trust-on-first-use and defeat the pin it exists to enforce."
+            ),
+        },
+        "ingest_status": "treasury-ingest-pending",
+        "disclaimer": (
+            "Two signed records and the join between them. The decision-ref proves what the "
+            "library concluded under a declared predicate; the settlement-ref is the signer's "
+            "assertion that this decision authorized that transaction. Neither proves the "
+            "transaction occurred — the chain observation is independent evidence, and the "
+            "classification it supports remains the ledger's own dual-control judgment."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI — offline; exit 0 verified, 1 fail-closed, 2 usage.
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: str) -> object:
+    import json
+    from pathlib import Path
+
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except RecursionError as exc:  # deeply nested input, before any bound applies
+        raise ValueError("input JSON is nested too deeply to parse") from exc
+
+
+def _load_signing_key(key_file: str | None) -> str:
+    """Read the signing key from a file or the environment — never from argv.
+
+    A key passed as a command-line argument is visible in ``ps`` output and in
+    shell history to every user on the host, so the flag simply does not exist.
+    """
+    import os
+    from pathlib import Path
+
+    if key_file:
+        return Path(key_file).read_text(encoding="utf-8").strip()
+    key = os.environ.get("PRESIDIO_X402_EVIDENCE_KEY", "")
+    if not key:
+        raise ValueError(
+            "no signing key: pass --key-file or set PRESIDIO_X402_EVIDENCE_KEY "
+            "(a key on the command line would be visible in ps output)"
+        )
+    return key.strip()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Export or verify a treasury bundle. Fully offline; exit 0/1/2.
+
+    Usage::
+
+        python -m presidio_x402.treasury_binding export ENVELOPE.json \\
+            --settlement settle.json --trust trust.json [--key-file policy.key] \\
+            [--key-id ID] [--algorithm ed25519|hmac-sha256] > bundle.json
+        python -m presidio_x402.treasury_binding verify BUNDLE.json TRUST.json
+    """
+    import argparse
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(prog="presidio_x402.treasury_binding")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    exp = sub.add_parser("export", help="export a verified decision + settlement as a bundle")
+    exp.add_argument("envelope", help="path to a decision-ref envelope .json")
+    exp.add_argument("--settlement", required=True, help="path to a settlement-facts .json")
+    exp.add_argument(
+        "--trust", required=True, help="path to the trust-store .json to verify against"
+    )
+    exp.add_argument(
+        "--key-file",
+        default=None,
+        help="file holding the signing key (or set PRESIDIO_X402_EVIDENCE_KEY)",
+    )
+    exp.add_argument("--algorithm", default="ed25519", choices=["ed25519", "hmac-sha256"])
+    exp.add_argument("--key-id", default=None, help="trust-store key id to pin in the bundle")
+    exp.add_argument(
+        "--signer", default=None, help="override the signer id (must match the decision's)"
+    )
+
+    ver = sub.add_parser("verify", help="verify a bundle offline against a trust store")
+    ver.add_argument("bundle", help="path to a bundle .json")
+    ver.add_argument("trust_store", help="path to a trust-store .json")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "export":
+        try:
+            envelope = _read_json(args.envelope)
+            settlement_raw = _read_json(args.settlement)
+            trust_text = _read_json(args.trust)
+            signing_key = _load_signing_key(args.key_file)
+        except (OSError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        if not isinstance(envelope, dict) or not isinstance(settlement_raw, dict):
+            print("error: envelope and settlement must each be a JSON object", file=sys.stderr)
+            return 2
+        try:
+            facts = SettlementFacts.from_mapping(settlement_raw)
+            declared = settlement_raw.get("decision_ref")
+            bundle = export_bundle(
+                envelope,
+                facts,
+                trust_store=trust_text,  # type: ignore[arg-type]
+                signing_key=signing_key,
+                algorithm=args.algorithm,
+                signer=args.signer,
+                key_id=args.key_id,
+            )
+            if isinstance(declared, str) and declared and declared != bundle["decision_ref"]:
+                raise TreasuryBindingError(
+                    f"settlement file names decision_ref {declared!r} but the envelope's is "
+                    f"{bundle['decision_ref']!r}: refusing to join a settlement to a decision "
+                    "it was not observed with"
+                )
+        except EvidenceError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
+            return 1
+        json.dump(bundle, sys.stdout, sort_keys=True, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    try:
+        bundle = _read_json(args.bundle)
+        trust_text = _read_json(args.trust_store)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(bundle, dict):
+        print("error: bundle must be a JSON object", file=sys.stderr)
+        return 2
+    result = verify_bundle(bundle, trust_text)  # type: ignore[arg-type]
+    detail = f"/{result.detail}" if result.detail else ""
+    status = "OK" if result.ok else f"FAIL({result.reason}{detail})"
+    print(
+        f"{result.decision_ref or '<no-ref>'}  verdict={result.verdict}  "
+        f"settlement={result.settlement_key or '<none>'}  {status}"
+    )
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/conformance/test_treasury_binding_vectors.py
+++ b/tests/conformance/test_treasury_binding_vectors.py
@@ -1,0 +1,289 @@
+"""Python side of the treasury-binding cross-language conformance vectors.
+
+These vectors are the *normative* contract between this repository's Python
+canonicaliser and the sibling Rust one — the binding's correctness rests on the
+bytes agreeing, not on any shared code. This file proves the Python half:
+``mica.canonical_bytes`` + ``sha256_hex`` + ``sign_evidence`` reproduce every
+pinned vector byte-for-byte, and every rejection case is refused with a *typed*
+error rather than an interpreter accident.
+
+The Rust half is a companion test in the ledger repository over these same
+files. Until it lands, Gate 1 ("green on both sides") is met only halfway — the
+gap is tracked, not papered over: nothing here asserts anything about Rust.
+
+Hard axes covered, one test each: non-ASCII escaping (emoji, combining marks,
+DEL, C0 controls), key ordering on non-ASCII keys, lone surrogates, non-string
+object keys, integers past i64::MAX, floats, and the depth boundary at 128/129.
+Plus the two family negatives, which a signature-only verifier would admit.
+
+Regenerate the vectors with ``tests/conformance/treasury-binding/build_vectors.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from presidio_x402.decision_ref import (
+    REASON_SIGNER_EQUALS_RUNTIME,
+    REASON_VERDICT_NOT_RECOMPUTABLE,
+    verify_decision_ref,
+)
+from presidio_x402.mica import (
+    EvidenceError,
+    canonical_bytes,
+    load_trust_store,
+    sha256_hex,
+    sign_evidence,
+)
+from presidio_x402.treasury_binding import (
+    SettlementFacts,
+    TreasuryBindingError,
+    build_settlement_ref_content,
+    check_canonical_depth,
+    verify_settlement_ref,
+)
+
+ROOT = Path(__file__).parent / "treasury-binding"
+VECTORS = ROOT / "vectors"
+
+
+def _load(rel: str) -> dict:
+    return json.loads((VECTORS / rel).read_text(encoding="utf-8"))
+
+
+CANONICAL = _load("canonical-bytes.json")
+SETTLEMENT = _load("settlement-ref.json")
+NEGATIVES = _load("decision-ref-negatives.json")
+
+
+def _materialise(case: dict) -> object:
+    """Build a case's payload from whichever representation it uses.
+
+    Three kinds, because not every input is expressible as JSON text: ``inline``
+    is a literal, ``raw-json`` carries the exact source text (a lone surrogate is
+    legal JSON but has no in-memory equivalent on every runtime), and
+    ``construct`` is a recipe (a 129-deep literal is unreadable, and a
+    non-string-keyed object cannot be written as JSON at all).
+    """
+    kind = case["kind"]
+    if kind == "inline":
+        return case["payload"]
+    if kind == "raw-json":
+        return json.loads(case["payload_json"])
+    spec = case["construct"]
+    if spec["op"] == "nested-object":
+        node: object = spec["leaf"]
+        for _ in range(spec["depth"]):
+            node = {spec["key"]: node}
+        return node
+    if spec["op"] == "int-keyed-object":
+        return dict.fromkeys(spec["keys"], spec["value"])
+    raise AssertionError(f"unknown construct op {spec['op']!r}")
+
+
+# ---------------------------------------------------------------------------
+# Provenance — drift detection
+# ---------------------------------------------------------------------------
+
+
+def test_vectors_match_provenance_hashes():
+    """Every vector file's SHA-256 matches PROVENANCE.json.
+
+    A mismatch means a vector was hand-edited rather than regenerated, which
+    would silently move the contract the sibling implementation is pinned to.
+    """
+    prov = json.loads((ROOT / "PROVENANCE.json").read_text(encoding="utf-8"))
+    assert prov["source_repo"] == "presidio-hardened-x402"
+    assert prov["files"], "provenance must list the vector files"
+    for rel, expected in prov["files"].items():
+        actual = hashlib.sha256((VECTORS / rel).read_bytes()).hexdigest()
+        assert actual == expected, f"vector drift: {rel}"
+
+
+def test_depth_definition_is_pinned_in_the_vector_file():
+    """The boundary cases are meaningless without the definition they assume."""
+    assert "depth 0" in CANONICAL["depth_definition"]
+    assert "128 is accepted" in CANONICAL["depth_definition"]
+    assert "129 is rejected" in CANONICAL["depth_definition"]
+
+
+# ---------------------------------------------------------------------------
+# Layer 0 — canonical bytes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", CANONICAL["accept"], ids=[c["name"] for c in CANONICAL["accept"]])
+def test_canonical_accept_cases_are_byte_identical(case: dict):
+    payload = _materialise(case)
+    produced = canonical_bytes(payload)
+    assert produced.hex() == case["canonical_hex"], case["name"]
+    assert hashlib.sha256(produced).hexdigest() == case["sha256"], case["name"]
+    if "canonical_utf8" in case:
+        assert produced.decode("utf-8") == case["canonical_utf8"]
+
+
+@pytest.mark.parametrize("case", CANONICAL["reject"], ids=[c["name"] for c in CANONICAL["reject"]])
+def test_canonical_reject_cases_fail_closed_with_a_typed_error(case: dict):
+    payload = _materialise(case)
+    if case["reject_reason"] == "too-deep":
+        # The canonicaliser itself has no depth cap on this side; the bound lives
+        # on the export path, which is the only path a sibling ever consumes.
+        with pytest.raises(TreasuryBindingError):
+            check_canonical_depth(payload)
+        return
+    with pytest.raises(EvidenceError):
+        canonical_bytes(payload)
+
+
+def test_depth_boundary_accepts_128_and_rejects_129():
+    """Both sides of the boundary, asserted against the pinned definition."""
+    accept = next(c for c in CANONICAL["accept"] if c["name"] == "nested-depth-128")
+    reject = next(c for c in CANONICAL["reject"] if c["name"] == "nested-depth-129")
+    check_canonical_depth(_materialise(accept))  # must not raise
+    with pytest.raises(TreasuryBindingError):
+        check_canonical_depth(_materialise(reject))
+
+
+def test_lone_surrogate_raises_evidence_error_not_unicode_error():
+    """Error-type parity: the family error, never a bare UnicodeEncodeError.
+
+    A caller catching ``EvidenceError`` at the boundary would otherwise see a
+    ``UnicodeEncodeError`` escape and turn a fail-closed refusal into a crash.
+    """
+    payload = json.loads('{"k":"\\ud800"}')
+    with pytest.raises(EvidenceError) as excinfo:
+        canonical_bytes(payload)
+    assert not isinstance(excinfo.value, UnicodeEncodeError)
+    assert "surrogate" in str(excinfo.value)
+
+
+def test_non_ascii_key_order_equals_code_point_order():
+    """UTF-8 byte order IS code-point order — pinned, not assumed."""
+    case = next(c for c in CANONICAL["accept"] if c["name"] == "non-ascii-keys")
+    keys = list(case["payload"].keys())
+    encoded = canonical_bytes(case["payload"]).decode("utf-8")
+    positions = [encoded.index(f'"{k}"') for k in sorted(keys)]
+    assert positions == sorted(positions)
+    assert sorted(keys) == sorted(keys, key=lambda k: k.encode("utf-8"))
+
+
+def test_nfc_and_nfd_spellings_do_not_collapse():
+    """Two spellings of one grapheme are distinct records, not one."""
+    case = next(c for c in CANONICAL["accept"] if c["name"] == "non-ascii-escaping")
+    payload = case["payload"]
+    assert payload["combining"] != payload["precomposed"]
+    assert canonical_bytes(payload["combining"]) != canonical_bytes(payload["precomposed"])
+
+
+# ---------------------------------------------------------------------------
+# settlement-ref@1 golden
+# ---------------------------------------------------------------------------
+
+
+def test_settlement_ref_golden_reproduces_byte_for_byte():
+    golden = SETTLEMENT["golden"]
+    content = golden["content"]
+    facts = SettlementFacts.from_mapping(content["settlement"])
+    rebuilt = build_settlement_ref_content(
+        decision_ref=content["decision_ref"], facts=facts, issued_at=content["issued_at"]
+    )
+    assert rebuilt == content
+    encoded = canonical_bytes(rebuilt)
+    assert encoded.hex() == golden["canonical_hex"]
+    assert encoded.decode("utf-8") == golden["canonical_utf8"]
+    assert sha256_hex(rebuilt) == golden["content_hash"]
+    assert facts.settlement_key == golden["settlement_key"]
+
+
+def test_settlement_ref_signature_is_reproducible_and_signer_bound():
+    golden = SETTLEMENT["golden"]
+    signer = golden["envelope"]["evidence"][0]["signer"]
+    signature = sign_evidence(
+        golden["content_hash"],
+        signer,
+        algorithm="ed25519",
+        key="01" * 32,
+    )
+    assert signature == golden["signature_hex"]
+    # The signed message binds the signer id, so re-labelling the record breaks it.
+    other = sign_evidence(
+        golden["content_hash"], "someone-else", algorithm="ed25519", key="01" * 32
+    )
+    assert other != golden["signature_hex"]
+
+
+def test_settlement_ref_envelope_verifies_against_the_pinned_trust_store():
+    trust = load_trust_store(SETTLEMENT["trust_store"])
+    envelope = SETTLEMENT["golden"]["envelope"]
+    ok, reason, ref = verify_settlement_ref(envelope, trust)
+    assert ok, reason
+    assert ref == SETTLEMENT["golden"]["content_hash"]
+
+
+def test_settlement_ref_tampered_field_fails_closed():
+    """Mutating a committed fact breaks the content hash, not just the meaning."""
+    trust = load_trust_store(SETTLEMENT["trust_store"])
+    envelope = json.loads(json.dumps(SETTLEMENT["golden"]["envelope"]))
+    envelope["settlement"]["settlement"]["log_index"] += 1
+    ok, reason, _ = verify_settlement_ref(envelope, trust)
+    assert not ok and reason == "settlement_hash_mismatch"
+
+
+@pytest.mark.parametrize(
+    "case", SETTLEMENT["reject"], ids=[c["name"] for c in SETTLEMENT["reject"]]
+)
+def test_settlement_facts_reject_cases(case: dict):
+    with pytest.raises(EvidenceError):
+        SettlementFacts.from_mapping(case["settlement"])
+
+
+@pytest.mark.parametrize(
+    "case", SETTLEMENT["normalisation"], ids=[c["name"] for c in SETTLEMENT["normalisation"]]
+)
+def test_settlement_facts_normalisation(case: dict):
+    facts = SettlementFacts(
+        chain=case["chain"], tx_hash=case["input"], block_number=1, log_index=0
+    )
+    assert facts.tx_hash == case["canonical"]
+
+
+# ---------------------------------------------------------------------------
+# The two family negatives — a signature-only verifier admits both
+# ---------------------------------------------------------------------------
+
+_NEG_IDS = [v["id"] for v in NEGATIVES["vectors"]]
+
+
+@pytest.mark.parametrize("vector", NEGATIVES["vectors"], ids=_NEG_IDS)
+def test_decision_negatives_grade_as_expected(vector: dict):
+    trust = dict(NEGATIVES["trust_store"])
+    trust.update(vector.get("trust_store_override", {}))
+    result = verify_decision_ref(vector["envelope"], trust)
+    assert result.ok == (vector["expect"] == "accept"), (vector["id"], result.reason)
+    if vector["expect"] == "reject":
+        expected = {
+            "signer_equals_runtime": REASON_SIGNER_EQUALS_RUNTIME,
+            "verdict_not_recomputable": REASON_VERDICT_NOT_RECOMPUTABLE,
+        }[vector["failure_mode"]]
+        assert result.reason == expected
+
+
+def test_negatives_are_cryptographically_valid_so_only_semantics_reject_them():
+    """The point of the pair: both signatures verify. Signature checking alone
+    is not admission control."""
+    for vector in NEGATIVES["vectors"]:
+        if vector["expect"] != "reject":
+            continue
+        ref = vector["envelope"]["evidence"][0]
+        signer = ref["signer"]
+        assert sign_evidence(ref["content_hash"], signer, key="01" * 32) == ref["signature"]
+
+
+def test_vector_set_leads_with_the_negatives():
+    modes = {v.get("failure_mode") for v in NEGATIVES["vectors"]}
+    assert {"signer_equals_runtime", "verdict_not_recomputable"} <= modes
+    assert any(v["expect"] == "accept" for v in NEGATIVES["vectors"])

--- a/tests/conformance/treasury-binding/PROVENANCE.json
+++ b/tests/conformance/treasury-binding/PROVENANCE.json
@@ -1,0 +1,21 @@
+{
+  "files": {
+    "canonical-bytes.json": "3bfde947d51f5729a7935d717c62fc5eeb1e52b8abc0956838c565655c723d91",
+    "decision-ref-negatives.json": "a32e57b1c18c1e1a0b90b53eebab6cd6491d791762d4e0f2c3724837eb829441",
+    "settlement-ref.json": "6e8d4a9cda412049d64eebb7b7ff0773b87b8c5fa18c25f32b7e96e32d74af1a"
+  },
+  "generated_at": "2026-07-26",
+  "generator": "tests/conformance/treasury-binding/build_vectors.py",
+  "note": "Authored here (not vendored) and vendored INTO the sibling Rust repository, where an equivalent test must reproduce every sha256 and accept every pinned signature. Regenerate with build_vectors.py; a hash that moves without a generator change means a vector was edited in place.",
+  "schema_ids": [
+    "presidio-hardened/evidence-ref@1",
+    "presidio-hardened-x402/payment-decision@1",
+    "presidio-hardened-x402/settlement-ref@1"
+  ],
+  "source_repo": "presidio-hardened-x402",
+  "test_key": {
+    "private_key_hex": "0101010101010101010101010101010101010101010101010101010101010101",
+    "public_key_hex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",
+    "signer": "presidio-hardened-x402-policy"
+  }
+}

--- a/tests/conformance/treasury-binding/README.md
+++ b/tests/conformance/treasury-binding/README.md
@@ -1,0 +1,92 @@
+# Treasury-binding conformance vectors
+
+The **normative cross-language contract** for the treasury binding. x402 is
+Python, the ledger it binds to is Rust, and there is no `import` across that
+boundary in either direction. The contract is the *bytes* — so the binding's
+correctness rests on these vectors, not on any shared code.
+
+```
+tools/tests/conformance/treasury-binding/     ← authored here
+  vectors/canonical-bytes.json                  the shared canonical-JSON profile
+  vectors/settlement-ref.json                   the signed join record, golden + rejects
+  vectors/decision-ref-negatives.json           the two family negatives
+  PROVENANCE.json                               per-file sha256 (drift detection)
+  build_vectors.py                              deterministic generator
+```
+
+Python side: `tests/conformance/test_treasury_binding_vectors.py` (in CI).
+Rust side: a companion test in the ledger repository over these same files —
+**not yet landed**. Until it does, "green on both sides" is half-proven, and
+nothing in this repository claims otherwise.
+
+## What each file pins
+
+**`canonical-bytes.json`** — the strict profile: sorted keys, `(",", ":")`
+separators, UTF-8, `ensure_ascii=False`, floats and non-string keys rejected.
+Every accept case carries `canonical_hex`, a hex dump of the expected bytes, so
+no whitespace or escaping question is left to interpretation.
+
+Cases are one of three kinds, because not every input can be written as JSON:
+
+| kind | why | example |
+|---|---|---|
+| `inline` | a literal payload | the ASCII baseline |
+| `raw-json` | the exact source text matters | a lone surrogate is legal JSON text with no valid UTF-8 encoding |
+| `construct` | a recipe | a 129-deep literal is unreadable; a non-string-keyed object cannot be written as JSON at all |
+
+**The depth definition is pinned in the file and must be read before grading
+the boundary cases.** The top-level value is at depth 0; every step into a
+nested container adds 1; depth 128 is accepted and depth 129 is rejected. An
+off-by-one in the *definition* grades the two boundary vectors in opposite
+directions, which looks exactly like a canonicaliser bug and is not one.
+
+**`settlement-ref.json`** — the `settlement-ref@1` join record: canonical bytes,
+content hash, signing message, detached signature under the pinned test key, and
+the `settlement_key` a ledger enforces uniqueness on. Plus the schema rejections
+that keep "both sides accept, or both reject" true: integers past `i64::MAX`,
+negative and boolean indices, floats, a rail nickname where a CAIP-2 chain id
+belongs, a malformed transaction hash, and the incomplete-facts case an operator
+hits when they skip the chain lookup.
+
+**`decision-ref-negatives.json`** — the two family negatives as complete signed
+envelopes. Both are cryptographically valid; both must still be rejected. A
+verifier that checks only the signature admits both, which is the entire point
+of shipping them:
+
+- `decision-signer-equals-runtime` — the signer resolves to the actor's own
+  payment wallet. Self-approval is not a second opinion.
+- `decision-verdict-not-recomputable` — the recorded verdict is not
+  `f(controls)`. Signed over the tampered content, so hash and signature both
+  check out; only recomputation catches it.
+
+## The axes, and what is actually at risk on each
+
+| axis | risk | status |
+|---|---|---|
+| non-ASCII escaping | the two encoders escape differently and hashes diverge on any record with an emoji, an accent, or a control character | **highest attention.** Both are believed to pass non-ASCII through raw and to use `\b \f \n \r \t` + `\u00xx`; pinned here so it is proven, not assumed |
+| key ordering on non-ASCII keys | assumed divergent in an earlier draft; it is not | UTF-8 byte-lexicographic order **is** code-point order, by construction. Pinned so a future toolchain change cannot break the equality silently |
+| lone surrogates | one side crashes where the other refuses | both reject, at *different layers* — Rust cannot parse it into a `String`, Python parses it and cannot encode it. The contract is that both reject with a typed error, not that both reject in the same place |
+| non-string object keys | `json.dumps` sorts integer keys numerically (1, 2, 10) and only then stringifies; every sibling sorts the strings (`"1"`, `"10"`, `"2"`) | a **producer-side** guard: unreachable from JSON text, so Rust satisfies it trivially and Python must enforce it explicitly |
+| integers past `i64`/`u64` | representable in Python, not in Rust | schema-bounded on `block_number`/`log_index` to `[0, i64::MAX]` — the only integers a sibling ever canonicalises here |
+| floats | not portable across encoders | both reject |
+| depth | Rust caps at 128; Python's canonicaliser has no cap | the bound is enforced on the export path, the only path a sibling consumes |
+
+## Regenerating
+
+```bash
+python tests/conformance/treasury-binding/build_vectors.py
+```
+
+Deterministic: every timestamp is pinned, so an unchanged generator reproduces
+byte-identical files. A `PROVENANCE.json` hash that moves without a generator
+change means a vector was hand-edited — investigate before trusting any
+conformance result, on either side.
+
+## Companion (out of this repository's control)
+
+The ledger side vendors these files and adds a test asserting that its own
+`canonical_bytes` + `sha256` reproduce every `content_hash`, that its Ed25519
+verify accepts every pinned signature, and that the hard cases are accepted or
+rejected identically. That test is authored there, tracked as part of the
+inbound-evidence companion change, and is what turns this half-proof into the
+byte-interop guarantee the binding rests on.

--- a/tests/conformance/treasury-binding/build_vectors.py
+++ b/tests/conformance/treasury-binding/build_vectors.py
@@ -1,0 +1,565 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
+"""Regenerate the treasury-binding cross-language conformance vectors.
+
+Run from this directory::
+
+    python build_vectors.py
+
+Deterministic by construction — every timestamp is pinned, so a re-run of an
+unchanged generator reproduces byte-identical files and ``PROVENANCE.json``
+hashes. A hash that moves without a generator change means a vector was edited
+in place; investigate before trusting any conformance result.
+
+These vectors are the **normative contract** between this repository's Python
+canonicaliser (``presidio_x402.mica``) and the sibling Rust one. They are
+authored here and vendored *into* the Rust repository, where an equivalent test
+must reproduce every ``sha256`` and accept every pinned signature — see
+``README.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from presidio_x402.decision_ref import (  # noqa: E402
+    ControlResults,
+    build_decision_evidence,
+    build_payment_decision_content,
+    compute_decision_ref,
+)
+from presidio_x402.mica import canonical_bytes, sha256_hex, sign_evidence  # noqa: E402
+from presidio_x402.treasury_binding import (  # noqa: E402
+    SettlementFacts,
+    build_settlement_evidence,
+    build_settlement_ref_content,
+)
+
+HERE = Path(__file__).resolve().parent
+VECTORS = HERE / "vectors"
+
+#: The family test key (private ``01`` × 32). Public key is pinned in every
+#: sibling repository's trust-store vector.
+PRIV_HEX = "01" * 32
+PUB_HEX = "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+SIGNER = "presidio-hardened-x402-policy"
+KEY_ID = "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3"
+
+#: Pinned so the generator is deterministic.
+ISSUED_AT = "2026-07-26T12:00:00.000Z"
+GENERATED_AT = "2026-07-26"
+SOURCE_VERSION = "0.10.0"
+
+MAX_DEPTH = 128
+
+
+def _accept(name: str, payload: object, note: str = "") -> dict:
+    encoded = canonical_bytes(payload)
+    return {
+        "name": name,
+        "kind": "inline",
+        "payload": payload,
+        "expect": "accept",
+        "canonical_hex": encoded.hex(),
+        "canonical_utf8": encoded.decode("utf-8"),
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+        "note": note,
+    }
+
+
+def _nested(depth: int) -> object:
+    """``depth`` nested single-key objects with a string leaf.
+
+    The leaf sits at exactly ``depth`` under the shared depth definition (the
+    top-level value is at depth 0; every step into a container adds 1), so
+    ``_nested(128)`` is the last accepted shape and ``_nested(129)`` the first
+    rejected one. Expressed constructively rather than as a literal so both
+    languages build the same shape without a 129-level-deep JSON file.
+    """
+    node: object = "x"
+    for _ in range(depth):
+        node = {"a": node}
+    return node
+
+
+def canonical_vectors() -> dict:
+    accept = [
+        _accept(
+            "ascii-baseline",
+            {"b": "2", "a": "1"},
+            "sorted keys, no spaces — the profile's floor.",
+        ),
+        _accept(
+            "non-ascii-escaping",
+            {
+                "emoji": "payment 💸 settled",
+                "combining": "égalité",
+                "precomposed": "égalité",
+                "del": "before\u007fafter",
+                "c0-control": "line\u0001break",
+                "tab-newline": "a\tb\nc\rd\be\ff",
+            },
+            "THE high-attention axis (R1). Both sides must pass non-ASCII through as raw "
+            "UTF-8, use the short forms \\b \\f \\n \\r \\t, and \\u00xx-escape other C0 "
+            "controls. U+007F DEL is NOT escaped by either side. NFC and NFD spellings of "
+            "the same grapheme are distinct byte sequences and must not fold together.",
+        ),
+        _accept(
+            "non-ascii-keys",
+            {"zebra": 1, "écu": 2, "über": 3, "中": 4, "a": 5},
+            "Key ordering is proven-equal, not assumed: UTF-8 byte-lexicographic order IS "
+            "code-point order by construction, so Python's sort_keys (code point) and a "
+            "Rust String sort (UTF-8 bytes) agree. Pinned so a future toolchain change "
+            "cannot silently break the equality.",
+        ),
+        _accept(
+            "integer-boundaries",
+            {"i64_max": 2**63 - 1, "zero": 0, "one": 1},
+            "The largest integer the shared profile admits. Anything above it is "
+            "schema-rejected on the settlement-ref (see settlement-ref.json).",
+        ),
+        _accept(
+            "nested-depth-128",
+            _nested(MAX_DEPTH),
+            "Depth boundary, accepted side. Leaf at depth 128 with the top-level value at "
+            "depth 0.",
+        ),
+    ]
+    # The depth-128 case is huge as an inline literal; carry it constructively.
+    accept[-1] = {
+        "name": "nested-depth-128",
+        "kind": "construct",
+        "construct": {"op": "nested-object", "key": "a", "leaf": "x", "depth": MAX_DEPTH},
+        "expect": "accept",
+        "canonical_hex": canonical_bytes(_nested(MAX_DEPTH)).hex(),
+        "sha256": sha256_hex(_nested(MAX_DEPTH)),
+        "note": accept[-1]["note"],
+    }
+
+    reject = [
+        {
+            "name": "float-anywhere",
+            "kind": "inline",
+            "payload": {"amount": 0.1},
+            "expect": "reject",
+            "reject_reason": "float",
+            "rejects_at": {"python": "encode", "rust": "encode"},
+            "note": "Floats are not portable across encoders; both sides refuse rather "
+            "than emit an unverifiable content_hash.",
+        },
+        {
+            "name": "float-nested-in-array",
+            "kind": "inline",
+            "payload": {"xs": [1, 2, 3.0]},
+            "expect": "reject",
+            "reject_reason": "float",
+            "rejects_at": {"python": "encode", "rust": "encode"},
+            "note": "3.0 is a float even though it is integral — the guard is by type.",
+        },
+        {
+            "name": "lone-surrogate",
+            "kind": "raw-json",
+            "payload_json": '{"k":"\\ud800"}',
+            "expect": "reject",
+            "reject_reason": "lone-surrogate",
+            "rejects_at": {"python": "encode", "rust": "parse"},
+            "note": "RFC 8259 permits the escape, so the TEXT is well-formed JSON, but the "
+            "value has no UTF-8 encoding. The two sides reject at different layers — Rust "
+            "cannot even parse it into a String; Python parses it and fails to encode — so "
+            "the contract is that BOTH reject, with a typed error, not that both reject in "
+            "the same place. Python raises EvidenceError (never a bare UnicodeEncodeError).",
+        },
+        {
+            "name": "non-string-object-key",
+            "kind": "construct",
+            "construct": {"op": "int-keyed-object", "keys": [1, 10, 2], "value": "v"},
+            "expect": "reject",
+            "reject_reason": "non-string-key",
+            "rejects_at": {"python": "encode", "rust": "unrepresentable"},
+            "note": "Unreachable from JSON text — JSON has no non-string keys — so this is "
+            "a PRODUCER-side guard, not a parse-side one. It matters because Python's "
+            "json.dumps would sort integer keys numerically (1, 2, 10) and only then "
+            "stringify, while every sibling sorts the strings ('1', '10', '2'): a silent "
+            "hash divergence. Rust cannot construct the input at all, so 'both reject' "
+            "holds trivially on that side.",
+        },
+        {
+            "name": "nested-depth-129",
+            "kind": "construct",
+            "construct": {"op": "nested-object", "key": "a", "leaf": "x", "depth": MAX_DEPTH + 1},
+            "expect": "reject",
+            "reject_reason": "too-deep",
+            "rejects_at": {"python": "bound", "rust": "encode"},
+            "note": "Depth boundary, rejected side. Python's canonicaliser itself has no "
+            "depth cap (the interpreter's recursion limit is not a contract), so the bound "
+            "is enforced by treasury_binding.check_canonical_depth on the export path — "
+            "which is the only path whose output a sibling canonicaliser ever sees.",
+        },
+    ]
+    return {
+        "description": (
+            "Cross-language canonical-JSON contract for the treasury binding. Profile: "
+            'sorted keys, (",", ":") separators, UTF-8, ensure_ascii=False, floats and '
+            "non-string keys rejected. 'canonical_hex' is the hex dump of the expected "
+            "bytes so no whitespace or escaping question is left to interpretation."
+        ),
+        "depth_definition": (
+            "The top-level value is at depth 0; every step into a nested object or array "
+            "adds 1. A value at depth 128 is accepted; a value at depth 129 is rejected. "
+            "Pin this definition before grading the boundary vectors — an off-by-one in "
+            "the definition grades the two cases in opposite directions."
+        ),
+        "generated_at": GENERATED_AT,
+        "accept": accept,
+        "reject": reject,
+    }
+
+
+def _decision_envelope(*, verdict_override: str | None = None, self_signed: bool = False) -> dict:
+    controls = ControlResults(
+        pii_verdict="PII_REDACTED",
+        pii_entities=("EMAIL_ADDRESS",),
+        pii_mutated=True,
+        trusted_wallet_verdict="TRUSTED",
+        policy_verdict="ALLOW",
+        policy_snapshot_hash="sha256:" + "11" * 32,
+        replay_verdict="FRESH",
+        replay_fingerprint_hash="sha256:" + "22" * 32,
+        mpa_verdict="NOT_REQUIRED",
+        mpa_required=False,
+    )
+    pay_to = "0x00000000000000000000000000000000c0ffee00"
+    content = build_payment_decision_content(
+        agent_id="did:presidio:x402:conformance-agent",
+        payment_signer=pay_to,
+        network="base-sepolia",
+        binding="x402",
+        offer_hash="sha256:" + "33" * 32,
+        details_hash="sha256:" + "44" * 32,
+        pay_to=pay_to,
+        amount="0.010000",
+        currency="USDC",
+        resource_origin="https://conformance.invalid",
+        controls=controls,
+        issued_at=ISSUED_AT,
+    )
+    signer = pay_to if self_signed else SIGNER
+    if verdict_override is None:
+        envelope = build_decision_evidence(
+            content,
+            signing_key=PRIV_HEX,
+            signer=signer,
+            key_id=KEY_ID,
+            source_version=SOURCE_VERSION,
+        )
+        envelope["generated_at"] = ISSUED_AT
+        envelope["evidence"][0]["claimed_at"] = ISSUED_AT
+        return envelope
+
+    # A non-recomputable verdict cannot be produced by the emitter (it refuses to
+    # sign one), so the negative is assembled by hand and signed over the
+    # tampered content — exactly what an attacker would have to do.
+    content["verdict"] = verdict_override
+    a_hash = sha256_hex(content)
+    d_ref = compute_decision_ref(
+        artifact_hash=a_hash,
+        policy_version=str(content["policy_version"]),
+        verdict=verdict_override,
+    )
+    return {
+        "schema": "presidio-hardened/evidence-ref@1",
+        "use_case": "x402-payment-decision",
+        "source": signer,
+        "source_version": SOURCE_VERSION,
+        "generated_at": ISSUED_AT,
+        "attested_content": {"schema": content["schema"]},
+        "evidence": [
+            {
+                "item_id": d_ref,
+                "source": signer,
+                "source_version": SOURCE_VERSION,
+                "ledger_ref": f"x402-decision:{d_ref}",
+                "content_hash": a_hash,
+                "signer": signer,
+                "signature": sign_evidence(a_hash, signer, key=PRIV_HEX),
+                "claimed_at": ISSUED_AT,
+                "key_id": KEY_ID,
+            }
+        ],
+        "signing_algorithm": "ed25519",
+        "payment_decision": content,
+        "artifact_hash": a_hash,
+        "decision_ref": d_ref,
+        "key_id": KEY_ID,
+    }
+
+
+def decision_negative_vectors() -> dict:
+    baseline = _decision_envelope()
+    self_signed = _decision_envelope(self_signed=True)
+    not_recomputable = _decision_envelope(verdict_override="ALLOW")
+    # Force the mismatch: DENY the payment in controls while the record says ALLOW.
+    not_recomputable["payment_decision"]["controls"]["policy"]["verdict"] = "VIOLATION"
+    a_hash = sha256_hex(not_recomputable["payment_decision"])
+    d_ref = compute_decision_ref(
+        artifact_hash=a_hash,
+        policy_version=str(not_recomputable["payment_decision"]["policy_version"]),
+        verdict="ALLOW",
+    )
+    not_recomputable["artifact_hash"] = a_hash
+    not_recomputable["decision_ref"] = d_ref
+    ref = not_recomputable["evidence"][0]
+    ref["content_hash"] = a_hash
+    ref["item_id"] = d_ref
+    ref["ledger_ref"] = f"x402-decision:{d_ref}"
+    ref["signature"] = sign_evidence(a_hash, SIGNER, key=PRIV_HEX)
+
+    return {
+        "description": (
+            "The two family negatives, as complete signed envelopes. Both are "
+            "cryptographically valid — the signature verifies — and both MUST still be "
+            "rejected. A content type proves its worth by what it rejects: a verifier that "
+            "checks only the signature admits both of these."
+        ),
+        "generated_at": GENERATED_AT,
+        "trust_store": {SIGNER: {"alg": "ed25519", "public_key": PUB_HEX}},
+        "vectors": [
+            {
+                "id": "treasury-decision-baseline",
+                "expect": "accept",
+                "envelope": baseline,
+                "note": "Signed by a policy identity distinct from the payment wallet; "
+                "verdict recomputes from controls.",
+            },
+            {
+                "id": "decision-signer-equals-runtime",
+                "expect": "reject",
+                "failure_mode": "signer_equals_runtime",
+                "envelope": self_signed,
+                "trust_store_override": {
+                    "0x00000000000000000000000000000000c0ffee00": {
+                        "alg": "ed25519",
+                        "public_key": PUB_HEX,
+                    }
+                },
+                "note": "The signer resolves to the actor's own payment wallet. The "
+                "signature verifies and the verdict recomputes; admission is what fails. "
+                "Self-approval is not a second opinion.",
+            },
+            {
+                "id": "decision-verdict-not-recomputable",
+                "expect": "reject",
+                "failure_mode": "verdict_not_recomputable",
+                "envelope": not_recomputable,
+                "note": "controls.policy.verdict = VIOLATION, so f(controls) = DENY, while "
+                "the record claims ALLOW. Signed over the tampered content, so the hash and "
+                "the signature both check out — only recomputation catches it.",
+            },
+        ],
+    }
+
+
+def settlement_vectors() -> dict:
+    decision_ref = _decision_envelope()["decision_ref"]
+    facts = SettlementFacts(
+        chain="eip155:84532",
+        tx_hash="0x" + "ab" * 32,
+        block_number=19_284_411,
+        log_index=7,
+    )
+    content = build_settlement_ref_content(
+        decision_ref=decision_ref, facts=facts, issued_at=ISSUED_AT
+    )
+    envelope = build_settlement_evidence(
+        content,
+        signing_key=PRIV_HEX,
+        signer=SIGNER,
+        key_id=KEY_ID,
+        source_version=SOURCE_VERSION,
+    )
+    envelope["generated_at"] = ISSUED_AT
+    envelope["evidence"][0]["claimed_at"] = ISSUED_AT
+    encoded = canonical_bytes(content)
+
+    return {
+        "description": (
+            "The settlement-ref@1 join record: a signed, off-chain statement that one "
+            "decision authorized one settlement. Commits to five values and nothing else — "
+            "no calldata digest and no precedence timestamp, both of which are "
+            "unsatisfiable over an ERC-3009 settlement, and no payer address, which the "
+            "join does not need."
+        ),
+        "generated_at": GENERATED_AT,
+        "schema_id": content["schema"],
+        "trust_store": {SIGNER: {"alg": "ed25519", "public_key": PUB_HEX}},
+        "golden": {
+            "content": content,
+            "canonical_hex": encoded.hex(),
+            "canonical_utf8": encoded.decode("utf-8"),
+            "content_hash": hashlib.sha256(encoded).hexdigest(),
+            "settlement_key": facts.settlement_key,
+            "signing_message_canonical": canonical_bytes(
+                {"content_hash": hashlib.sha256(encoded).hexdigest(), "signer": SIGNER}
+            ).decode("utf-8"),
+            "signature_hex": envelope["evidence"][0]["signature"],
+            "public_key_hex": PUB_HEX,
+            "envelope": envelope,
+        },
+        "settlement_key_definition": (
+            "chain|tx_hash|log_index, '|' separated. This is the uniqueness key a "
+            "downstream ledger enforces 'at most one settlement-ref per (period, key)' on. "
+            "block_number is deliberately excluded: it is implied by the transaction hash, "
+            "and including it would let a wrong-but-plausible height mint a second distinct "
+            "key for one settlement."
+        ),
+        "reject": [
+            {
+                "name": "block-number-above-i64-max",
+                "settlement": {
+                    "chain": "eip155:84532",
+                    "tx_hash": "0x" + "ab" * 32,
+                    "block_number": 2**63,
+                    "log_index": 0,
+                },
+                "reject_reason": "integer-out-of-range",
+                "note": "Representable in Python, not in an i64. Bounded by schema so both "
+                "sides reject rather than one accepting silently.",
+            },
+            {
+                "name": "log-index-above-u64-max",
+                "settlement": {
+                    "chain": "eip155:84532",
+                    "tx_hash": "0x" + "ab" * 32,
+                    "block_number": 1,
+                    "log_index": 2**64,
+                },
+                "reject_reason": "integer-out-of-range",
+                "note": "Above u64::MAX as well as i64::MAX — rejected by the same bound.",
+            },
+            {
+                "name": "negative-block-number",
+                "settlement": {
+                    "chain": "eip155:84532",
+                    "tx_hash": "0x" + "ab" * 32,
+                    "block_number": -1,
+                    "log_index": 0,
+                },
+                "reject_reason": "integer-out-of-range",
+                "note": "A block height is unsigned.",
+            },
+            {
+                "name": "float-log-index",
+                "settlement": {
+                    "chain": "eip155:84532",
+                    "tx_hash": "0x" + "ab" * 32,
+                    "block_number": 1,
+                    "log_index": 7.0,
+                },
+                "reject_reason": "float",
+                "note": "Refused rather than truncated to 7.",
+            },
+            {
+                "name": "boolean-log-index",
+                "settlement": {
+                    "chain": "eip155:84532",
+                    "tx_hash": "0x" + "ab" * 32,
+                    "block_number": 1,
+                    "log_index": True,
+                },
+                "reject_reason": "integer-out-of-range",
+                "note": "bool is an int subclass in Python; True is not a log index.",
+            },
+            {
+                "name": "chain-not-caip2",
+                "settlement": {
+                    "chain": "base-sepolia",
+                    "tx_hash": "0x" + "ab" * 32,
+                    "block_number": 1,
+                    "log_index": 0,
+                },
+                "reject_reason": "chain-not-caip2",
+                "note": "A rail nickname is not a chain id. The mapping happens at capture "
+                "time; the committed value is always CAIP-2.",
+            },
+            {
+                "name": "tx-hash-not-evm",
+                "settlement": {
+                    "chain": "eip155:84532",
+                    "tx_hash": "0xdeadbeef",
+                    "block_number": 1,
+                    "log_index": 0,
+                },
+                "reject_reason": "tx-hash-malformed",
+                "note": "eip155 transaction hashes are 0x + 64 hex.",
+            },
+            {
+                "name": "missing-log-index",
+                "settlement": {
+                    "chain": "eip155:84532",
+                    "tx_hash": "0x" + "ab" * 32,
+                    "block_number": 1,
+                },
+                "reject_reason": "incomplete",
+                "note": "The settlement echo does not carry a log index, so an operator who "
+                "skips the chain lookup lands here. Required, not optional: without it "
+                "there is no key for the one-settlement-one-leg invariant.",
+            },
+        ],
+        "normalisation": [
+            {
+                "name": "evm-tx-hash-case",
+                "input": "0x" + "AB" * 32,
+                "chain": "eip155:84532",
+                "canonical": "0x" + "ab" * 32,
+                "note": "Case is normalised, not merely accepted, so two operators "
+                "exporting the same settlement produce byte-identical join records.",
+            }
+        ],
+    }
+
+
+def main() -> int:
+    VECTORS.mkdir(parents=True, exist_ok=True)
+    files = {
+        "canonical-bytes.json": canonical_vectors(),
+        "settlement-ref.json": settlement_vectors(),
+        "decision-ref-negatives.json": decision_negative_vectors(),
+    }
+    for name, payload in files.items():
+        text = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        (VECTORS / name).write_text(text, encoding="utf-8")
+
+    provenance = {
+        "source_repo": "presidio-hardened-x402",
+        "generator": "tests/conformance/treasury-binding/build_vectors.py",
+        "generated_at": GENERATED_AT,
+        "schema_ids": [
+            "presidio-hardened/evidence-ref@1",
+            "presidio-hardened-x402/payment-decision@1",
+            "presidio-hardened-x402/settlement-ref@1",
+        ],
+        "test_key": {"private_key_hex": PRIV_HEX, "public_key_hex": PUB_HEX, "signer": SIGNER},
+        "note": (
+            "Authored here (not vendored) and vendored INTO the sibling Rust repository, "
+            "where an equivalent test must reproduce every sha256 and accept every pinned "
+            "signature. Regenerate with build_vectors.py; a hash that moves without a "
+            "generator change means a vector was edited in place."
+        ),
+        "files": {
+            name: hashlib.sha256((VECTORS / name).read_bytes()).hexdigest() for name in files
+        },
+    }
+    (HERE / "PROVENANCE.json").write_text(
+        json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {len(files)} vector files + PROVENANCE.json to {HERE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conformance/treasury-binding/vectors/canonical-bytes.json
+++ b/tests/conformance/treasury-binding/vectors/canonical-bytes.json
@@ -1,0 +1,164 @@
+{
+  "accept": [
+    {
+      "canonical_hex": "7b2261223a2231222c2262223a2232227d",
+      "canonical_utf8": "{\"a\":\"1\",\"b\":\"2\"}",
+      "expect": "accept",
+      "kind": "inline",
+      "name": "ascii-baseline",
+      "note": "sorted keys, no spaces — the profile's floor.",
+      "payload": {
+        "a": "1",
+        "b": "2"
+      },
+      "sha256": "21f76dfbfe6dfe21f762080ef484112cf2952974cef30741fd1931e1c6d92112"
+    },
+    {
+      "canonical_hex": "7b2263302d636f6e74726f6c223a226c696e655c7530303031627265616b222c22636f6d62696e696e67223a2265cc8167616c697465cc81222c2264656c223a226265666f72657f6166746572222c22656d6f6a69223a227061796d656e7420f09f92b820736574746c6564222c22707265636f6d706f736564223a22c3a967616c6974c3a9222c227461622d6e65776c696e65223a22615c74625c6e635c72645c62655c6666227d",
+      "canonical_utf8": "{\"c0-control\":\"line\\u0001break\",\"combining\":\"égalité\",\"del\":\"beforeafter\",\"emoji\":\"payment 💸 settled\",\"precomposed\":\"égalité\",\"tab-newline\":\"a\\tb\\nc\\rd\\be\\ff\"}",
+      "expect": "accept",
+      "kind": "inline",
+      "name": "non-ascii-escaping",
+      "note": "THE high-attention axis (R1). Both sides must pass non-ASCII through as raw UTF-8, use the short forms \\b \\f \\n \\r \\t, and \\u00xx-escape other C0 controls. U+007F DEL is NOT escaped by either side. NFC and NFD spellings of the same grapheme are distinct byte sequences and must not fold together.",
+      "payload": {
+        "c0-control": "line\u0001break",
+        "combining": "égalité",
+        "del": "beforeafter",
+        "emoji": "payment 💸 settled",
+        "precomposed": "égalité",
+        "tab-newline": "a\tb\nc\rd\be\ff"
+      },
+      "sha256": "2e41bb93099a273d147a0af8c42fe0d7873d4e54c994d6dacc367ba4c2258356"
+    },
+    {
+      "canonical_hex": "7b2261223a352c227a65627261223a312c22c3a96375223a322c22c3bc626572223a332c22e4b8ad223a347d",
+      "canonical_utf8": "{\"a\":5,\"zebra\":1,\"écu\":2,\"über\":3,\"中\":4}",
+      "expect": "accept",
+      "kind": "inline",
+      "name": "non-ascii-keys",
+      "note": "Key ordering is proven-equal, not assumed: UTF-8 byte-lexicographic order IS code-point order by construction, so Python's sort_keys (code point) and a Rust String sort (UTF-8 bytes) agree. Pinned so a future toolchain change cannot silently break the equality.",
+      "payload": {
+        "a": 5,
+        "zebra": 1,
+        "écu": 2,
+        "über": 3,
+        "中": 4
+      },
+      "sha256": "8e7110ffef8f8c082d211342921d17265007868791ef1b6d30249e51200a47ea"
+    },
+    {
+      "canonical_hex": "7b226936345f6d6178223a393232333337323033363835343737353830372c226f6e65223a312c227a65726f223a307d",
+      "canonical_utf8": "{\"i64_max\":9223372036854775807,\"one\":1,\"zero\":0}",
+      "expect": "accept",
+      "kind": "inline",
+      "name": "integer-boundaries",
+      "note": "The largest integer the shared profile admits. Anything above it is schema-rejected on the settlement-ref (see settlement-ref.json).",
+      "payload": {
+        "i64_max": 9223372036854775807,
+        "one": 1,
+        "zero": 0
+      },
+      "sha256": "44d26709088307ff7dba764df73aef8ecd07cfdd576810008fda2d2bfc8632f6"
+    },
+    {
+      "canonical_hex": "7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a7b2261223a2278227d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d",
+      "construct": {
+        "depth": 128,
+        "key": "a",
+        "leaf": "x",
+        "op": "nested-object"
+      },
+      "expect": "accept",
+      "kind": "construct",
+      "name": "nested-depth-128",
+      "note": "Depth boundary, accepted side. Leaf at depth 128 with the top-level value at depth 0.",
+      "sha256": "70c885f92a071e0e17a5127ded31de9aff63160fe3a364fe0e4e98a78f27b5fa"
+    }
+  ],
+  "depth_definition": "The top-level value is at depth 0; every step into a nested object or array adds 1. A value at depth 128 is accepted; a value at depth 129 is rejected. Pin this definition before grading the boundary vectors — an off-by-one in the definition grades the two cases in opposite directions.",
+  "description": "Cross-language canonical-JSON contract for the treasury binding. Profile: sorted keys, (\",\", \":\") separators, UTF-8, ensure_ascii=False, floats and non-string keys rejected. 'canonical_hex' is the hex dump of the expected bytes so no whitespace or escaping question is left to interpretation.",
+  "generated_at": "2026-07-26",
+  "reject": [
+    {
+      "expect": "reject",
+      "kind": "inline",
+      "name": "float-anywhere",
+      "note": "Floats are not portable across encoders; both sides refuse rather than emit an unverifiable content_hash.",
+      "payload": {
+        "amount": 0.1
+      },
+      "reject_reason": "float",
+      "rejects_at": {
+        "python": "encode",
+        "rust": "encode"
+      }
+    },
+    {
+      "expect": "reject",
+      "kind": "inline",
+      "name": "float-nested-in-array",
+      "note": "3.0 is a float even though it is integral — the guard is by type.",
+      "payload": {
+        "xs": [
+          1,
+          2,
+          3.0
+        ]
+      },
+      "reject_reason": "float",
+      "rejects_at": {
+        "python": "encode",
+        "rust": "encode"
+      }
+    },
+    {
+      "expect": "reject",
+      "kind": "raw-json",
+      "name": "lone-surrogate",
+      "note": "RFC 8259 permits the escape, so the TEXT is well-formed JSON, but the value has no UTF-8 encoding. The two sides reject at different layers — Rust cannot even parse it into a String; Python parses it and fails to encode — so the contract is that BOTH reject, with a typed error, not that both reject in the same place. Python raises EvidenceError (never a bare UnicodeEncodeError).",
+      "payload_json": "{\"k\":\"\\ud800\"}",
+      "reject_reason": "lone-surrogate",
+      "rejects_at": {
+        "python": "encode",
+        "rust": "parse"
+      }
+    },
+    {
+      "construct": {
+        "keys": [
+          1,
+          10,
+          2
+        ],
+        "op": "int-keyed-object",
+        "value": "v"
+      },
+      "expect": "reject",
+      "kind": "construct",
+      "name": "non-string-object-key",
+      "note": "Unreachable from JSON text — JSON has no non-string keys — so this is a PRODUCER-side guard, not a parse-side one. It matters because Python's json.dumps would sort integer keys numerically (1, 2, 10) and only then stringify, while every sibling sorts the strings ('1', '10', '2'): a silent hash divergence. Rust cannot construct the input at all, so 'both reject' holds trivially on that side.",
+      "reject_reason": "non-string-key",
+      "rejects_at": {
+        "python": "encode",
+        "rust": "unrepresentable"
+      }
+    },
+    {
+      "construct": {
+        "depth": 129,
+        "key": "a",
+        "leaf": "x",
+        "op": "nested-object"
+      },
+      "expect": "reject",
+      "kind": "construct",
+      "name": "nested-depth-129",
+      "note": "Depth boundary, rejected side. Python's canonicaliser itself has no depth cap (the interpreter's recursion limit is not a contract), so the bound is enforced by treasury_binding.check_canonical_depth on the export path — which is the only path whose output a sibling canonicaliser ever sees.",
+      "reject_reason": "too-deep",
+      "rejects_at": {
+        "python": "bound",
+        "rust": "encode"
+      }
+    }
+  ]
+}

--- a/tests/conformance/treasury-binding/vectors/decision-ref-negatives.json
+++ b/tests/conformance/treasury-binding/vectors/decision-ref-negatives.json
@@ -1,0 +1,294 @@
+{
+  "description": "The two family negatives, as complete signed envelopes. Both are cryptographically valid — the signature verifies — and both MUST still be rejected. A content type proves its worth by what it rejects: a verifier that checks only the signature admits both of these.",
+  "generated_at": "2026-07-26",
+  "trust_store": {
+    "presidio-hardened-x402-policy": {
+      "alg": "ed25519",
+      "public_key": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+    }
+  },
+  "vectors": [
+    {
+      "envelope": {
+        "artifact_hash": "4d34360ed2218616d483bbe6b7a832be6620b5a85efe2d26a73bd7468c8d2caa",
+        "attested_content": {
+          "schema": "presidio-hardened-x402/payment-decision@1"
+        },
+        "decision_ref": "63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+        "decision_ref_preimage": {
+          "artifact_hash": "4d34360ed2218616d483bbe6b7a832be6620b5a85efe2d26a73bd7468c8d2caa",
+          "artifact_type": "presidio-hardened-x402/payment-decision@1",
+          "policy_version": "presidio-x402.policy.v1",
+          "verdict": "ALLOW"
+        },
+        "decision_ref_preimage_fields": [
+          "artifact_hash",
+          "artifact_type",
+          "policy_version",
+          "verdict"
+        ],
+        "disclaimer": "Proof-carrying record of one x402 payment decision under a declared predicate: it is tamper-evident (signed) and admissible (verdict = f(controls) recomputes). It does NOT prove the process was uncompromised or that the declared controls are the real controls (no TEE claim).",
+        "evidence": [
+          {
+            "claimed_at": "2026-07-26T12:00:00.000Z",
+            "content_hash": "4d34360ed2218616d483bbe6b7a832be6620b5a85efe2d26a73bd7468c8d2caa",
+            "item_id": "63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+            "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+            "ledger_ref": "x402-decision:63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+            "signature": "2162770ccdb37035d48d8093dd623812fbc67c0aa8055d1df5746b65283c48f34a77c504637bc007c5bc666c50ddb88e48efc5198017d6d6d3fd402dd452410d",
+            "signer": "presidio-hardened-x402-policy",
+            "source": "presidio-hardened-x402-policy",
+            "source_version": "0.10.0"
+          }
+        ],
+        "generated_at": "2026-07-26T12:00:00.000Z",
+        "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+        "payment_decision": {
+          "actor": {
+            "binding": "x402",
+            "network": "base-sepolia",
+            "payment_signer": "0x00000000000000000000000000000000c0ffee00"
+          },
+          "agent_id": "did:presidio:x402:conformance-agent",
+          "controls": {
+            "mpa": {
+              "required": false,
+              "verdict": "NOT_REQUIRED"
+            },
+            "pii": {
+              "entities": [
+                "EMAIL_ADDRESS"
+              ],
+              "mutated": true,
+              "verdict": "PII_REDACTED"
+            },
+            "policy": {
+              "policy_snapshot_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+              "verdict": "ALLOW"
+            },
+            "replay": {
+              "fingerprint_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+              "verdict": "FRESH"
+            },
+            "trusted_wallet": {
+              "verdict": "TRUSTED"
+            }
+          },
+          "issued_at": "2026-07-26T12:00:00.000Z",
+          "payment": {
+            "amount": "0.010000",
+            "currency": "USDC",
+            "details_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+            "offer_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+            "pay_to": "0x00000000000000000000000000000000c0ffee00",
+            "resource_origin": "https://conformance.invalid"
+          },
+          "policy_version": "presidio-x402.policy.v1",
+          "provenance": {
+            "parents": [],
+            "prior_decision_refs": []
+          },
+          "schema": "presidio-hardened-x402/payment-decision@1",
+          "verdict": "ALLOW"
+        },
+        "provenance": {
+          "parents": [],
+          "prior_decision_refs": []
+        },
+        "schema": "presidio-hardened/evidence-ref@1",
+        "signing_algorithm": "ed25519",
+        "source": "presidio-hardened-x402-policy",
+        "source_version": "0.10.0",
+        "use_case": "x402-payment-decision"
+      },
+      "expect": "accept",
+      "id": "treasury-decision-baseline",
+      "note": "Signed by a policy identity distinct from the payment wallet; verdict recomputes from controls."
+    },
+    {
+      "envelope": {
+        "artifact_hash": "4d34360ed2218616d483bbe6b7a832be6620b5a85efe2d26a73bd7468c8d2caa",
+        "attested_content": {
+          "schema": "presidio-hardened-x402/payment-decision@1"
+        },
+        "decision_ref": "63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+        "decision_ref_preimage": {
+          "artifact_hash": "4d34360ed2218616d483bbe6b7a832be6620b5a85efe2d26a73bd7468c8d2caa",
+          "artifact_type": "presidio-hardened-x402/payment-decision@1",
+          "policy_version": "presidio-x402.policy.v1",
+          "verdict": "ALLOW"
+        },
+        "decision_ref_preimage_fields": [
+          "artifact_hash",
+          "artifact_type",
+          "policy_version",
+          "verdict"
+        ],
+        "disclaimer": "Proof-carrying record of one x402 payment decision under a declared predicate: it is tamper-evident (signed) and admissible (verdict = f(controls) recomputes). It does NOT prove the process was uncompromised or that the declared controls are the real controls (no TEE claim).",
+        "evidence": [
+          {
+            "claimed_at": "2026-07-26T12:00:00.000Z",
+            "content_hash": "4d34360ed2218616d483bbe6b7a832be6620b5a85efe2d26a73bd7468c8d2caa",
+            "item_id": "63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+            "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+            "ledger_ref": "x402-decision:63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+            "signature": "5c95fd77fa26ddd21f6ecf6b2d08bc8124fab35a4e703b070ee4c777edadd6cff4f5199eefbd33f3276e1bfcf46674f99ef457f528c52aa88e8242a0247ea300",
+            "signer": "0x00000000000000000000000000000000c0ffee00",
+            "source": "0x00000000000000000000000000000000c0ffee00",
+            "source_version": "0.10.0"
+          }
+        ],
+        "generated_at": "2026-07-26T12:00:00.000Z",
+        "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+        "payment_decision": {
+          "actor": {
+            "binding": "x402",
+            "network": "base-sepolia",
+            "payment_signer": "0x00000000000000000000000000000000c0ffee00"
+          },
+          "agent_id": "did:presidio:x402:conformance-agent",
+          "controls": {
+            "mpa": {
+              "required": false,
+              "verdict": "NOT_REQUIRED"
+            },
+            "pii": {
+              "entities": [
+                "EMAIL_ADDRESS"
+              ],
+              "mutated": true,
+              "verdict": "PII_REDACTED"
+            },
+            "policy": {
+              "policy_snapshot_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+              "verdict": "ALLOW"
+            },
+            "replay": {
+              "fingerprint_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+              "verdict": "FRESH"
+            },
+            "trusted_wallet": {
+              "verdict": "TRUSTED"
+            }
+          },
+          "issued_at": "2026-07-26T12:00:00.000Z",
+          "payment": {
+            "amount": "0.010000",
+            "currency": "USDC",
+            "details_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+            "offer_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+            "pay_to": "0x00000000000000000000000000000000c0ffee00",
+            "resource_origin": "https://conformance.invalid"
+          },
+          "policy_version": "presidio-x402.policy.v1",
+          "provenance": {
+            "parents": [],
+            "prior_decision_refs": []
+          },
+          "schema": "presidio-hardened-x402/payment-decision@1",
+          "verdict": "ALLOW"
+        },
+        "provenance": {
+          "parents": [],
+          "prior_decision_refs": []
+        },
+        "schema": "presidio-hardened/evidence-ref@1",
+        "signing_algorithm": "ed25519",
+        "source": "0x00000000000000000000000000000000c0ffee00",
+        "source_version": "0.10.0",
+        "use_case": "x402-payment-decision"
+      },
+      "expect": "reject",
+      "failure_mode": "signer_equals_runtime",
+      "id": "decision-signer-equals-runtime",
+      "note": "The signer resolves to the actor's own payment wallet. The signature verifies and the verdict recomputes; admission is what fails. Self-approval is not a second opinion.",
+      "trust_store_override": {
+        "0x00000000000000000000000000000000c0ffee00": {
+          "alg": "ed25519",
+          "public_key": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+        }
+      }
+    },
+    {
+      "envelope": {
+        "artifact_hash": "215a7c3e509eca2fb29d9a1d450cdedbca9d9f5d6cb57da6aadb439925fe7429",
+        "attested_content": {
+          "schema": "presidio-hardened-x402/payment-decision@1"
+        },
+        "decision_ref": "0ac21516afda683775922eaa4270f24535b8352f63c3080580812d0f9acefade",
+        "evidence": [
+          {
+            "claimed_at": "2026-07-26T12:00:00.000Z",
+            "content_hash": "215a7c3e509eca2fb29d9a1d450cdedbca9d9f5d6cb57da6aadb439925fe7429",
+            "item_id": "0ac21516afda683775922eaa4270f24535b8352f63c3080580812d0f9acefade",
+            "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+            "ledger_ref": "x402-decision:0ac21516afda683775922eaa4270f24535b8352f63c3080580812d0f9acefade",
+            "signature": "a5dd8e6409bd3bb6e54c8b940c974d50d86e183b65c971f1d360015d862c602b7cafa16618ab27c5465efb2a5d97aaab7b26a888353d5d8cdd0a57bc2a396502",
+            "signer": "presidio-hardened-x402-policy",
+            "source": "presidio-hardened-x402-policy",
+            "source_version": "0.10.0"
+          }
+        ],
+        "generated_at": "2026-07-26T12:00:00.000Z",
+        "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+        "payment_decision": {
+          "actor": {
+            "binding": "x402",
+            "network": "base-sepolia",
+            "payment_signer": "0x00000000000000000000000000000000c0ffee00"
+          },
+          "agent_id": "did:presidio:x402:conformance-agent",
+          "controls": {
+            "mpa": {
+              "required": false,
+              "verdict": "NOT_REQUIRED"
+            },
+            "pii": {
+              "entities": [
+                "EMAIL_ADDRESS"
+              ],
+              "mutated": true,
+              "verdict": "PII_REDACTED"
+            },
+            "policy": {
+              "policy_snapshot_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+              "verdict": "VIOLATION"
+            },
+            "replay": {
+              "fingerprint_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+              "verdict": "FRESH"
+            },
+            "trusted_wallet": {
+              "verdict": "TRUSTED"
+            }
+          },
+          "issued_at": "2026-07-26T12:00:00.000Z",
+          "payment": {
+            "amount": "0.010000",
+            "currency": "USDC",
+            "details_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+            "offer_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+            "pay_to": "0x00000000000000000000000000000000c0ffee00",
+            "resource_origin": "https://conformance.invalid"
+          },
+          "policy_version": "presidio-x402.policy.v1",
+          "provenance": {
+            "parents": [],
+            "prior_decision_refs": []
+          },
+          "schema": "presidio-hardened-x402/payment-decision@1",
+          "verdict": "ALLOW"
+        },
+        "schema": "presidio-hardened/evidence-ref@1",
+        "signing_algorithm": "ed25519",
+        "source": "presidio-hardened-x402-policy",
+        "source_version": "0.10.0",
+        "use_case": "x402-payment-decision"
+      },
+      "expect": "reject",
+      "failure_mode": "verdict_not_recomputable",
+      "id": "decision-verdict-not-recomputable",
+      "note": "controls.policy.verdict = VIOLATION, so f(controls) = DENY, while the record claims ALLOW. Signed over the tampered content, so the hash and the signature both check out — only recomputation catches it."
+    }
+  ]
+}

--- a/tests/conformance/treasury-binding/vectors/settlement-ref.json
+++ b/tests/conformance/treasury-binding/vectors/settlement-ref.json
@@ -1,0 +1,171 @@
+{
+  "description": "The settlement-ref@1 join record: a signed, off-chain statement that one decision authorized one settlement. Commits to five values and nothing else — no calldata digest and no precedence timestamp, both of which are unsatisfiable over an ERC-3009 settlement, and no payer address, which the join does not need.",
+  "generated_at": "2026-07-26",
+  "golden": {
+    "canonical_hex": "7b226465636973696f6e5f726566223a2236336336376266326665643361373466633065326435366363363733663631326435306561353933393262633237633433633664623835646439393236653037222c226973737565645f6174223a22323032362d30372d32365431323a30303a30302e3030305a222c22736368656d61223a22707265736964696f2d68617264656e65642d783430322f736574746c656d656e742d7265664031222c22736574746c656d656e74223a7b22626c6f636b5f6e756d626572223a31393238343431312c22636861696e223a226569703135353a3834353332222c226c6f675f696e646578223a372c2274785f68617368223a22307861626162616261626162616261626162616261626162616261626162616261626162616261626162616261626162616261626162616261626162616261626162227d7d",
+    "canonical_utf8": "{\"decision_ref\":\"63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07\",\"issued_at\":\"2026-07-26T12:00:00.000Z\",\"schema\":\"presidio-hardened-x402/settlement-ref@1\",\"settlement\":{\"block_number\":19284411,\"chain\":\"eip155:84532\",\"log_index\":7,\"tx_hash\":\"0xabababababababababababababababababababababababababababababababab\"}}",
+    "content": {
+      "decision_ref": "63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+      "issued_at": "2026-07-26T12:00:00.000Z",
+      "schema": "presidio-hardened-x402/settlement-ref@1",
+      "settlement": {
+        "block_number": 19284411,
+        "chain": "eip155:84532",
+        "log_index": 7,
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    },
+    "content_hash": "426827c5d9c50af6a3f6351f5e6ed5d618c5074eff529ef3b471b18abb0a0b71",
+    "envelope": {
+      "artifact_hash": "426827c5d9c50af6a3f6351f5e6ed5d618c5074eff529ef3b471b18abb0a0b71",
+      "attested_content": {
+        "schema": "presidio-hardened-x402/settlement-ref@1"
+      },
+      "decision_ref": "63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+      "disclaimer": "Signed off-chain join record: the x402 policy signer asserts that the named decision authorized the named settlement. It is NOT an on-chain anchor and proves nothing about the transaction beyond the signer's assertion; the transaction itself must be observed independently on the chain.",
+      "evidence": [
+        {
+          "claimed_at": "2026-07-26T12:00:00.000Z",
+          "content_hash": "426827c5d9c50af6a3f6351f5e6ed5d618c5074eff529ef3b471b18abb0a0b71",
+          "item_id": "426827c5d9c50af6a3f6351f5e6ed5d618c5074eff529ef3b471b18abb0a0b71",
+          "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+          "ledger_ref": "x402-settlement:426827c5d9c50af6a3f6351f5e6ed5d618c5074eff529ef3b471b18abb0a0b71",
+          "signature": "73309870f3f5ac2eca5ec8842d9287804f86a8e395e123d290241de0913194d8c1abd33b39f20e16d69e3f243077920f4e709906ba6590fd9ba569aaa4398701",
+          "signer": "presidio-hardened-x402-policy",
+          "source": "presidio-hardened-x402-policy",
+          "source_version": "0.10.0"
+        }
+      ],
+      "generated_at": "2026-07-26T12:00:00.000Z",
+      "key_id": "presidio-v/presidio-evidence:trust-store:x402-policy-2026q3",
+      "schema": "presidio-hardened/evidence-ref@1",
+      "settlement": {
+        "decision_ref": "63c67bf2fed3a74fc0e2d56cc673f612d50ea59392bc27c43c6db85dd9926e07",
+        "issued_at": "2026-07-26T12:00:00.000Z",
+        "schema": "presidio-hardened-x402/settlement-ref@1",
+        "settlement": {
+          "block_number": 19284411,
+          "chain": "eip155:84532",
+          "log_index": 7,
+          "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+        }
+      },
+      "settlement_key": "eip155:84532|0xabababababababababababababababababababababababababababababababab|7",
+      "settlement_ref": "426827c5d9c50af6a3f6351f5e6ed5d618c5074eff529ef3b471b18abb0a0b71",
+      "signing_algorithm": "ed25519",
+      "source": "presidio-hardened-x402-policy",
+      "source_version": "0.10.0",
+      "use_case": "x402-settlement-join"
+    },
+    "public_key_hex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",
+    "settlement_key": "eip155:84532|0xabababababababababababababababababababababababababababababababab|7",
+    "signature_hex": "73309870f3f5ac2eca5ec8842d9287804f86a8e395e123d290241de0913194d8c1abd33b39f20e16d69e3f243077920f4e709906ba6590fd9ba569aaa4398701",
+    "signing_message_canonical": "{\"content_hash\":\"426827c5d9c50af6a3f6351f5e6ed5d618c5074eff529ef3b471b18abb0a0b71\",\"signer\":\"presidio-hardened-x402-policy\"}"
+  },
+  "normalisation": [
+    {
+      "canonical": "0xabababababababababababababababababababababababababababababababab",
+      "chain": "eip155:84532",
+      "input": "0xABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB",
+      "name": "evm-tx-hash-case",
+      "note": "Case is normalised, not merely accepted, so two operators exporting the same settlement produce byte-identical join records."
+    }
+  ],
+  "reject": [
+    {
+      "name": "block-number-above-i64-max",
+      "note": "Representable in Python, not in an i64. Bounded by schema so both sides reject rather than one accepting silently.",
+      "reject_reason": "integer-out-of-range",
+      "settlement": {
+        "block_number": 9223372036854775808,
+        "chain": "eip155:84532",
+        "log_index": 0,
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    },
+    {
+      "name": "log-index-above-u64-max",
+      "note": "Above u64::MAX as well as i64::MAX — rejected by the same bound.",
+      "reject_reason": "integer-out-of-range",
+      "settlement": {
+        "block_number": 1,
+        "chain": "eip155:84532",
+        "log_index": 18446744073709551616,
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    },
+    {
+      "name": "negative-block-number",
+      "note": "A block height is unsigned.",
+      "reject_reason": "integer-out-of-range",
+      "settlement": {
+        "block_number": -1,
+        "chain": "eip155:84532",
+        "log_index": 0,
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    },
+    {
+      "name": "float-log-index",
+      "note": "Refused rather than truncated to 7.",
+      "reject_reason": "float",
+      "settlement": {
+        "block_number": 1,
+        "chain": "eip155:84532",
+        "log_index": 7.0,
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    },
+    {
+      "name": "boolean-log-index",
+      "note": "bool is an int subclass in Python; True is not a log index.",
+      "reject_reason": "integer-out-of-range",
+      "settlement": {
+        "block_number": 1,
+        "chain": "eip155:84532",
+        "log_index": true,
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    },
+    {
+      "name": "chain-not-caip2",
+      "note": "A rail nickname is not a chain id. The mapping happens at capture time; the committed value is always CAIP-2.",
+      "reject_reason": "chain-not-caip2",
+      "settlement": {
+        "block_number": 1,
+        "chain": "base-sepolia",
+        "log_index": 0,
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    },
+    {
+      "name": "tx-hash-not-evm",
+      "note": "eip155 transaction hashes are 0x + 64 hex.",
+      "reject_reason": "tx-hash-malformed",
+      "settlement": {
+        "block_number": 1,
+        "chain": "eip155:84532",
+        "log_index": 0,
+        "tx_hash": "0xdeadbeef"
+      }
+    },
+    {
+      "name": "missing-log-index",
+      "note": "The settlement echo does not carry a log index, so an operator who skips the chain lookup lands here. Required, not optional: without it there is no key for the one-settlement-one-leg invariant.",
+      "reject_reason": "incomplete",
+      "settlement": {
+        "block_number": 1,
+        "chain": "eip155:84532",
+        "tx_hash": "0xabababababababababababababababababababababababababababababababab"
+      }
+    }
+  ],
+  "schema_id": "presidio-hardened-x402/settlement-ref@1",
+  "settlement_key_definition": "chain|tx_hash|log_index, '|' separated. This is the uniqueness key a downstream ledger enforces 'at most one settlement-ref per (period, key)' on. block_number is deliberately excluded: it is implied by the transaction hash, and including it would let a wrong-but-plausible height mint a second distinct key for one settlement.",
+  "trust_store": {
+    "presidio-hardened-x402-policy": {
+      "alg": "ed25519",
+      "public_key": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+    }
+  }
+}

--- a/tests/test_treasury_binding.py
+++ b/tests/test_treasury_binding.py
@@ -1,0 +1,928 @@
+"""Treasury binding — adapter, settlement-ref@1, identity bounds, capture, CLI.
+
+What these tests are really asserting, in one line each:
+
+- the adapter **refuses** more than it accepts (non-verifying envelope, wrong
+  signer, non-terminal verdict, out-of-bound identity string, incomplete
+  settlement facts) — a bundle that exists is a bundle that verified;
+- the join is *signer-bound and content-bound*: swapping either envelope, the
+  decision it names, or one committed chain fact fails closed with a distinct
+  reason;
+- the privacy claim is the honest one — the control block is structurally
+  PII-free, and the identity fields, which are **not**, are value-bounded;
+- the client captures only what it actually observes on the wire, and says so.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from presidio_x402 import HardenedX402Client
+from presidio_x402._types import PaymentDetails, PaymentResponse, SettlementReceipt
+from presidio_x402.audit_log import NullAuditWriter
+from presidio_x402.bindings.x402 import (
+    X402Binding,
+    caip2_for_network,
+    parse_settlement_receipt,
+)
+from presidio_x402.decision_ref import (
+    ControlResults,
+    DecisionRefEmitter,
+    build_decision_evidence,
+    build_payment_decision_content,
+)
+from presidio_x402.treasury_binding import (
+    REASON_DECISION,
+    REASON_IDENTITY_BOUNDS,
+    REASON_JOIN_MISMATCH,
+    REASON_MALFORMED,
+    REASON_NON_TERMINAL_VERDICT,
+    REASON_SETTLEMENT_BAD_SIGNATURE,
+    REASON_SETTLEMENT_HASH_MISMATCH,
+    REASON_SIGNER_MISMATCH,
+    FileSettlementWriter,
+    SettlementFacts,
+    TreasuryBindingError,
+    check_identity_bounds,
+    export_bundle,
+    main,
+    settlement_facts_record,
+    verify_bundle,
+)
+
+SIGNER = "presidio-hardened-x402-policy"
+PAY_TO = "0x00000000000000000000000000000000c0ffee00"
+TX_HASH = "0x" + "ab" * 32
+
+
+def _keypair() -> tuple[str, str]:
+    sk = ed25519.Ed25519PrivateKey.generate()
+    return sk.private_bytes_raw().hex(), sk.public_key().public_bytes_raw().hex()
+
+
+def _facts(**overrides) -> SettlementFacts:
+    kwargs = {
+        "chain": "eip155:84532",
+        "tx_hash": TX_HASH,
+        "block_number": 19_284_411,
+        "log_index": 7,
+    }
+    kwargs.update(overrides)
+    return SettlementFacts(**kwargs)
+
+
+def _content(**overrides) -> dict:
+    controls = overrides.pop("controls", None) or ControlResults(
+        pii_verdict="PII_REDACTED",
+        pii_entities=("EMAIL_ADDRESS",),
+        pii_mutated=True,
+        policy_snapshot_hash="sha256:" + "11" * 32,
+        replay_fingerprint_hash="sha256:" + "22" * 32,
+    )
+    kwargs = {
+        "agent_id": "did:presidio:x402:agent-1",
+        "payment_signer": PAY_TO,
+        "network": "base-sepolia",
+        "binding": "x402",
+        "offer_hash": "sha256:" + "33" * 32,
+        "details_hash": "sha256:" + "44" * 32,
+        "pay_to": PAY_TO,
+        "amount": "0.010000",
+        "currency": "USDC",
+        "resource_origin": "https://api.example.com",
+        "issued_at": "2026-07-26T12:00:00.000Z",
+    }
+    kwargs.update(overrides)
+    return build_payment_decision_content(controls=controls, **kwargs)
+
+
+def _envelope(priv: str, *, signer: str = SIGNER, content: dict | None = None) -> dict:
+    return build_decision_evidence(content or _content(), signing_key=priv, signer=signer)
+
+
+@pytest.fixture
+def bundle_fixture():
+    priv, pub = _keypair()
+    trust = {SIGNER: {"alg": "ed25519", "public_key": pub}}
+    envelope = _envelope(priv)
+    bundle = export_bundle(
+        envelope,
+        _facts(),
+        trust_store=trust,
+        signing_key=priv,
+        issued_at="2026-07-26T12:00:00.000Z",
+    )
+    return priv, trust, envelope, bundle
+
+
+# ---------------------------------------------------------------------------
+# Export + verify, happy path
+# ---------------------------------------------------------------------------
+
+
+def test_exported_bundle_verifies_end_to_end(bundle_fixture):
+    _priv, trust, decision_env, bundle = bundle_fixture
+    result = verify_bundle(bundle, trust)
+    assert result.ok, result.reason
+    assert result.verdict == "ALLOW"
+    assert result.decision_ref == decision_env["decision_ref"]
+    assert result.settlement_key == f"eip155:84532|{TX_HASH}|7"
+    assert result.checked == (
+        "structure",
+        "decision",
+        "terminal",
+        "identity",
+        "settlement",
+        "signer",
+    )
+
+
+def test_bundle_carries_no_key_material(bundle_fixture):
+    """A bundle-supplied public key would make verification trust-on-first-use.
+
+    The reference names the signer and the key id; the verifier resolves both
+    against its *own* pinned store. Nothing in the bundle may substitute for it.
+    """
+    _priv, _trust, decision_env, bundle = bundle_fixture
+    ref = bundle["trust_store_ref"]
+    assert ref["signer"] == SIGNER
+    assert "public_key" not in ref and "key" not in ref
+    serialised = json.dumps(bundle)
+    assert "public_key" not in serialised
+    assert bundle["ingest_status"] == "treasury-ingest-pending"
+
+
+def test_export_is_idempotent_for_a_fixed_issue_time(bundle_fixture):
+    """Same decision + same settlement + same clock ⇒ byte-identical bundle."""
+    priv, trust, decision_env, bundle = bundle_fixture
+    again = export_bundle(
+        decision_env,
+        _facts(),
+        trust_store=trust,
+        signing_key=priv,
+        issued_at="2026-07-26T12:00:00.000Z",
+    )
+    assert again["settlement_ref"] == bundle["settlement_ref"]
+    assert (
+        again["settlement_ref_envelope"]["settlement"]
+        == bundle["settlement_ref_envelope"]["settlement"]
+    )
+    assert (
+        again["settlement_ref_envelope"]["evidence"][0]["signature"]
+        == bundle["settlement_ref_envelope"]["evidence"][0]["signature"]
+    )
+
+
+def test_deny_verdict_is_exportable_on_purpose(bundle_fixture):
+    """A settlement that happened despite a DENY is the anomaly an auditor needs.
+
+    Refusing to export it would hide the one case worth escalating, so DENY is
+    terminal and exportable; only the interim REFER is refused.
+    """
+    priv, trust, decision_env, _bundle = bundle_fixture
+    denied = _content(
+        controls=ControlResults(
+            policy_verdict="VIOLATION", policy_snapshot_hash="sha256:" + "11" * 32
+        )
+    )
+    envelope = _envelope(priv, content=denied)
+    bundle = export_bundle(envelope, _facts(), trust_store=trust, signing_key=priv)
+    assert bundle["verdict"] == "DENY"
+    assert verify_bundle(bundle, trust).ok
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed refusals on the export path
+# ---------------------------------------------------------------------------
+
+
+def test_export_refuses_a_tampered_envelope(bundle_fixture):
+    priv, trust, decision_env, _bundle = bundle_fixture
+    tampered = json.loads(json.dumps(decision_env))
+    tampered["payment_decision"]["payment"]["amount"] = "9999.00"
+    with pytest.raises(TreasuryBindingError, match="does not verify"):
+        export_bundle(tampered, _facts(), trust_store=trust, signing_key=priv)
+
+
+def test_export_refuses_an_unknown_signer(bundle_fixture):
+    """No trust store entry ⇒ the signature was never checked ⇒ no bundle."""
+    priv, _trust, decision_env, _bundle = bundle_fixture
+    with pytest.raises(TreasuryBindingError, match="does not verify"):
+        export_bundle(decision_env, _facts(), trust_store={}, signing_key=priv)
+
+
+def test_export_refuses_a_non_terminal_verdict(bundle_fixture):
+    priv, trust, decision_env, _bundle = bundle_fixture
+    referred = _content(
+        controls=ControlResults(
+            mpa_verdict="PENDING",
+            mpa_required=True,
+            policy_snapshot_hash="sha256:" + "11" * 32,
+        )
+    )
+    envelope = _envelope(priv, content=referred)
+    assert envelope["payment_decision"]["verdict"] == "REFER"
+    with pytest.raises(TreasuryBindingError, match="non-terminal"):
+        export_bundle(envelope, _facts(), trust_store=trust, signing_key=priv)
+
+
+def test_export_refuses_to_sign_the_join_as_a_different_identity(bundle_fixture):
+    """The join is the *decision signer's* assertion, not any trusted party's.
+
+    Otherwise any trust-store member could re-point any decision at any
+    transaction, which is the whole attack the signed join exists to stop.
+    """
+    priv, trust, decision_env, _bundle = bundle_fixture
+    with pytest.raises(TreasuryBindingError, match="refusing to sign the join"):
+        export_bundle(
+            decision_env, _facts(), trust_store=trust, signing_key=priv, signer="someone-else"
+        )
+
+
+def test_export_refuses_incomplete_settlement_facts():
+    """block_number/log_index are required — the receipt never carries them."""
+    with pytest.raises(TreasuryBindingError, match="operator"):
+        SettlementFacts.from_mapping({"chain": "eip155:8453", "tx_hash": TX_HASH})
+
+
+# ---------------------------------------------------------------------------
+# Identity bounds (T-TB-3) — and the honest PII claim
+# ---------------------------------------------------------------------------
+
+
+def test_control_block_is_structurally_pii_free(bundle_fixture):
+    """Every control value is a hash, an enum label, an entity type, or a bool.
+
+    This is the part of the record that *is* structurally PII-free, asserted by
+    walking it rather than by trusting the docstring.
+    """
+    _priv, _trust, decision_env, _bundle = bundle_fixture
+    controls = decision_env["payment_decision"]["controls"]
+    enums = {
+        "PII_NONE",
+        "PII_WARNED",
+        "PII_REDACTED",
+        "PII_BLOCKED",
+        "TRUSTED",
+        "UNTRUSTED",
+        "ALLOW",
+        "VIOLATION",
+        "FRESH",
+        "DUPLICATE",
+        "NOT_REQUIRED",
+        "APPROVED",
+        "PENDING",
+        "TIMEOUT",
+        "DENIED",
+    }
+    for gate, block in controls.items():
+        for key, value in block.items():
+            if isinstance(value, bool) or value is None:
+                continue
+            if key == "verdict":
+                assert value in enums, (gate, value)
+            elif key == "entities":
+                assert all(v.replace("_", "").isalnum() for v in value), (gate, value)
+            elif key.endswith("_hash"):
+                assert value.startswith("sha256:") and len(value) == 71, (gate, key)
+            elif key in ("threshold", "approval_refs"):
+                continue  # caller strings — bounded, not structural (see below)
+            else:  # pragma: no cover - a new control field must be classified here
+                raise AssertionError(f"unclassified control field {gate}.{key}")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "why"),
+    [
+        ("agent_id", "a" * 257, "over the length bound"),
+        ("agent_id", "agent‮evil", "bidi override (Cf)"),
+        ("agent_id", "agent\x00null", "null byte (Cc)"),
+        ("pay_to", "0x" + "f" * 200, "over the length bound"),
+        ("resource_origin", "https://x.invalid/￹", "interlinear annotation (Cf)"),
+    ],
+)
+def test_out_of_bound_identity_strings_are_rejected(field: str, value: str, why: str):
+    """The honest half of the privacy claim: these fields exist and carry caller
+    strings, so they are *bounded* rather than pretended away."""
+    content = _content(**{field: value})
+    with pytest.raises(TreasuryBindingError):
+        check_identity_bounds(content)
+
+
+def test_approval_refs_are_bounded_in_count_and_length():
+    many = _content(
+        controls=ControlResults(
+            mpa_verdict="APPROVED",
+            mpa_required=True,
+            mpa_approval_refs=tuple(f"ref-{i}" for i in range(33)),
+            policy_snapshot_hash="sha256:" + "11" * 32,
+        )
+    )
+    with pytest.raises(TreasuryBindingError, match="entries"):
+        check_identity_bounds(many)
+
+    # A 513-character ref cannot be built through the emitter — decision_ref
+    # already caps it at 512 — so the over-long case is assembled by hand, which
+    # is exactly how it would arrive from a laxer or older producer.
+    long_ref = _content()
+    long_ref["controls"]["mpa"]["approval_refs"] = ["x" * 513]
+    with pytest.raises(TreasuryBindingError, match="exceeds"):
+        check_identity_bounds(long_ref)
+
+    control_char = _content()
+    control_char["controls"]["mpa"]["approval_refs"] = ["approval‮reversed"]
+    with pytest.raises(TreasuryBindingError, match="disallowed character"):
+        check_identity_bounds(control_char)
+
+
+def test_empty_agent_id_is_allowed_but_empty_pay_to_is_not():
+    """The pipeline emits agent_id="" when none is configured; that is a valid
+    record. A missing counterparty is not."""
+    check_identity_bounds(_content(agent_id=""))
+    with pytest.raises(TreasuryBindingError, match="must not be empty"):
+        check_identity_bounds(_content(pay_to=""))
+
+
+def test_non_ascii_identity_strings_are_accepted():
+    """A charset bound, not an ASCII allowlist — an international agent id is
+    legitimate; a control or format character is not."""
+    check_identity_bounds(_content(agent_id="агент-Ω-代理"))
+
+
+def test_export_refuses_an_out_of_bound_identity_string(bundle_fixture):
+    priv, trust, decision_env, _bundle = bundle_fixture
+    envelope = _envelope(priv, content=_content(agent_id="a" * 300))
+    with pytest.raises(TreasuryBindingError, match="exceeds"):
+        export_bundle(envelope, _facts(), trust_store=trust, signing_key=priv)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed refusals on the verify path
+# ---------------------------------------------------------------------------
+
+
+def test_verify_rejects_a_swapped_join(bundle_fixture):
+    """A settlement-ref naming a different decision must not ride along."""
+    priv, trust, decision_env, bundle = bundle_fixture
+    other = _envelope(priv, content=_content(agent_id="did:presidio:x402:agent-2"))
+    other_bundle = export_bundle(other, _facts(), trust_store=trust, signing_key=priv)
+    swapped = json.loads(json.dumps(bundle))
+    swapped["settlement_ref_envelope"] = other_bundle["settlement_ref_envelope"]
+    result = verify_bundle(swapped, trust)
+    assert not result.ok and result.reason == REASON_JOIN_MISMATCH
+
+
+def test_verify_rejects_a_join_signed_by_another_trusted_party(bundle_fixture):
+    """Trusted is not the same as *this decision's* signer."""
+    priv, trust, decision_env, bundle = bundle_fixture
+    other_priv, other_pub = _keypair()
+    trust_two = dict(trust)
+    trust_two["other-party"] = {"alg": "ed25519", "public_key": other_pub}
+    forged = json.loads(json.dumps(bundle))
+    settlement = forged["settlement_ref_envelope"]
+    from presidio_x402.mica import sign_evidence
+
+    settlement["evidence"][0]["signer"] = "other-party"
+    settlement["evidence"][0]["signature"] = sign_evidence(
+        settlement["evidence"][0]["content_hash"], "other-party", key=other_priv
+    )
+    result = verify_bundle(forged, trust_two)
+    assert not result.ok and result.reason == REASON_SIGNER_MISMATCH
+
+
+def test_verify_reports_the_underlying_decision_reason(bundle_fixture):
+    _priv, trust, decision_env, bundle = bundle_fixture
+    broken = json.loads(json.dumps(bundle))
+    broken["decision_ref_envelope"]["payment_decision"]["amount"] = "1"
+    result = verify_bundle(broken, trust)
+    assert not result.ok and result.reason == REASON_DECISION
+    assert result.detail == "hash_mismatch"
+
+
+def test_verify_rejects_a_tampered_settlement_signature(bundle_fixture):
+    _priv, trust, decision_env, bundle = bundle_fixture
+    broken = json.loads(json.dumps(bundle))
+    sig = broken["settlement_ref_envelope"]["evidence"][0]["signature"]
+    broken["settlement_ref_envelope"]["evidence"][0]["signature"] = ("0" * 8) + sig[8:]
+    result = verify_bundle(broken, trust)
+    assert not result.ok and result.reason == REASON_SETTLEMENT_BAD_SIGNATURE
+
+
+def test_verify_rejects_a_mutated_settlement_fact(bundle_fixture):
+    _priv, trust, decision_env, bundle = bundle_fixture
+    broken = json.loads(json.dumps(bundle))
+    broken["settlement_ref_envelope"]["settlement"]["settlement"]["block_number"] += 1
+    result = verify_bundle(broken, trust)
+    assert not result.ok and result.reason == REASON_SETTLEMENT_HASH_MISMATCH
+
+
+def test_verify_rebounds_identity_on_the_read_path(bundle_fixture):
+    """A bundle from an older or laxer producer still fails here.
+
+    The read path cannot assume the writer applied the bound, so it re-applies
+    it — the check is on the value, and the value travels in the bundle.
+    """
+    priv, trust, decision_env, _bundle = bundle_fixture
+    content = _content(agent_id="a" * 300)
+    envelope = build_decision_evidence(content, signing_key=priv, signer=SIGNER)
+    handmade = {
+        "schema": "presidio-hardened-x402/treasury-bundle@1",
+        "decision_ref_envelope": envelope,
+        "settlement_ref_envelope": {},
+        "trust_store_ref": {"signer": SIGNER},
+    }
+    result = verify_bundle(handmade, trust)
+    assert not result.ok and result.reason == REASON_IDENTITY_BOUNDS
+
+
+def test_verify_rejects_a_non_bundle():
+    assert verify_bundle({"schema": "something-else"}, {}).reason == REASON_MALFORMED
+    assert verify_bundle({}, {}).reason == REASON_MALFORMED
+
+
+def test_verify_rejects_a_refer_bundle_assembled_by_hand(bundle_fixture):
+    priv, trust, decision_env, bundle = bundle_fixture
+    referred = _content(
+        controls=ControlResults(
+            mpa_verdict="TIMEOUT", mpa_required=True, policy_snapshot_hash="sha256:" + "11" * 32
+        )
+    )
+    handmade = json.loads(json.dumps(bundle))
+    handmade["decision_ref_envelope"] = build_decision_evidence(
+        referred, signing_key=priv, signer=SIGNER
+    )
+    result = verify_bundle(handmade, trust)
+    assert not result.ok and result.reason == REASON_NON_TERMINAL_VERDICT
+
+
+# ---------------------------------------------------------------------------
+# A0 — settlement receipt capture on the client path
+# ---------------------------------------------------------------------------
+
+
+def _receipt_header(**overrides) -> str:
+    import base64
+
+    payload = {
+        "success": True,
+        "transaction": TX_HASH,
+        "network": "base-sepolia",
+        "payer": "0x1111111111111111111111111111111111111111",
+    }
+    payload.update(overrides)
+    return base64.b64encode(json.dumps(payload).encode()).decode()
+
+
+def test_receipt_parses_base64_and_bare_json():
+    encoded = parse_settlement_receipt(_receipt_header())
+    plain = parse_settlement_receipt(
+        json.dumps({"success": True, "transaction": TX_HASH, "network": "base-sepolia"})
+    )
+    assert encoded is not None and plain is not None
+    assert encoded.tx_hash == plain.tx_hash == TX_HASH
+    assert encoded.chain == "eip155:84532"
+    assert encoded.payer is not None and plain.payer is None
+
+
+def test_receipt_is_incomplete_because_the_wire_does_not_carry_block_or_log_index():
+    """The documented gap, asserted rather than assumed."""
+    receipt = parse_settlement_receipt(_receipt_header())
+    assert receipt is not None
+    assert receipt.block_number is None and receipt.log_index is None
+    assert receipt.is_complete is False
+    record = settlement_facts_record(receipt, decision_ref="a" * 64)
+    assert record["complete"] is False
+    with pytest.raises(TreasuryBindingError, match="operator"):
+        SettlementFacts.from_mapping(record)
+
+
+def test_receipt_uses_volunteered_block_and_log_index_when_present():
+    receipt = parse_settlement_receipt(_receipt_header(blockNumber=42, logIndex=3))
+    assert receipt is not None and receipt.is_complete
+    facts = SettlementFacts.from_mapping(settlement_facts_record(receipt))
+    assert (facts.block_number, facts.log_index) == (42, 3)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "not-base64-not-json",
+        json.dumps({"success": True}),  # nothing correlatable
+        json.dumps([1, 2, 3]),
+        "x" * 9000,  # over the size cap
+    ],
+)
+def test_receipt_parsing_never_raises_and_returns_none_on_junk(raw: str):
+    assert parse_settlement_receipt(raw) is None
+
+
+def test_receipt_records_an_unmapped_network_without_guessing_a_chain():
+    """A wrong chain id would correlate a decision to a transaction on another
+    chain — worse than no chain id at all."""
+    receipt = parse_settlement_receipt(
+        json.dumps({"transaction": TX_HASH, "network": "some-new-l2"})
+    )
+    assert receipt is not None
+    assert receipt.network == "some-new-l2" and receipt.chain is None
+
+
+def test_caip2_passthrough_and_rejection():
+    assert caip2_for_network("eip155:8453") == "eip155:8453"
+    assert caip2_for_network("base-sepolia") == "eip155:84532"
+    assert caip2_for_network("BASE-SEPOLIA") == "eip155:84532"
+    assert caip2_for_network("nope") is None
+    assert caip2_for_network("") is None
+    assert caip2_for_network("A" * 40) is None
+
+
+def test_binding_reads_every_accepted_receipt_header_name():
+    binding = X402Binding()
+    for name in ("PAYMENT-RESPONSE", "X-PAYMENT-RESPONSE", "X-PAYMENT-RECEIPT"):
+        receipt = binding.settlement_receipt(httpx.Headers({name: _receipt_header()}))
+        assert receipt is not None and receipt.tx_hash == TX_HASH
+    assert binding.settlement_receipt(httpx.Headers({})) is None
+    assert binding.settlement_receipt(object()) is None
+
+
+def test_receipt_hash_binds_the_parsed_facts_to_the_bytes_received():
+    header = _receipt_header()
+    import hashlib
+
+    receipt = parse_settlement_receipt(header)
+    assert receipt is not None
+    assert receipt.receipt_hash == "sha256:" + hashlib.sha256(header.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Gateway wiring (opt-in; default off)
+# ---------------------------------------------------------------------------
+
+_OFFER = json.dumps(
+    {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base-sepolia",
+                "maxAmountRequired": "0.01",
+                "resource": "https://api.example.com/data",
+                "payTo": PAY_TO,
+                "requiredDeadlineSeconds": 300,
+            }
+        ]
+    }
+)
+
+
+async def _mock_signer(details: PaymentDetails) -> PaymentResponse:
+    return PaymentResponse(token="mock-signed-token", details=details)  # noqa: S106
+
+
+class _ListSettlementWriter:
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+
+    def write(self, record):
+        self.records.append(dict(record))
+
+
+@pytest.mark.asyncio
+async def test_client_captures_the_receipt_and_correlates_the_decision_ref():
+    priv, pub = _keypair()
+    writer = _ListSettlementWriter()
+    emitter = DecisionRefEmitter(signing_key=priv, signer=SIGNER)
+    with respx.mock:
+        route = respx.get("https://api.example.com/data")
+        route.side_effect = [
+            httpx.Response(402, headers={"X-PAYMENT": _OFFER}),
+            httpx.Response(200, headers={"PAYMENT-RESPONSE": _receipt_header()}, text="paid"),
+        ]
+        client = HardenedX402Client(
+            payment_signer=_mock_signer,
+            audit_writer=NullAuditWriter(),
+            decision_ref_emitter=emitter,
+            settlement_writer=writer,
+        )
+        async with client:
+            resp = await client.get("https://api.example.com/data")
+    assert resp.status_code == 200
+    assert len(writer.records) == 1
+    record = writer.records[0]
+    assert record["tx_hash"] == TX_HASH
+    assert record["chain"] == "eip155:84532"
+    assert isinstance(record["decision_ref"], str) and len(record["decision_ref"]) == 64
+    assert record["complete"] is False
+    assert pub  # keypair fixture sanity
+
+
+@pytest.mark.asyncio
+async def test_capture_is_off_by_default_and_never_breaks_a_payment():
+    class _Exploding:
+        def write(self, record):
+            raise RuntimeError("sink is down")
+
+    with respx.mock:
+        route = respx.get("https://api.example.com/data")
+        route.side_effect = [
+            httpx.Response(402, headers={"X-PAYMENT": _OFFER}),
+            httpx.Response(200, headers={"PAYMENT-RESPONSE": _receipt_header()}, text="paid"),
+        ]
+        client = HardenedX402Client(
+            payment_signer=_mock_signer,
+            audit_writer=NullAuditWriter(),
+            settlement_writer=_Exploding(),
+        )
+        async with client:
+            resp = await client.get("https://api.example.com/data")
+    assert resp.status_code == 200 and resp.text == "paid"
+
+
+@pytest.mark.asyncio
+async def test_no_settlement_writer_means_no_capture_work_at_all():
+    with respx.mock:
+        route = respx.get("https://api.example.com/data")
+        route.side_effect = [
+            httpx.Response(402, headers={"X-PAYMENT": _OFFER}),
+            httpx.Response(200, headers={"PAYMENT-RESPONSE": _receipt_header()}, text="paid"),
+        ]
+        client = HardenedX402Client(payment_signer=_mock_signer, audit_writer=NullAuditWriter())
+        async with client:
+            resp = await client.get("https://api.example.com/data")
+    assert resp.status_code == 200
+
+
+def test_file_settlement_writer_appends_json_lines(tmp_path):
+    path = tmp_path / "settlements.jsonl"
+    writer = FileSettlementWriter(str(path), fsync=False)
+    receipt = SettlementReceipt(network="base-sepolia", chain="eip155:84532", tx_hash=TX_HASH)
+    writer.write(settlement_facts_record(receipt, decision_ref="b" * 64))
+    writer.write(settlement_facts_record(receipt))
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["decision_ref"] == "b" * 64
+    assert json.loads(lines[1])["decision_ref"] is None
+
+
+# ---------------------------------------------------------------------------
+# CLI round-trip
+# ---------------------------------------------------------------------------
+
+
+def _cli_files(tmp_path, bundle_fixture):
+    priv, trust, envelope, _bundle = bundle_fixture
+    (tmp_path / "env.json").write_text(json.dumps(envelope), encoding="utf-8")
+    (tmp_path / "trust.json").write_text(json.dumps(trust), encoding="utf-8")
+    (tmp_path / "key").write_text(priv + "\n", encoding="utf-8")
+    receipt = SettlementReceipt(network="base-sepolia", chain="eip155:84532", tx_hash=TX_HASH)
+    record = settlement_facts_record(receipt, decision_ref=envelope["decision_ref"])
+    record["block_number"] = 19_284_411
+    record["log_index"] = 7
+    (tmp_path / "settle.json").write_text(json.dumps(record), encoding="utf-8")
+    return tmp_path
+
+
+def test_cli_export_then_verify_round_trip(tmp_path, bundle_fixture, capsys):
+    d = _cli_files(tmp_path, bundle_fixture)
+    code = main(
+        [
+            "export",
+            str(d / "env.json"),
+            "--settlement",
+            str(d / "settle.json"),
+            "--trust",
+            str(d / "trust.json"),
+            "--key-file",
+            str(d / "key"),
+        ]
+    )
+    assert code == 0
+    bundle_text = capsys.readouterr().out
+    (d / "bundle.json").write_text(bundle_text, encoding="utf-8")
+
+    assert main(["verify", str(d / "bundle.json"), str(d / "trust.json")]) == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_cli_verify_fails_on_a_tampered_bundle(tmp_path, bundle_fixture, capsys):
+    d = _cli_files(tmp_path, bundle_fixture)
+    main(
+        [
+            "export",
+            str(d / "env.json"),
+            "--settlement",
+            str(d / "settle.json"),
+            "--trust",
+            str(d / "trust.json"),
+            "--key-file",
+            str(d / "key"),
+        ]
+    )
+    bundle = json.loads(capsys.readouterr().out)
+    bundle["settlement_ref_envelope"]["settlement"]["settlement"]["log_index"] = 8
+    (d / "bad.json").write_text(json.dumps(bundle), encoding="utf-8")
+    assert main(["verify", str(d / "bad.json"), str(d / "trust.json")]) == 1
+    assert "FAIL(settlement_hash_mismatch)" in capsys.readouterr().out
+
+
+def test_cli_export_refuses_a_settlement_file_naming_another_decision(
+    tmp_path, bundle_fixture, capsys
+):
+    d = _cli_files(tmp_path, bundle_fixture)
+    record = json.loads((d / "settle.json").read_text(encoding="utf-8"))
+    record["decision_ref"] = "c" * 64
+    (d / "settle.json").write_text(json.dumps(record), encoding="utf-8")
+    code = main(
+        [
+            "export",
+            str(d / "env.json"),
+            "--settlement",
+            str(d / "settle.json"),
+            "--trust",
+            str(d / "trust.json"),
+            "--key-file",
+            str(d / "key"),
+        ]
+    )
+    assert code == 1
+    assert "refusing to join" in capsys.readouterr().err
+
+
+def test_cli_usage_errors_exit_two(tmp_path, bundle_fixture, capsys):
+    d = _cli_files(tmp_path, bundle_fixture)
+    assert (
+        main(
+            [
+                "export",
+                str(d / "missing.json"),
+                "--settlement",
+                str(d / "settle.json"),
+                "--trust",
+                str(d / "trust.json"),
+                "--key-file",
+                str(d / "key"),
+            ]
+        )
+        == 2
+    )
+    assert main(["verify", str(d / "missing.json"), str(d / "trust.json")]) == 2
+    capsys.readouterr()
+
+
+def test_cli_never_accepts_a_signing_key_as_an_argument():
+    """A key in argv is visible in ps output to every user on the host."""
+    with pytest.raises(SystemExit):
+        main(["export", "e.json", "--settlement", "s.json", "--trust", "t.json", "--key", "01"])
+
+
+def test_cli_export_reads_the_key_from_the_environment(
+    tmp_path, bundle_fixture, capsys, monkeypatch
+):
+    d = _cli_files(tmp_path, bundle_fixture)
+    priv = (d / "key").read_text(encoding="utf-8").strip()
+    monkeypatch.setenv("PRESIDIO_X402_EVIDENCE_KEY", priv)
+    code = main(
+        [
+            "export",
+            str(d / "env.json"),
+            "--settlement",
+            str(d / "settle.json"),
+            "--trust",
+            str(d / "trust.json"),
+        ]
+    )
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["schema"].endswith("treasury-bundle@1")
+
+    monkeypatch.delenv("PRESIDIO_X402_EVIDENCE_KEY")
+    assert (
+        main(
+            [
+                "export",
+                str(d / "env.json"),
+                "--settlement",
+                str(d / "settle.json"),
+                "--trust",
+                str(d / "trust.json"),
+            ]
+        )
+        == 2
+    )
+    assert "no signing key" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Malformed-input surface — every shape a hostile or broken producer can send
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("envelope", "why"),
+    [
+        ("not-a-mapping", "not an object"),
+        ({"evidence": [], "settlement": {}}, "no evidence ref"),
+        ({"evidence": [{}, {}], "settlement": {}}, "two evidence refs"),
+        ({"evidence": [{}], "settlement": {"schema": "wrong"}}, "wrong content schema"),
+        (
+            {
+                "evidence": [{"content_hash": 1, "signer": "s", "signature": "x"}],
+                "settlement": {"schema": "presidio-hardened-x402/settlement-ref@1"},
+            },
+            "non-string content hash",
+        ),
+    ],
+)
+def test_settlement_envelope_malformed_shapes_fail_closed(envelope, why: str):
+    from presidio_x402.treasury_binding import verify_settlement_ref
+
+    ok, reason, _ = verify_settlement_ref(envelope, {})
+    assert not ok and reason == "settlement_malformed", why
+
+
+def test_settlement_envelope_with_out_of_domain_fact_is_refused_even_when_signed(bundle_fixture):
+    """A signed-but-out-of-domain integer is exactly what a sibling rejects.
+
+    Admitting it here because "the signature checks out" would move the
+    divergence downstream, where it is someone else's outage.
+    """
+    from presidio_x402.mica import load_trust_store, sha256_hex, sign_evidence
+    from presidio_x402.treasury_binding import verify_settlement_ref
+
+    priv, trust, _decision_env, bundle = bundle_fixture
+    envelope = json.loads(json.dumps(bundle["settlement_ref_envelope"]))
+    envelope["settlement"]["settlement"]["block_number"] = 2**63  # above i64::MAX
+    content_hash = sha256_hex(envelope["settlement"])
+    envelope["evidence"][0]["content_hash"] = content_hash
+    envelope["evidence"][0]["signature"] = sign_evidence(content_hash, SIGNER, key=priv)
+    ok, reason, _ = verify_settlement_ref(envelope, load_trust_store(trust))
+    assert not ok and reason == "settlement_malformed"
+
+
+def test_verify_rejects_an_unknown_settlement_signer(bundle_fixture):
+    from presidio_x402.treasury_binding import verify_settlement_ref
+
+    _priv, _trust, _env, bundle = bundle_fixture
+    ok, reason, _ = verify_settlement_ref(bundle["settlement_ref_envelope"], {})
+    assert not ok and reason == "settlement_unknown_signer"
+
+
+def test_verify_rejects_a_malformed_trust_store(bundle_fixture):
+    _priv, _trust, _env, bundle = bundle_fixture
+    result = verify_bundle(bundle, {SIGNER: {"alg": "not-an-algorithm"}})
+    assert not result.ok and result.reason == REASON_MALFORMED
+
+
+def test_export_refuses_an_envelope_without_content_or_signer(bundle_fixture):
+    priv, trust, decision_env, _bundle = bundle_fixture
+    no_content = json.loads(json.dumps(decision_env))
+    no_content["payment_decision"] = None
+    with pytest.raises(TreasuryBindingError):
+        export_bundle(no_content, _facts(), trust_store=trust, signing_key=priv)
+
+
+def test_cli_rejects_non_object_inputs(tmp_path, bundle_fixture, capsys):
+    d = _cli_files(tmp_path, bundle_fixture)
+    (d / "array.json").write_text("[1, 2, 3]", encoding="utf-8")
+    assert (
+        main(
+            [
+                "export",
+                str(d / "array.json"),
+                "--settlement",
+                str(d / "settle.json"),
+                "--trust",
+                str(d / "trust.json"),
+                "--key-file",
+                str(d / "key"),
+            ]
+        )
+        == 2
+    )
+    assert main(["verify", str(d / "array.json"), str(d / "trust.json")]) == 2
+    capsys.readouterr()
+
+
+def test_cli_rejects_json_nested_past_the_parser(tmp_path, bundle_fixture, capsys):
+    """Deep input dies at the parser, before any bound could apply — still a
+    usage error, never a traceback."""
+    d = _cli_files(tmp_path, bundle_fixture)
+    (d / "deep.json").write_text("[" * 100_000 + "]" * 100_000, encoding="utf-8")
+    assert main(["verify", str(d / "deep.json"), str(d / "trust.json")]) == 2
+    capsys.readouterr()
+
+
+def test_non_evm_transaction_ids_are_accepted_verbatim():
+    """A non-eip155 chain's transaction id is not hex and is not case-folded."""
+    facts = SettlementFacts(
+        chain="solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ",
+        tx_hash="5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV",
+        block_number=1,
+        log_index=0,
+    )
+    assert facts.tx_hash.startswith("5VER")
+    with pytest.raises(TreasuryBindingError, match="bounded ASCII"):
+        SettlementFacts(chain="solana:x", tx_hash="tx with spaces", block_number=1, log_index=0)

--- a/tests/test_treasury_binding.py
+++ b/tests/test_treasury_binding.py
@@ -160,7 +160,14 @@ def test_bundle_carries_no_key_material(bundle_fixture):
 
 
 def test_export_is_idempotent_for_a_fixed_issue_time(bundle_fixture):
-    """Same decision + same settlement + same clock ⇒ byte-identical bundle."""
+    """Same decision + settlement + issued_at ⇒ identical *signed core*.
+
+    The interop-relevant identity — the settlement content, its content hash, and
+    the detached signature — is deterministic. The bundle wrapper is not:
+    ``generated_at`` / ``claimed_at`` are wall-clock and independent of
+    ``issued_at``, so full-bundle bytes are not reproducible. Correlation and
+    verification key off the signed core, which is what this pins.
+    """
     priv, trust, decision_env, bundle = bundle_fixture
     again = export_bundle(
         decision_env,
@@ -960,6 +967,41 @@ def test_verify_rejects_each_lying_summary_field(bundle_fixture, field: str):
     lying = json.loads(json.dumps(bundle))
     lying[field] = "0" * 64 if field != "verdict" else "DENY"
     result = verify_bundle(lying, trust)
+    assert not result.ok and result.reason == REASON_SUMMARY_MISMATCH
+
+
+@pytest.mark.parametrize(
+    "field", ["settlement_ref", "artifact_hash", "settlement_key", "decision_ref"]
+)
+def test_verify_rejects_a_lying_settlement_envelope_companion(bundle_fixture, field: str):
+    """The trap lives one level down too: the settlement envelope's companion
+    mirrors are unsigned. Tampering one leaves the signed content intact — the
+    signature still verifies — but a consumer reading the companion in isolation
+    would act on a forged join fact. Disagreement is a rejection."""
+    _priv, trust, _decision_env, bundle = bundle_fixture
+    lying = json.loads(json.dumps(bundle))
+    lying["settlement_ref_envelope"][field] = "0" * 64
+    result = verify_bundle(lying, trust)
+    assert not result.ok and result.reason == REASON_SUMMARY_MISMATCH
+
+
+@pytest.mark.parametrize(
+    ("obj", "field"),
+    [
+        ("bundle", "settlement_key"),
+        ("bundle", "decision_ref"),
+        ("settlement_ref_envelope", "settlement_key"),
+        ("settlement_ref_envelope", "artifact_hash"),
+    ],
+)
+def test_verify_rejects_an_absent_mirror(bundle_fixture, obj: str, field: str):
+    """An absent mirror is as dangerous as a wrong one: a consumer reads it as
+    None and may skip the uniqueness dedupe entirely. Presence is required."""
+    _priv, trust, _decision_env, bundle = bundle_fixture
+    stripped = json.loads(json.dumps(bundle))
+    target = stripped if obj == "bundle" else stripped[obj]
+    del target[field]
+    result = verify_bundle(stripped, trust)
     assert not result.ok and result.reason == REASON_SUMMARY_MISMATCH
 
 

--- a/tests/test_treasury_binding.py
+++ b/tests/test_treasury_binding.py
@@ -45,6 +45,7 @@ from presidio_x402.treasury_binding import (
     REASON_SETTLEMENT_BAD_SIGNATURE,
     REASON_SETTLEMENT_HASH_MISMATCH,
     REASON_SIGNER_MISMATCH,
+    REASON_SUMMARY_MISMATCH,
     FileSettlementWriter,
     SettlementFacts,
     TreasuryBindingError,
@@ -139,6 +140,7 @@ def test_exported_bundle_verifies_end_to_end(bundle_fixture):
         "identity",
         "settlement",
         "signer",
+        "summary",
     )
 
 
@@ -926,3 +928,44 @@ def test_non_evm_transaction_ids_are_accepted_verbatim():
     assert facts.tx_hash.startswith("5VER")
     with pytest.raises(TreasuryBindingError, match="bounded ASCII"):
         SettlementFacts(chain="solana:x", tx_hash="tx with spaces", block_number=1, log_index=0)
+
+
+def test_verify_rejects_a_bundle_whose_summary_contradicts_its_envelopes(bundle_fixture):
+    """A mirror that can disagree with what it mirrors is a trap.
+
+    Nothing in verification *reads* the top-level summary — every reported value
+    is re-derived from the envelopes. But a consumer enforcing the
+    one-settlement-one-leg invariant reads `settlement_key`, so a swapped
+    settlement-ref that leaves a stale key pointing at the old transaction would
+    let the same settlement be counted twice. Disagreement is a rejection.
+    """
+    priv, trust, decision_env, bundle = bundle_fixture
+    other = export_bundle(
+        decision_env,
+        _facts(tx_hash="0x" + "cd" * 32, block_number=2, log_index=1),
+        trust_store=trust,
+        signing_key=priv,
+    )
+    swapped = json.loads(json.dumps(bundle))
+    swapped["settlement_ref_envelope"] = other["settlement_ref_envelope"]
+    result = verify_bundle(swapped, trust)
+    assert not result.ok and result.reason == REASON_SUMMARY_MISMATCH
+    # …and the reported key is the derived one, never the stale declared one.
+    assert result.settlement_key == f"eip155:84532|{'0x' + 'cd' * 32}|1"
+
+
+@pytest.mark.parametrize("field", ["decision_ref", "settlement_ref", "settlement_key", "verdict"])
+def test_verify_rejects_each_lying_summary_field(bundle_fixture, field: str):
+    _priv, trust, _decision_env, bundle = bundle_fixture
+    lying = json.loads(json.dumps(bundle))
+    lying[field] = "0" * 64 if field != "verdict" else "DENY"
+    result = verify_bundle(lying, trust)
+    assert not result.ok and result.reason == REASON_SUMMARY_MISMATCH
+
+
+def test_identity_bounds_refuses_a_non_object_with_a_typed_error():
+    """A fail-closed boundary owes its caller a typed refusal, not an
+    AttributeError from three frames down."""
+    for bad in (None, "a string", 42, []):
+        with pytest.raises(TreasuryBindingError, match="must be an object"):
+            check_identity_bounds(bad)

--- a/uv.lock
+++ b/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# Treasury binding — `settlement-ref@1`, bundle export/verify, cross-language vectors

Implements the x402-local scope of the treasury binding (`plan/v10-treasury-binding.md`,
workstreams A0–D). Releases as **0.10.0** — 0.9.0 and 0.9.1 are already published, so the
plan's working title of "v0.9.0" collides with a shipped version. `pyproject.toml` and
`uv.lock` are bumped; the CHANGELOG entry stays under `[Unreleased]` until the tag.

## The problem

A `payment-decision@1` record (v0.9.0) says *why* a payment was allowed. It carries
`details_hash`, `pay_to`, `amount`, `resource_origin` — and **no settlement transaction
hash**. Nothing connects it to the money that actually moved, so "agent spend reconciles
into a close" has an unspecified manual join at its crux.

Worse, the paying client never sees a settlement at all: x402 settles on the payee side,
via the facilitator. The tx hash exists in `screening-api/`, not in `tools/`.

## What this adds

**`settlement-ref@1`** — a signed `evidence-ref@1` envelope, under the same policy signer,
committing to `{decision_ref, chain (CAIP-2), tx_hash, block_number, log_index}` and
nothing else.

It is deliberately **not** the design note's `decision-anchor@1`. An ERC-3009 settlement's
calldata carries no decision digest, so a `calldata_digest` would verify nothing against
the chain; and if the committed `tx_hash` *is* the settlement, a "decision precedes
settlement" check compares a value with itself. Both fields would have asserted what they
cannot prove. This record asserts only what the signer can: *this decision, that
transaction, signed*. The stronger pre-settlement on-chain commitment stays available as a
future opt-in mode — see the design fork below.

**Fail-closed export + offline verify, with a CLI.** `export_bundle` re-runs the *whole*
decision-ref verification and refuses:

| refusal | why |
|---|---|
| envelope does not verify | every layer, signature included — which is why the trust store is a **required** argument. A bundle whose signature was never checked is not evidence of anything |
| `REFER` verdict | an unresolved quorum is interim; export the terminal decision that supersedes it |
| out-of-bound identity string | see the privacy section |
| out-of-domain settlement facts | non-CAIP-2 chain, malformed tx hash, index past `i64::MAX`, missing block/log index |
| join signed by another identity | the join is the *decision signer's* assertion. Otherwise any trust-store member could re-point any decision at any transaction |

`DENY` **is** exportable on purpose: a settlement that happened despite a DENY is the
anomaly an auditor most needs to see, and refusing to export it would hide it.

The bundle carries **no key material**. `trust_store_ref` names the signer and key id; the
verifier resolves both against its own pinned store, because a bundle-supplied public key
would make verification trust-on-first-use and defeat the pin it exists to enforce. The
CLI has no `--key` flag — a key in `argv` is world-readable in `ps` output — and reads from
`--key-file` or `PRESIDIO_X402_EVIDENCE_KEY`.

**Client-side receipt capture (A0), documented honestly.** The client now parses the
settlement echo (`PAYMENT-RESPONSE` / `X-PAYMENT-RESPONSE` / `X-PAYMENT-RECEIPT`) on the
paid response and hands the facts to an optional `settlement_writer`, correlated with that
payment's `decision_ref`. **The echo carries the transaction hash and the network — not a
block number and not a log index.** Those come back `null`, the record is flagged
`"complete": false`, and completing them from a chain lookup is documented as an operator
step rather than quietly omitted. They are required, not optional: without a log index
there is no key on which the ledger can enforce one-settlement-one-leg.

So A0 is neither the plan's option (a) nor (b) but the honest hybrid — parse what is
actually on the wire, declare the rest operator-supplied.

**Cross-language conformance vectors (B).** x402 is Python, the ledger is Rust, nothing is
imported across that boundary — so the contract is the bytes. Vectors pin canonical bytes
as hex dumps, the `settlement-ref@1` golden with its signature under the family test key,
and the two family negatives as complete signed envelopes (both verify cryptographically;
both must still be rejected). Axes: non-ASCII escaping (emoji, combining marks, U+007F, C0
controls), non-ASCII key ordering, lone surrogates, non-string keys, integers past
`i64::MAX`, floats, and depth 128/129 **with the depth definition pinned beside the
boundary cases** — an off-by-one in the definition grades the two vectors in opposite
directions and looks exactly like a canonicaliser bug.

`PROVENANCE.json` pins a hash per file; the generator is deterministic, so a hash that
moves without a generator change means a vector was hand-edited.

## `mica.canonical_bytes` now fails closed across its whole domain

Two inputs escaped the strict profile's guard. Neither affects a valid input, so **no
emitted bytes move**; the float guard and the new key guard share one walk instead of two.

- **Lone surrogates** raised a bare `UnicodeEncodeError` from the encode step. Callers of
  this boundary catch `EvidenceError`, so an interpreter error escaping it turned a
  fail-closed refusal into a crash. Now `EvidenceError` — error *parity* with an
  implementation whose string type cannot hold a lone surrogate.
- **Non-string object keys** are rejected. `json.dumps` sorts integer keys *numerically*
  and only then stringifies, so `{1:…, 10:…, 2:…}` encodes as `1, 2, 10` here and as
  `"1", "10", "2"` anywhere that models object keys as strings — a silent cross-language
  hash divergence rather than a visible failure. Unreachable from JSON text; this is a
  producer-side guard.

## Privacy claim, corrected

The old claim that the record is PII-free was an overclaim. Only the `controls{}` block is
structurally PII-free — every value there is a hash, an entity-type label, an enum verdict
or a boolean, and the test walks it and **fails on any field it cannot classify**, so a new
control field has to be classified rather than silently admitted.

`agent_id`, `actor.payment_signer`, `pay_to`, `resource_origin` and `mpa.approval_refs`
are caller strings, and a wallet address is pseudonymous personal data to a GDPR-minded
auditor. They are present by design — a ledger cannot reconcile an anonymous payment — so
the mitigation is a **value bound**: length, plus a Unicode-category charset bound (no
control, format, surrogate, private-use or unassigned code point). A charset bound, not an
ASCII allowlist: an international agent id stays legal, a bidi override in a disclosure
pack does not. The bound is re-applied on read, since the read path cannot assume the
writer applied it.

## One finding from the adversarial pass (fixed in `75d53ad`)

A bundle's top-level `decision_ref` / `settlement_ref` / `settlement_key` / `verdict` are a
convenience mirror of what the envelopes prove. Verification never read them — every value
it reports is re-derived — so they were unchecked, and an unchecked mirror is worse than no
mirror. Swapping in a settlement-ref for a *different* transaction verified cleanly: the
join still named the right decision, the signature still checked, and the stale top-level
`settlement_key` still named the old transaction. A consumer enforcing "at most one
settlement-ref per (period, key)" reads that field, so the same settlement could have been
counted into two closes *through a bundle that verified*. Disagreement is now a distinct
fail-closed reason (`summary_mismatch`).

## A second adversarial pass, and what it found (fixed in the final commit)

An independent audit hardened the above check further:

- **The same trap survived one level down.** The `summary_mismatch` guard covered the
  *bundle* top-level, but the settlement envelope carries the identical join facts again as
  its own **unsigned companion fields** (`settlement_ref` / `artifact_hash` /
  `settlement_key` / `decision_ref`) — and nothing re-derived *those*. Tampering an envelope
  companion left the signed content intact, so the signature still verified. `verify_bundle`
  now re-derives and rejects the envelope companions too.
- **Absence was as dangerous as disagreement.** The check only compared a mirror field when
  it was *present*; an absent `settlement_key` a consumer reads as `None` and may skip its
  dedupe on. Every mirror (bundle and envelope) must now be **present and equal**.
- **Doc honesty (`settlement_key`).** The ingest doc now states plainly that
  one-settlement-one-leg is the consuming ledger's to enforce and rests on an
  operator-supplied `log_index` the signature does not attest — the ledger must corroborate
  it against its own chain observation (T-TB-2).

The lint on the production sources is clean; the two remaining advisory flags are analyzed
false positives (a depth-bound `and children` guard and an optional CLI cross-check).

## In scope / deferred

**In scope (x402-local, entirely within this repo):** A0 receipt capture · A1 adapter · A2
`settlement-ref@1` producer · A3 CLI · B Python-side vectors + provenance · C tests · D
docs. No change to the `AuditEvent` wire format — the adapter is a downstream consumer of
the emitted envelope.

**Deferred, and not claimed here:**

- **The ledger side (`presidio-hardened-treasury#49`, Gate 0)** — the inbound evidence
  class, Ed25519 trust store, designation-schema bump, and the uniqueness/volume
  enforcement points. Out of this repo's release control. Bundles are marked
  `"ingest_status": "treasury-ingest-pending"` until that surface is agreed.
- **The Rust half of the conformance proof** — authored there, over these same vector
  files. Until it lands, "green on both sides" is half-proven, and nothing in this branch
  asserts otherwise.
- **End-to-end reconciliation (Tier-3)** — blocked on the companion; not stubbed as a
  passing test.
- **Evidence Phase-B (`import presidio_evidence`)** — patent-gated and off this critical
  path. Ships on the vendored `mica.py` substrate, which changes no wire bytes either way.

## Open design fork (R8) — needs a conscious call

**Off-chain `settlement-ref@1` (shipped now)** vs **on-chain strong anchor (deferred)**.
The shipped join is signer-asserted: cheap, honest, no change to the hot payment path,
and it rides trust the auditor already extends to that signer for the decision itself. The
alternative publishes a commitment transaction carrying `sha256(decision_ref)` *before*
settlement, making the join on-chain rather than signer-trusted — strictly stronger, at
the cost of an extra chain transaction on every payment and a change to the v0.8.0 settle
path. Recommendation: ship off-chain now, offer the strong anchor as an opt-in mode later.

## Residual risks (documented, not mitigated on paper)

- **Stolen signer key** — signature verification does not cover it. Operational
  mitigation: `key_id` pinning with a revocation path, short signer epochs, and the fact
  that a full-semantics consumer still needs an independent L1 settlement to corroborate
  amount and counterparty.
- **Cryptographically valid, semantically false verdict** — a record whose `controls` were
  fabricated signs and recomputes correctly. The honesty bound of the whole scheme;
  containment (evidence *feeding* dual control, never a control itself), not elimination.

## Verification

```
ruff check src/ tests/ fuzz/           # clean
ruff format --check src/ tests/ fuzz/  # clean
pytest tests/ -x -q                    # 740 passed, 1 skipped
python -m presidio_x402.conformance    # 7/7
coverage                               # statement 92.09% (floor 90), branch 84.20% (floor 80)
uv lock --locked                       # clean after the version bump
```

CLI round-trip: `export` exits 0 on a good decision + settlement, `verify` exits 0 on the
resulting bundle, and exits 1 with `FAIL(settlement_hash_mismatch)` on a bundle whose
committed log index was altered by one.

`ruff format --check .` (repo root, rather than the CI paths) reports 8 pre-existing
markdown files under `.claude/` — unchanged by this branch and equally unformatted on
`main`.

## Companion follow-ups (outside this repo)

- `evidence-bridge/README.md` — treasury-binding section + ingest contract.
- `plan/roadmap.md` — v0.10.0 arc line updated to "x402-local scope built".
- `presidio-hardened-treasury#49` — hand over `tools/tests/conformance/treasury-binding/`
  and the Rust conformance test.
