### PR TITLE
release: v0.10.1 — F1 signing-key repr fix (CWE-312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-07-27
+
+### Security
+- **`DecisionRefEmitter` no longer leaks its signing key via `repr` (F1, CWE-312).**
+  The Ed25519 private key in `signing_key` surfaced through the auto-generated
+  dataclass `repr`, so debug logging of the emitter or any traceback holding it
+  exposed key material. The field is now `field(repr=False)` — still required and
+  readable by the signing path, but absent from `repr`/tracebacks/debug logs. A
+  regression test asserts the key is not in `repr()`. (`asdict()` still emits the
+  field — inherent to dataclasses; `repr` was the finding's exposure vector.)
+
 ## [0.10.0] — 2026-07-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.10.0"
+version = "0.10.1"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release to ship the merged **F1 security fix** (#102, `5a76fdb`) to PyPI. v0.10.0 still exposes the leak.

## Changes
- **`pyproject.toml` + `uv.lock`**: `0.10.0` → `0.10.1`.
- **CHANGELOG.md**: `[0.10.1] — 2026-07-27` under **Security**, documenting the F1 / CWE-312 `repr` key-leak fix.

No code change beyond the version bump — the fix itself already landed in #102.

## Test plan
- [x] `uv lock --locked` clean (no drift)
- [x] ruff clean; F1 regression test passes
- [ ] CI green
- After merge: tag `v0.10.1` (signed) → PyPI OIDC publish → GitHub release → verify.