### PR TITLE
decision_ref: keep DecisionRefEmitter signing key out of repr (F1, CWE-312)

### DIFF
--- a/src/presidio_x402/decision_ref.py
+++ b/src/presidio_x402/decision_ref.py
@@ -924,7 +924,7 @@ class DecisionRefEmitter:
     fails closed on self-approval.
     """
 
-    signing_key: str
+    signing_key: str = field(repr=False)  # keep key material out of repr/tracebacks/debug logs
     signer: str = DEFAULT_DECISION_SIGNER
     algorithm: str = "ed25519"
     key_id: str | None = None

--- a/tests/test_decision_ref.py
+++ b/tests/test_decision_ref.py
@@ -560,3 +560,11 @@ def test_conformance_module_exits_with_runner_code(monkeypatch):
     monkeypatch.setattr(runner, "main", lambda: 7)
     with pytest.raises(SystemExit, match="7"):
         runpy.run_module("presidio_x402.conformance.__main__", run_name="__main__")
+
+
+def test_emitter_repr_hides_signing_key(policy_signer):
+    # F1 (CWE-312): the Ed25519 private key must never surface via repr/tracebacks/debug logs.
+    signer, priv, _pub, _trust = policy_signer
+    emitter = DecisionRefEmitter(signing_key=priv, signer=signer, key_id="k1")
+    assert priv not in repr(emitter)
+    assert emitter.signing_key == priv  # still readable by the code that needs it


### PR DESCRIPTION
## Security fix — F1 / CWE-312 (signing key leaked via repr)

`DecisionRefEmitter` is a `@dataclass` whose `signing_key: str` field had no `repr=False`, so the **Ed25519 private key surfaces through the auto-generated `repr()`** — leaking into debug logs and any traceback that holds the emitter. This affects the released **v0.10.0** line.

### Fix
- `signing_key: str = field(repr=False)` — the field stays **required and readable** by the signing path; only its appearance in `repr`/tracebacks/debug logs is suppressed.
- Regression test `test_emitter_repr_hides_signing_key` asserts the key is absent from `repr(emitter)` and still readable via the attribute.

### Note on provenance
This fix was authored 2026-07-13 on an unpushed branch and never reached `main` (it was believed shipped in v0.9.1 — it was not). Re-landed here on the current v0.10.0 line.

### Scope / honesty bound
`dataclasses.asdict()` still emits the field (inherent — `field()` cannot suppress `asdict`); `repr` was the finding's actual exposure vector (logs/tracebacks). No behavior change to signing or verification.

## Test plan
- [x] `test_emitter_repr_hides_signing_key` passes
- [x] full suite green, ruff check + format clean, vstantch-code lint clean on `decision_ref.py`
- [ ] CI green