### PR TITLE
docs: sync release-state docs to v0.11.0

### DIFF
--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -567,6 +567,43 @@ wire format + cross-language conformance vectors, never by import.
 
 ---
 
+## v0.11.0 Requirements (capability enforcement) — **delivered 2026-07-27**
+
+Additive, **opt-in, default-off** consumer of the v0.9.0 capability surface. It makes each
+outgoing payment prove it is authorised by a verified `capability-grant@1` chain *before*
+signing/transmission. The runnable E2 harness for the Computational Jurisprudence evaluation
+paper (CJ-EVAL Phase A2 + B2).
+
+### Delivered
+
+- [x] **`CapabilityEnforcer` — pre-transmission `capability-grant@1` enforcement.** A thin
+  `ScreeningPipeline` stage placed between the trusted-wallet allowlist and the policy engine
+  (`PII → trusted-wallet → capability → policy → replay → MPA`) — a pure predicate ahead of the
+  stateful gates, so a denial needs no compensating rollback. It **reuses** the released pieces:
+  `verify_chain` / `VerifiedGrantChain.check_payment` (per-call cap, endpoint prefix, validity
+  window), `policy_config_from_chain`, and `decision_ref` for a block-time signed
+  `payment-decision@1` DENY parent-linked to the chain's terminal `grant_hash`. A capability
+  denial recomputes to `DENY` under the existing five-control schema — the `payment-decision@1`
+  vectors are untouched. Implemented in `src/presidio_x402/capability_enforcer.py`
+  (`CapabilityEnforcer`, `StageTiming`); wired into `ScreeningPipeline` / `HardenedX402Client`
+  via the additive `capability_enforcer=` parameter.
+- [x] **Default-off invariant.** When `capability_enforcer=` is unset, no capability code runs,
+  no `perf_counter` is called, and `apply()` is byte-identical to prior releases. No network I/O
+  on any path.
+- [x] **`StageTiming`** per-stage breakdown (`redaction | capability verification | evidence
+  write`) via `ScreeningPipeline.apply(stage_timings=…)`, for the CJ-EVAL harnesses
+  (`experiments/e2_replay.py`, `e2_chains.py`, `e2_violations.py`).
+
+### Bounds
+
+- Enforces the shipped `@1` caveat fragment (`max_per_call_usd`, `endpoint_prefixes`, validity
+  window); **jurisdiction is not representable in `@1` and is not enforced.** Aggregate budgets
+  (`daily_limit_usd`, `window_seconds`) remain the `PolicyEngine` ledger's responsibility.
+- Measures the *released* grant@1 artifact end-to-end; **ZK-tier numbers remain literature-cited**
+  (CJ-EVAL Phase C). See `plan/e2-capability-enforcer-design.md`.
+
+---
+
 ## Security Model
 
 The threat model for presidio-hardened-x402 addresses the following adversaries:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/presidio-v/presidio-hardened-x402/badge)](https://securityscorecards.dev/viewer/?uri=github.com/presidio-v/presidio-hardened-x402)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13675/badge)](https://www.bestpractices.dev/projects/13675)
 
-> v0.10.0 — treasury binding: x402 payment decisions reconcile into an audit-grade close via a signed off-chain `settlement-ref@1` join record, a fail-closed bundle export/verify CLI, client-side settlement-receipt capture, and cross-language canonicalization conformance vectors.
+> v0.11.0 — capability enforcement: each outgoing x402 payment can be required to prove it is authorised by a verified `capability-grant@1` chain **before** signing — an opt-in, default-off `CapabilityEnforcer` stage between the trusted-wallet allowlist and the policy engine.
 
 Security middleware for the [x402 payment protocol](https://www.x402.org/).
 
@@ -523,7 +523,9 @@ All exceptions are importable from `presidio_x402`.
 | v0.6.0 | **Production hardening + evidence substrate** — multi-tenant replay namespaces · enterprise audit sinks (S3 / Splunk / Datadog) · signed `evidence-ref@1` verification · SLSA/OIDC release provenance · digest-pinned Docker base + hash-pinned spaCy model · latency SLO and all-matrix coverage CI gates · OTel spans · policy hot-reload · startup key gates · human-pentest retest closure |
 | v0.7.0 | **SLO payment broker (library)** — x402 micropayments as runtime infrastructure bids: `SLOPaymentBroker` + `SLOPaymentPolicy` + evidence-anchored `ArchTranslucencyAdapter` + provisioning PII entities; cross-repo validated against `presidio-hardened-arch-translucency`. cs.DC preprint + empirical eval tracked separately |
 | v0.8.0 | PII completeness + supply-chain hardening (library) — `nlp` mode is now a structural superset of `regex` (no structured-identifier misses) · composed-envelope `screen_ref` leg · `action_ref` byte-determinism (NFC + non-empty entity sets) · URL-redacted log hygiene · OpenSSF Scorecard workflow/badge + SLSA Build L3 provenance · independent multi-round security audit cleared |
-| **v0.10.0** | **Treasury binding** — `settlement-ref@1` signed off-chain join record + fail-closed bundle export/verify CLI · client-side settlement-receipt capture · caller-identity value bounds · cross-language conformance vectors (non-ASCII escaping, lone surrogates, non-string keys, `i64` bounds, depth 128/129) — **latest release** |
+| **v0.11.0** | **CapabilityEnforcer** — opt-in, default-off `capability-grant@1` enforcement stage on the payment path (`PII → wallet → capability → policy → replay → MPA`); reuses `verify_chain` / `check_payment` / `policy_config_from_chain` / `decision_ref`; `StageTiming` per-stage breakdown; byte-identical when unset — **latest release** |
+| v0.10.1 | **Security patch** — `DecisionRefEmitter` signing key no longer leaks via `repr` (F1, CWE-312) |
+| v0.10.0 | **Treasury binding** — `settlement-ref@1` signed off-chain join record + fail-closed bundle export/verify CLI · client-side settlement-receipt capture · caller-identity value bounds · cross-language conformance vectors (non-ASCII escaping, lone surrogates, non-string keys, `i64` bounds, depth 128/129) |
 | v0.9.1 | **Security patch** — dependency-audit floors for `click` / `setuptools`, missing-payment-header log exposure hardening, and `setup-uv` v8.3.2 CI action pin |
 | v0.9.0 | Proof-carrying x402 evidence — `capability-grant@1` attenuable spending grants + opt-in `payment-decision@1` decision refs with raw-offer digest binding, fail-closed offline verification, capability-chain provenance linkage, and PII-free emitted records |
 | Future | Deferred #23 prompt-injection / agent-bound response scanning threat-model work |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.10.x  | ✓ (latest release) |
+| 0.11.x  | ✓ (latest release) |
+| 0.10.x  | ✓ |
 | 0.9.x   | ✓ |
-| 0.8.x   | ✓ |
-| 0.7.x   | security fixes only |
-| 0.6.x and older | security fixes only |
+| 0.8.x   | security fixes only |
+| 0.7.x and older | security fixes only |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Post-release documentation sync for **v0.11.0** (and picking up **v0.10.1**). The two release PRs (#103, #104) bumped the version + changelog but did not touch the version-coupled docs, so they still reflected v0.10.0 — the same kind of staleness a prior audit flagged (SECURITY-AUDIT I-03).

## Changes
- **README.md** — current-release callout is now v0.11.0 (CapabilityEnforcer); the version table gains **v0.11.0** (latest release) and **v0.10.1**, with the "latest release" marker moved off v0.10.0.
- **SECURITY.md** — Supported Versions window shifted (0.11.x latest; 0.11/0.10/0.9 supported, 0.8 and older security-fixes-only).
- **PRESIDIO-REQ.md** — adds the **v0.11.0 requirements** section (capability enforcement), matching the per-version baseline pattern (through v0.10.0), including the default-off invariant and the `@1`-caveat / ZK-literature-cited bounds.

Docs-only; no code change. CHANGELOG was already current.

## Test plan
- [ ] CI green
- [ ] README + SECURITY version references agree with the shipped v0.11.0