### PR TITLE
docs: sync release-state docs to v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-> Releases as **0.10.0**; `pyproject.toml` is bumped ahead of the tag.
+## [0.10.0] — 2026-07-27
 
 ### Added
 - **Treasury binding — `settlement-ref@1`, a signed off-chain join record.** A

--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -521,6 +521,52 @@ public-chain anchor (`decision-anchor@1`) is deferred, not implemented.
 
 ---
 
+## v0.10.0 Requirements (treasury binding) — **delivered 2026-07-27**
+
+Additive, opt-in consumer of the v0.9.0 evidence surface. It correlates an x402
+payment decision to its on-chain settlement so an audit-grade ledger
+(`presidio-hardened-treasury`) can reconcile agent spend. The binding is by shared
+wire format + cross-language conformance vectors, never by import.
+
+### Delivered
+
+- [x] **`settlement-ref@1` — a signed off-chain join record.** A family
+  `evidence-ref@1` envelope, under the same policy signer as the decision, committing
+  to exactly `{decision_ref, chain (CAIP-2), tx_hash, block_number, log_index}`.
+  Deliberately **not** the on-chain `decision-anchor@1` an earlier design sketched —
+  an ERC-3009 settlement's calldata carries no decision digest, so that check would
+  verify nothing. Implemented in `src/presidio_x402/treasury_binding.py`.
+- [x] **Fail-closed bundle `export` + offline `verify`, with a CLI.** `export`
+  re-runs the *whole* decision-ref verification (signature included — the trust store
+  is a required argument) and refuses a non-verifying envelope, a non-terminal
+  `REFER`, an out-of-bound caller identity, out-of-domain settlement facts, or a join
+  signed by a non-decision signer. Bundles carry **no key material**. CLI exit codes:
+  0 verified / 1 fail-closed (distinct reason) / 2 usage.
+- [x] **Mirror-consistency.** Every unsigned mirror of a join fact — on the bundle
+  *and* on the settlement envelope — must be present and equal to what the signed
+  envelopes prove, or the bundle is rejected (`summary_mismatch`).
+- [x] **Client-side settlement-receipt capture** (opt-in `settlement_writer=`) from
+  the paid `PAYMENT-RESPONSE` header; `block_number` / `log_index` are
+  operator-supplied (not on the wire).
+- [x] **Cross-language canonicalization conformance vectors** — the byte-interop
+  contract for a Rust consumer: non-ASCII escaping, lone surrogates (typed error, not
+  `UnicodeEncodeError`), non-string keys, `i64` bounds, float/NaN/Infinity rejection,
+  depth 128 accept / 129 reject. `mica.canonical_bytes` now fails closed across its
+  whole input domain.
+
+### Bounds and deferrals
+
+- The one-settlement-one-leg **uniqueness invariant is the consuming ledger's to
+  enforce**, and rests on an operator-supplied `log_index` the signature does not
+  attest; a ledger must corroborate it against its own chain observation.
+- **End-to-end reconciliation** depends on the treasury-side companion change
+  (Ed25519 trust store + inbound evidence class + Rust conformance test), tracked at
+  `presidio-hardened-treasury#49`; until it lands, bundles are marked
+  `"ingest_status": "treasury-ingest-pending"`.
+- The stronger pre-settlement on-chain anchor remains a future opt-in mode.
+
+---
+
 ## Security Model
 
 The threat model for presidio-hardened-x402 addresses the following adversaries:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/presidio-v/presidio-hardened-x402/badge)](https://securityscorecards.dev/viewer/?uri=github.com/presidio-v/presidio-hardened-x402)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13675/badge)](https://www.bestpractices.dev/projects/13675)
 
-> v0.9.1 — security patch: dependency-audit floors for `click`/`setuptools`, missing-payment-header log exposure hardening, and `setup-uv` v8.3.2 CI action pin.
+> v0.10.0 — treasury binding: x402 payment decisions reconcile into an audit-grade close via a signed off-chain `settlement-ref@1` join record, a fail-closed bundle export/verify CLI, client-side settlement-receipt capture, and cross-language canonicalization conformance vectors.
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -523,9 +523,9 @@ All exceptions are importable from `presidio_x402`.
 | v0.6.0 | **Production hardening + evidence substrate** — multi-tenant replay namespaces · enterprise audit sinks (S3 / Splunk / Datadog) · signed `evidence-ref@1` verification · SLSA/OIDC release provenance · digest-pinned Docker base + hash-pinned spaCy model · latency SLO and all-matrix coverage CI gates · OTel spans · policy hot-reload · startup key gates · human-pentest retest closure |
 | v0.7.0 | **SLO payment broker (library)** — x402 micropayments as runtime infrastructure bids: `SLOPaymentBroker` + `SLOPaymentPolicy` + evidence-anchored `ArchTranslucencyAdapter` + provisioning PII entities; cross-repo validated against `presidio-hardened-arch-translucency`. cs.DC preprint + empirical eval tracked separately |
 | v0.8.0 | PII completeness + supply-chain hardening (library) — `nlp` mode is now a structural superset of `regex` (no structured-identifier misses) · composed-envelope `screen_ref` leg · `action_ref` byte-determinism (NFC + non-empty entity sets) · URL-redacted log hygiene · OpenSSF Scorecard workflow/badge + SLSA Build L3 provenance · independent multi-round security audit cleared |
-| **v0.9.1** | **Security patch** — dependency-audit floors for `click` / `setuptools`, missing-payment-header log exposure hardening, and `setup-uv` v8.3.2 CI action pin — **latest release** |
+| **v0.10.0** | **Treasury binding** — `settlement-ref@1` signed off-chain join record + fail-closed bundle export/verify CLI · client-side settlement-receipt capture · caller-identity value bounds · cross-language conformance vectors (non-ASCII escaping, lone surrogates, non-string keys, `i64` bounds, depth 128/129) — **latest release** |
+| v0.9.1 | **Security patch** — dependency-audit floors for `click` / `setuptools`, missing-payment-header log exposure hardening, and `setup-uv` v8.3.2 CI action pin |
 | v0.9.0 | Proof-carrying x402 evidence — `capability-grant@1` attenuable spending grants + opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records |
-| v0.10.0 | **Treasury binding** — `settlement-ref@1` signed off-chain join record + fail-closed bundle export/verify CLI · client-side settlement-receipt capture · caller-identity value bounds · cross-language conformance vectors (non-ASCII escaping, lone surrogates, non-string keys, `i64` bounds, depth 128/129) |
 | Future | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |
 
 ### Planned direction (next 12 months)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.9.x   | ✓ (latest release) |
+| 0.10.x  | ✓ (latest release) |
+| 0.9.x   | ✓ |
 | 0.8.x   | ✓ |
-| 0.7.x   | ✓ |
-| 0.6.x   | security fixes only |
-| 0.5.x and older | security fixes only |
+| 0.7.x   | security fixes only |
+| 0.6.x and older | security fixes only |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Post-release documentation sync for **v0.10.0** (published, tagged, PyPI live). Keeps the version-coupled docs current — a requirement the OpenSSF posture enforces, and one a prior audit flagged directly (SECURITY-AUDIT I-03: stale "Supported Versions").

## Changes
- **CHANGELOG.md** — `[Unreleased]` → `## [0.10.0] — 2026-07-27` (dated, versioned release notes); a fresh empty `[Unreleased]` stays on top so `CONTRIBUTING`'s "add under Unreleased" instruction remains valid.
- **README.md** — the current-release callout is now v0.10.0; the version table is reordered newest-first with the **latest release** marker moved to v0.10.0.
- **SECURITY.md** — Supported Versions window shifted forward (0.10.x latest; 0.10/0.9/0.8 supported, 0.7 and older security-fixes-only), clearing the stale `0.9.x (latest release)` row.
- **PRESIDIO-REQ.md** — adds the **v0.10.0 requirements** section (treasury binding), matching the per-version baseline pattern (v0.9.0 precedent), including the honesty bounds (uniqueness is the ledger's to enforce; end-to-end depends on `presidio-hardened-treasury#49`).

Docs-only; no code or behavior change.

## Test plan
- [ ] CI green (lint / checks)
- [ ] CHANGELOG renders with a dated 0.10.0 heading and an empty Unreleased
- [ ] SECURITY.md and README version references agree with the shipped v0.10.0