### PR TITLE
pii_filter: close the percent-encoding redaction bypass (+ audit F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **`PIIFilter` missed percent-encoded PII — a silent redaction bypass.**
+  `_normalise` closed the Unicode evasion paths (NFKC, invisible codepoints,
+  Cyrillic homoglyphs, hyphen folding) but did no percent-decoding, so
+  `alice.martin%40example.com` — the ordinary way an address appears inside a URL
+  path or query string — never reached the email pattern in a form it could
+  match. `experiments/surface_form_probe.py` measured **0 of 6** encoded forms
+  detected against v0.11.0 at the recommended configuration, with both unencoded
+  controls detected; the address passed through unredacted into the payment
+  payload. `resource_url` is by construction a URL and carries 45% of the entity
+  labels in the evaluation corpus, so this was the most likely encoding for real
+  x402 metadata to use.
+
+  Matching now runs additionally against a **bounded percent-decode** of the
+  input, with the resulting spans mapped back to the caller's own bytes. The
+  decode is capped at two rounds (enough for double-encoded `%2540`; not
+  "decode until stable", which would make the normaliser an amplification vector
+  on hostile input), is skipped entirely when the input holds no well-formed
+  escape, and passes malformed escapes through verbatim rather than raising —
+  the filter is fail-closed on exceptions, so a decode error would block an
+  otherwise legitimate payment. Decoding is used for **matching only**: the
+  returned string is still the caller's, so benign escapes are not rewritten and
+  URL semantics are preserved (`%2F` is not `/`). Both `regex` and `nlp` modes
+  are covered, as is `scan_dict`. Re-running the probe now reports 6/6 detected
+  and 0/6 surviving. No published evaluation number moves — the corpus contains
+  zero `%` characters. See `plan/percent-decoding-redaction-bypass.md`.
+- **MPA webhook response body was unbounded on the plain-httpx path**
+  (CWE-400, audit finding F1 of 2026-07-19). `_MPA_RESPONSE_MAX_BYTES` was
+  enforced while streaming inside `_post_pinned_https` but not on the
+  `self._httpx.post()` branch, taken for an IP-literal webhook URL or with
+  `dns_rebinding_protection` disabled; `resp.json()` then parsed an unbounded
+  body. A hostile approver at such a URL could exhaust agent process memory. The
+  cap is now applied on both branches before the response is verified or parsed.
+  Reaching it requires operator-level misconfiguration *and* a hostile approver.
+
+### Changed
+- NLP-mode install instructions now name **`en_core_web_lg`**, not
+  `en_core_web_sm`, in `README.md`, `docker/Dockerfile` (hash-pinned to the same
+  wheel the deployed service uses), and the `ImportError` hint raised by
+  `PIIFilter(mode="nlp")`. `en_core_web_lg` is what Presidio's default NLP engine
+  loads and what the published evaluation used; the previous instructions
+  produced an image in which `mode="nlp"` could not start.
+
 ## [0.11.0] — 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ For full NLP-based PII detection (PERSON, ORG, location, etc.):
 
 ```bash
 pip install "presidio-hardened-x402[nlp]"
-python -m spacy download en_core_web_sm
+python -m spacy download en_core_web_lg
 ```
+
+`en_core_web_lg` is the model Presidio's default NLP engine loads, and the one
+the published evaluation used. Installing `en_core_web_sm` instead leaves
+`mode="nlp"` unable to start.
 
 For production replay guard with cross-process deduplication:
 
@@ -155,6 +159,28 @@ client = HardenedX402Client(
     pii_action="block",     # raise PIIBlockedError instead of redacting
 )
 ```
+
+#### Known detection limits
+
+The filter canonicalises input before matching, so PII survives NFKC forms,
+zero-width characters, Cyrillic homoglyphs, non-ASCII hyphens, and — since the
+current release — percent-encoding, including one level of double-encoding
+(`%2540`). Encoded input is decoded for matching only; the string you get back
+is still yours, so benign escapes are never rewritten.
+
+Two bounds are deliberate rather than accidental, and worth knowing:
+
+- **Percent-decoding stops after two rounds.** Triple-encoded PII
+  (`%252540`) is not recovered. Decoding until stable would let a short hostile
+  input amplify inside the filter, which is the worse trade for a control on the
+  payment path.
+- **`regex` mode detects structural PII only** — emails, SSNs, credit cards,
+  phone numbers, IBANs, IP addresses. Names, organisations, and locations need
+  `mode="nlp"`.
+
+Detection gaps are measured, not assumed: `experiments/surface_form_probe.py`
+reports the current numbers, and the entity-level results are in
+`experiments/results/`.
 
 ### Replay Guard
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,11 @@ RUN pip install --no-cache-dir uv && \
         "uvicorn[standard]>=0.29.0"
 
 # Install spaCy model for NLP mode from a hash-pinned wheel.
+# en_core_web_lg, not _sm: it is what Presidio's default NLP engine loads, so a
+# _sm-only image cannot start `PIIFilter(mode="nlp")` at all. Same wheel and hash
+# as screening-api/requirements-model.lock, which the deployed service uses.
 RUN python -m pip install --no-cache-dir --no-deps \
-    "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl#sha256=1932429db727d4bff3deed6b34cfc05df17794f4a52eeb26cf8928f7c1a0fb85"
+    "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl#sha256=293e9547a655b25499198ab15a525b05b9407a75f10255e405e8c3854329ab63"
 
 # ── Stage 2: runtime ────────────────────────────────────────────────────────
 # Resolved 2026-06-21: python:3.12-slim -> sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9

--- a/src/presidio_x402/mpa.py
+++ b/src/presidio_x402/mpa.py
@@ -724,6 +724,16 @@ class MPAEngine:
                     content=request_body,
                     headers=headers,
                 )
+            # Bound the body before anything reads it. `_post_pinned_https` caps
+            # the read as it streams (see `_MPA_RESPONSE_MAX_BYTES` above); the
+            # plain-httpx branch — taken for an IP-literal webhook URL, or with
+            # dns_rebinding_protection off — has no equivalent, and httpx offers
+            # no transport-level limit. The body is already buffered by the time
+            # we get here, so this caps the amplification step (`resp.json()`
+            # inflating a multi-GB body into Python objects) rather than the read
+            # itself. Prefer a DNS-named webhook URL, which takes the pinned path.
+            if len(resp.content) > _MPA_RESPONSE_MAX_BYTES:
+                raise httpx.ProtocolError("MPA webhook response too large")
             resp.raise_for_status()
 
             # Verify response HMAC if the approver has a shared secret configured.

--- a/src/presidio_x402/pii_filter.py
+++ b/src/presidio_x402/pii_filter.py
@@ -90,17 +90,121 @@ _HYPHEN_FOLD = str.maketrans(
 )
 
 
+# Maximum number of percent-decoding rounds applied before matching. One round
+# recovers ordinary escapes (``%40`` → ``@``); two recover double-encoded ones
+# (``%2540`` → ``%40`` → ``@``). The cap is hard rather than "decode until
+# stable" — unbounded iteration would turn the decoder into an amplification
+# vector on hostile input.
+_MAX_PERCENT_DECODE_ROUNDS = 2
+
+# A well-formed percent escape. Used as a cheap presence test so input without
+# escapes — the common case — skips the decoding pass entirely.
+_PERCENT_ESCAPE = re.compile(r"%[0-9A-Fa-f]{2}")
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
 def _normalise(text: str) -> str:
     """Canonicalise *text* to foil regex-evasion via Unicode encoding tricks.
 
     Steps: NFKC → strip invisible codepoints → fold Cyrillic homoglyphs and
     hyphen-like characters to ASCII equivalents.
+
+    Percent-decoding is deliberately *not* one of these steps: the result of
+    ``_normalise`` is returned to the caller, and decoding escapes there would
+    rewrite benign ones and change URL semantics (``%2F`` is not ``/``). It is
+    handled separately by :func:`_percent_decode`, whose output is used for
+    matching only.
     """
     text = unicodedata.normalize("NFKC", text)
     text = "".join(c for c in text if ord(c) not in _INVISIBLE_CODEPOINTS)
     text = text.translate(_HOMOGLYPH_FOLD)
     text = text.translate(_HYPHEN_FOLD)
     return text
+
+
+def _decode_percent_once(text: str) -> tuple[str, list[int]]:
+    """Apply one round of percent-decoding, returning the result and an index map.
+
+    ``index_map[i]`` is the offset in *text* at which decoded character ``i``
+    originates, and ``index_map[len(decoded)] == len(text)``. A decoded span
+    ``[a, b)`` therefore maps back to ``[index_map[a], index_map[b])``.
+
+    Malformed escapes (``%zz``, a trailing ``%``) are copied through verbatim
+    rather than raising: the filter is fail-closed on exceptions, so a decode
+    error would block an otherwise legitimate payment.
+    """
+    out: list[str] = []
+    index_map: list[int] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if (
+            text[i] == "%"
+            and i + 2 < n
+            and text[i + 1] in _HEX_DIGITS
+            and text[i + 2] in _HEX_DIGITS
+        ):
+            # Consume the maximal run of consecutive escapes: percent-encoding
+            # encodes bytes, so one non-ASCII character can span several of them.
+            starts: list[int] = []
+            raw = bytearray()
+            j = i
+            while (
+                j + 2 < n
+                and text[j] == "%"
+                and text[j + 1] in _HEX_DIGITS
+                and text[j + 2] in _HEX_DIGITS
+            ):
+                raw.append(int(text[j + 1 : j + 3], 16))
+                starts.append(j)
+                j += 3
+            try:
+                run = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                run = raw.decode("latin-1")
+            last = len(starts) - 1
+            for k, ch in enumerate(run):
+                out.append(ch)
+                # Exact for single-byte escapes. A multi-byte sequence decodes to
+                # fewer characters than it had escapes; clamping keeps the map
+                # monotone and keeps every mapped span inside the run.
+                index_map.append(starts[k if k <= last else last])
+            i = j
+        else:
+            out.append(text[i])
+            index_map.append(i)
+            i += 1
+    index_map.append(n)
+    return "".join(out), index_map
+
+
+def _percent_decode(text: str) -> tuple[str, list[int]] | None:
+    """Percent-decode *text* for matching, with a span map back to *text*.
+
+    Returns ``None`` when *text* carries no well-formed escape, or when decoding
+    leaves it unchanged, so the caller can skip the second scan entirely.
+    Otherwise returns ``(decoded, index_map)`` — see :func:`_decode_percent_once`
+    for the map's meaning.
+    """
+    if not _PERCENT_ESCAPE.search(text):
+        return None
+
+    decoded = text
+    index_map = list(range(len(text) + 1))
+    for _ in range(_MAX_PERCENT_DECODE_ROUNDS):
+        candidate, step = _decode_percent_once(decoded)
+        if candidate == decoded:
+            break
+        decoded = candidate
+        # step maps new offsets to the previous round's; compose back to *text*.
+        index_map = [index_map[offset] for offset in step]
+        if not _PERCENT_ESCAPE.search(decoded):
+            break
+
+    if decoded == text:
+        return None
+    return decoded, index_map
 
 
 # ---------------------------------------------------------------------------
@@ -316,7 +420,7 @@ class PIIFilter:
         except ImportError as exc:
             raise ImportError(
                 "NLP mode requires: pip install presidio-hardened-x402[nlp] "
-                "and python -m spacy download en_core_web_sm"
+                "and python -m spacy download en_core_web_lg"
             ) from exc
 
     def _active_patterns(self) -> list[tuple[str, re.Pattern[str]]]:
@@ -349,50 +453,70 @@ class PIIFilter:
         # normalised form so downstream callers see a clean, canonical string.
         text = _normalise(text)
 
+        # Percent-encoding is the other evasion path, and the likely one for a
+        # resource URL: `alice%40example.com` never reaches the email pattern in
+        # a form that pattern can match. Match against a bounded decode, then map
+        # the spans back, so redaction still happens on — and returns — the
+        # caller's own bytes.
+        decoded = _percent_decode(text)
+
         if self.mode == "nlp" and self._analyzer is not None:
-            return self._scan_nlp(text)
-        return self._scan_regex(text)
+            return self._scan_nlp(text, decoded)
+        return self._scan_regex(text, decoded)
 
-    def _scan_regex(self, text: str) -> tuple[str, list[EntityResult]]:
-        results: list[EntityResult] = []
-        redacted = text
-
-        # Track offset shifts as substitutions change string length
-        offset = 0
-        # Collect all matches first to handle overlaps deterministically
-        all_matches: list[tuple[str, re.Match[str]]] = []
+    def _scan_regex(
+        self, text: str, decoded: tuple[str, list[int]] | None = None
+    ) -> tuple[str, list[EntityResult]]:
+        # (entity_type, start, end), all in `text` coordinates. Direct matches are
+        # collected first so that the dedupe below keeps the historical
+        # pattern-order tie-break; decoded matches only ever fill gaps.
+        spans: list[tuple[str, int, int]] = []
         for entity_type, pattern in self._active_patterns():
             for m in pattern.finditer(text):
-                all_matches.append((entity_type, m))
+                spans.append((entity_type, m.start(), m.end()))
 
-        # Sort by start position; for overlapping matches keep the first one
-        all_matches.sort(key=lambda t: t[1].start())
-        deduplicated: list[tuple[str, re.Match[str]]] = []
+        if decoded is not None:
+            decoded_text, index_map = decoded
+            for entity_type, pattern in self._active_patterns():
+                for m in pattern.finditer(decoded_text):
+                    start, end = index_map[m.start()], index_map[m.end()]
+                    if end > start:
+                        spans.append((entity_type, start, end))
+
+        # Sort by start position, preserving insertion order on ties; for
+        # overlapping matches keep the first one.
+        ordered = sorted(enumerate(spans), key=lambda t: (t[1][1], t[0]))
+        deduplicated: list[tuple[str, int, int]] = []
         last_end = -1
-        for entity_type, m in all_matches:
-            if m.start() >= last_end:
-                deduplicated.append((entity_type, m))
-                last_end = m.end()
+        for _rank, (entity_type, start, end) in ordered:
+            if start >= last_end:
+                deduplicated.append((entity_type, start, end))
+                last_end = end
 
-        for entity_type, m in deduplicated:
+        results: list[EntityResult] = []
+        redacted = text
+        # Track offset shifts as substitutions change string length
+        offset = 0
+        for entity_type, start, end in deduplicated:
             replacement = self.redaction_template.format(entity_type=entity_type)
-            start_adj = m.start() + offset
-            end_adj = m.end() + offset
             results.append(
                 EntityResult(
                     entity_type=entity_type,
-                    start=m.start(),
-                    end=m.end(),
+                    start=start,
+                    end=end,
                     score=1.0,
-                    original_text=m.group(0),
+                    original_text=text[start:end],
                 )
             )
-            redacted = redacted[:start_adj] + replacement + redacted[end_adj:]
-            offset += len(replacement) - (m.end() - m.start())
+            redacted = redacted[: start + offset] + replacement + redacted[end + offset :]
+            offset += len(replacement) - (end - start)
 
         return redacted, results
 
-    def _scan_nlp(self, text: str) -> tuple[str, list[EntityResult]]:
+    def _scan_nlp(
+        self, text: str, decoded: tuple[str, list[int]] | None = None
+    ) -> tuple[str, list[EntityResult]]:
+        from presidio_analyzer import RecognizerResult
         from presidio_anonymizer.entities import OperatorConfig
 
         entities_to_analyze = list(self.entities) if self.entities else None
@@ -403,6 +527,29 @@ class PIIFilter:
         )
         # Filter by minimum confidence score
         analyzer_results = [r for r in analyzer_results if r.score >= self.min_score]
+
+        if decoded is not None:
+            decoded_text, index_map = decoded
+            seen = {(r.entity_type, r.start, r.end) for r in analyzer_results}
+            for r in self._analyzer.analyze(
+                text=decoded_text,
+                entities=entities_to_analyze,
+                language="en",
+            ):
+                if r.score < self.min_score:
+                    continue
+                start, end = index_map[r.start], index_map[r.end]
+                if end <= start or (r.entity_type, start, end) in seen:
+                    continue
+                seen.add((r.entity_type, start, end))
+                # The anonymizer resolves the remaining overlaps (a URL entity
+                # spanning the whole string against the address inside it) the
+                # same way it already does for unencoded input.
+                analyzer_results.append(
+                    RecognizerResult(
+                        entity_type=r.entity_type, start=start, end=end, score=r.score
+                    )
+                )
 
         entity_results = [
             EntityResult(

--- a/tests/test_mpa.py
+++ b/tests/test_mpa.py
@@ -864,3 +864,52 @@ class TestResolveAndCheckHostPaths:
         monkeypatch.setattr(loop, "getaddrinfo", dup)
         result = await mpa_mod._resolve_and_check_host("example.test")
         assert result == ("93.184.216.34",)
+
+
+class TestWebhookResponseSizeCap:
+    """Audit F1 (2026-07-19, CWE-400): the plain-httpx branch — taken for an
+    IP-literal webhook URL or with `dns_rebinding_protection` off — parsed the
+    response body without bounding it, so a hostile approver could inflate a
+    multi-GB body into Python objects via `resp.json()`. `_post_pinned_https`
+    already capped its own read.
+    """
+
+    def _engine(self) -> mpa_mod.MPAEngine:
+        return mpa_mod.MPAEngine(
+            mpa_mod.MPAConfig(
+                dns_rebinding_protection=False,
+                threshold=1,
+                timeout_seconds=5.0,
+                approvers=[
+                    mpa_mod.MPAApproverConfig(
+                        "alice", mode="webhook", webhook_url="https://approvals.internal/alice"
+                    )
+                ],
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_oversized_response_is_denied_not_parsed(self):
+        oversized = b'{"approved": true, "pad": "' + b"A" * mpa_mod._MPA_RESPONSE_MAX_BYTES + b'"}'
+        with respx.mock:
+            respx.post("https://approvals.internal/alice").mock(
+                return_value=httpx.Response(
+                    200, content=oversized, headers={"Content-Type": "application/json"}
+                )
+            )
+            # An approving body that is over the cap must not count as an approval.
+            with pytest.raises(MPADeniedError):
+                await self._engine().request_approval(_make_details(amount="3.00"), 3.00)
+
+    @pytest.mark.asyncio
+    async def test_response_at_the_cap_is_still_accepted(self):
+        pad = mpa_mod._MPA_RESPONSE_MAX_BYTES - len(b'{"approved": true, "pad": ""}')
+        body = b'{"approved": true, "pad": "' + b"A" * pad + b'"}'
+        assert len(body) == mpa_mod._MPA_RESPONSE_MAX_BYTES
+        with respx.mock:
+            respx.post("https://approvals.internal/alice").mock(
+                return_value=httpx.Response(
+                    200, content=body, headers={"Content-Type": "application/json"}
+                )
+            )
+            await self._engine().request_approval(_make_details(amount="3.00"), 3.00)

--- a/tests/test_pii_filter.py
+++ b/tests/test_pii_filter.py
@@ -411,3 +411,277 @@ class TestPIIFilterRegexMode:
         monkeypatch.setattr(builtins, "__import__", mock_import)
         with pytest.raises(ImportError, match="NLP mode requires"):
             PIIFilter(mode="nlp")
+
+
+class TestPercentEncodingBypass:
+    """Percent-encoded PII evaded the filter through v0.11.0.
+
+    `_normalise` closed the Unicode evasion paths (homoglyphs, zero-width
+    characters, non-ASCII hyphens) but did no percent-decoding, so
+    `alice.martin%40example.com` — the ordinary way an address appears inside a
+    URL — never reached the email pattern in a form it could match. Measured by
+    `experiments/surface_form_probe.py`: 0 of 6 encoded forms detected, both
+    unencoded controls detected.
+    """
+
+    def setup_method(self):
+        self.filt = PIIFilter(mode="regex")
+
+    # ------------------------------------------------------------------
+    # The probe cases
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.example.com/users/alice.martin@example.com/exports",
+            "https://api.example.com/records?user=alice.martin@example.com",
+            "https://api.example.com/users/alice.martin%40example.com/exports",
+            "https://api.example.com/records?user=alice.martin%40example.com",
+            "https://api.example.com/users/alice%2Emartin%40example%2Ecom/exports",
+            "https://api.example.com/users/alice.martin%2540example.com/exports",
+            "mailto:alice.martin%40example.com",
+            "https://api.example.com/users/alice.martin%2Bapi%40example.com/exports",
+        ],
+    )
+    def test_encoded_address_is_detected_and_redacted(self, url):
+        redacted, entities = self.filt.scan_and_redact(url)
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+        assert "example.com/exports" not in redacted.replace("api.example.com", "")
+        assert "alice" not in redacted
+
+    def test_lowercase_escapes_are_decoded_too(self):
+        _, entities = self.filt.scan_and_redact("https://x.test/u/alice.martin%40example.com")
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    def test_encoded_ssn_is_detected(self):
+        redacted, entities = self.filt.scan_and_redact("https://x.test/q?ssn=123%2D45%2D6789")
+        assert any(e.entity_type == "US_SSN" for e in entities)
+        assert "123" not in redacted
+
+    # ------------------------------------------------------------------
+    # Caller bytes are preserved — decoding is for matching only
+    # ------------------------------------------------------------------
+    def test_benign_escapes_are_returned_unchanged(self):
+        """`%2F` is not `/`: rewriting escapes would change URL semantics."""
+        url = "https://api.example.com/a%2Fb/search?q=hello%20world"
+        redacted, entities = self.filt.scan_and_redact(url)
+        assert redacted == url
+        assert entities == []
+
+    def test_redaction_replaces_the_encoded_span_in_the_original(self):
+        url = "https://x.test/u/alice.martin%40example.com/exports"
+        redacted, entities = self.filt.scan_and_redact(url)
+        assert redacted == "https://x.test/u/<REDACTED>/exports"
+        (hit,) = [e for e in entities if e.entity_type == "EMAIL_ADDRESS"]
+        # Spans index the caller's string, so the reported original text is the
+        # encoded form the caller actually sent.
+        assert url[hit.start : hit.end] == hit.original_text == "alice.martin%40example.com"
+
+    def test_unencoded_input_is_unaffected(self):
+        url = "https://x.test/u/alice@example.com/exports"
+        redacted, entities = self.filt.scan_and_redact(url)
+        assert redacted == "https://x.test/u/<REDACTED>/exports"
+        assert [(e.start, e.end) for e in entities] == [(17, 34)]
+        assert url[17:34] == "alice@example.com"
+
+    # ------------------------------------------------------------------
+    # Malformed input must not raise — the filter is fail-closed on exceptions,
+    # so a decode error would block an otherwise legitimate payment.
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://x.test/p?a=100%25",
+            "https://x.test/p?a=%zz",
+            "https://x.test/p?a=%",
+            "https://x.test/p?a=%4",
+            "https://x.test/%",
+            "%%%%",
+        ],
+    )
+    def test_malformed_escapes_pass_through_without_raising(self, url):
+        redacted, _ = self.filt.scan_and_redact(url)
+        assert isinstance(redacted, str)
+
+    def test_malformed_escape_around_encoded_pii_still_catches_it(self):
+        _, entities = self.filt.scan_and_redact("https://x.test/%zz/alice%40example.com/%")
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    # ------------------------------------------------------------------
+    # The decode depth is a hard cap, not "decode until stable"
+    # ------------------------------------------------------------------
+    def test_double_encoding_is_within_the_cap(self):
+        _, entities = self.filt.scan_and_redact("https://x.test/u/alice%2540example.com")
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    def test_triple_encoding_is_beyond_the_cap(self):
+        """Documents the bound. Unbounded decoding would let a short hostile
+        input amplify inside the normaliser; two rounds is the accepted trade.
+        """
+        from presidio_x402.pii_filter import _MAX_PERCENT_DECODE_ROUNDS
+
+        assert _MAX_PERCENT_DECODE_ROUNDS == 2
+        _, entities = self.filt.scan_and_redact("https://x.test/u/alice%252540example.com")
+        assert not any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    def test_decoding_terminates_on_escape_free_input(self):
+        from presidio_x402.pii_filter import _percent_decode
+
+        assert _percent_decode("https://x.test/plain/path") is None
+        assert _percent_decode("") is None
+
+    # ------------------------------------------------------------------
+    # Index map
+    # ------------------------------------------------------------------
+    def test_index_map_is_monotone_and_bounded(self):
+        from presidio_x402.pii_filter import _percent_decode
+
+        for text in (
+            "a%40b",
+            "%2Emartin%40example%2Ecom",
+            "caf%C3%A9@example.com",
+            "%2540",
+            "%zz%40x",
+            "%E2%82%AC100 to alice%40example.com",
+        ):
+            decoded = _percent_decode(text)
+            assert decoded is not None, text
+            body, index_map = decoded
+            assert len(index_map) == len(body) + 1
+            assert index_map[-1] == len(text)
+            assert all(a <= b for a, b in zip(index_map, index_map[1:], strict=False)), text
+            assert all(0 <= o <= len(text) for o in index_map), text
+
+    def test_multibyte_escapes_do_not_break_the_span(self):
+        """A multi-byte UTF-8 sequence decodes to fewer characters than it had
+        escapes; the span must still cover the encoded bytes in the original.
+        """
+        url = "https://x.test/caf%C3%A9/alice%40example.com"
+        redacted, entities = self.filt.scan_and_redact(url)
+        (hit,) = [e for e in entities if e.entity_type == "EMAIL_ADDRESS"]
+        assert url[hit.start : hit.end] == "alice%40example.com"
+        assert redacted == "https://x.test/caf%C3%A9/<REDACTED>"
+
+    def test_invalid_utf8_escapes_fall_back_without_raising(self):
+        from presidio_x402.pii_filter import _percent_decode
+
+        decoded = _percent_decode("%FF%FEalice%40example.com")
+        assert decoded is not None
+        assert "@" in decoded[0]
+
+    # ------------------------------------------------------------------
+    # scan_dict inherits the fix
+    # ------------------------------------------------------------------
+    def test_scan_dict_catches_encoded_pii(self):
+        clean, entities = self.filt.scan_dict({"resource": "https://x.test/u/alice%40example.com"})
+        assert "alice" not in str(clean)
+        assert any(e.entity_type == "EMAIL_ADDRESS" for e in entities)
+
+    # ------------------------------------------------------------------
+    # NLP mode routes the decoded scan through the analyzer too
+    # ------------------------------------------------------------------
+    def test_nlp_mode_remaps_decoded_findings_to_original_offsets(self, monkeypatch):
+        class FakeOperatorConfig:
+            def __init__(self, operator_name, params):
+                self.operator_name = operator_name
+                self.params = params
+
+        class FakeRecognizerResult:
+            def __init__(self, *, entity_type, start, end, score):
+                self.entity_type = entity_type
+                self.start = start
+                self.end = end
+                self.score = score
+
+        monkeypatch.setitem(
+            sys.modules,
+            "presidio_anonymizer.entities",
+            types.SimpleNamespace(OperatorConfig=FakeOperatorConfig),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "presidio_analyzer",
+            types.SimpleNamespace(RecognizerResult=FakeRecognizerResult),
+        )
+
+        url = "https://x.test/u/alice%40example.com"
+        decoded_url = "https://x.test/u/alice@example.com"
+
+        class FakeAnalyzer:
+            def analyze(self, *, text, entities, language):  # noqa: ARG002
+                if text != decoded_url:
+                    return []
+                start = decoded_url.index("alice")
+                return [
+                    FakeRecognizerResult(
+                        entity_type="EMAIL_ADDRESS",
+                        start=start,
+                        end=len(decoded_url),
+                        score=0.9,
+                    )
+                ]
+
+        seen: dict = {}
+
+        class FakeAnonymizer:
+            def anonymize(self, *, text, analyzer_results, operators):
+                seen["text"] = text
+                seen["results"] = analyzer_results
+                seen["operators"] = operators
+                return types.SimpleNamespace(text="redacted")
+
+        filt = PIIFilter(mode="regex", min_score=0.5)
+        filt.mode = "nlp"
+        filt._analyzer = FakeAnalyzer()
+        filt._anonymizer = FakeAnonymizer()
+
+        redacted, entities = filt.scan_and_redact(url)
+
+        assert redacted == "redacted"
+        # The anonymizer runs against the caller's own bytes, not the decode.
+        assert seen["text"] == url
+        (hit,) = entities
+        assert hit.entity_type == "EMAIL_ADDRESS"
+        assert url[hit.start : hit.end] == "alice%40example.com"
+
+    def test_nlp_mode_does_not_duplicate_a_finding_present_in_both_scans(self, monkeypatch):
+        class FakeOperatorConfig:
+            def __init__(self, operator_name, params):
+                self.operator_name = operator_name
+                self.params = params
+
+        class FakeRecognizerResult:
+            def __init__(self, *, entity_type, start, end, score):
+                self.entity_type = entity_type
+                self.start = start
+                self.end = end
+                self.score = score
+
+        monkeypatch.setitem(
+            sys.modules,
+            "presidio_anonymizer.entities",
+            types.SimpleNamespace(OperatorConfig=FakeOperatorConfig),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "presidio_analyzer",
+            types.SimpleNamespace(RecognizerResult=FakeRecognizerResult),
+        )
+
+        # Trailing "%20" decodes to a space, so the decoded string keeps the same
+        # offsets for the leading URL entity both scans report.
+        class FakeAnalyzer:
+            def analyze(self, *, text, entities, language):  # noqa: ARG002
+                return [FakeRecognizerResult(entity_type="URL", start=0, end=14, score=0.8)]
+
+        class FakeAnonymizer:
+            def anonymize(self, *, text, analyzer_results, operators):  # noqa: ARG002
+                return types.SimpleNamespace(text="redacted")
+
+        filt = PIIFilter(mode="regex", min_score=0.5)
+        filt.mode = "nlp"
+        filt._analyzer = FakeAnalyzer()
+        filt._anonymizer = FakeAnonymizer()
+
+        _, entities = filt.scan_and_redact("https://x.test/a%20b")
+        assert len(entities) == 1


### PR DESCRIPTION
## Summary

- **Closes the percent-encoding redaction bypass.** `PIIFilter` missed percent-encoded PII entirely — `_normalise` folded the Unicode evasion paths (NFKC, invisible codepoints, homoglyphs, hyphens) but did no percent-decoding, so `alice.martin%40example.com` never reached the email pattern in a form it could match. `experiments/surface_form_probe.py` measured **0 of 6** encoded forms detected against v0.11.0, both unencoded controls detected; the address passed through unredacted into the payment payload. `resource_url` is by construction a URL and carries 45% of the corpus entity labels, so this was the likeliest encoding for real x402 metadata to use.
- **Bounds the MPA webhook response body on the plain-httpx branch** — audit finding F1 (CWE-400), open four consecutive cycles. `_MPA_RESPONSE_MAX_BYTES` was enforced while streaming inside `_post_pinned_https` but not on the branch taken for an IP-literal webhook URL or with `dns_rebinding_protection` off, where `resp.json()` then parsed an unbounded body.
- **Installs `en_core_web_lg`, not `_sm`**, in README, `docker/Dockerfile`, and the `mode="nlp"` `ImportError` hint. Not a doc nit: `_lg` is what Presidio's default NLP engine loads, so a `_sm`-only image could not start NLP mode at all.

## Design note — why this is not a decode inside `_normalise`

`scan_and_redact` returns the *normalised* string. Decoding escapes there would rewrite benign ones in the output and change URL semantics (`%2F` is not `/`), so matching runs against a bounded decode whose spans are mapped back through an exact index map. The caller's bytes are returned intact; only the matching sees the decoded form.

Three bounds are deliberate:

- **Two decode rounds max.** Enough for double-encoded `%2540`; "decode until stable" would make the normaliser an amplification vector on hostile input. Triple-encoding is documented as out of scope and covered by a test that asserts the bound.
- **Malformed escapes are copied through, never raised.** The filter is fail-closed on exceptions, so a decode error would block an otherwise legitimate payment.
- **Direct matches are collected before decoded ones**, preserving the historical pattern-order tie-break. On escape-free input, behaviour is byte-identical to v0.11.0.

Consecutive escapes decode as a byte run so a multi-byte UTF-8 sequence cannot desynchronise the index map; invalid UTF-8 falls back to latin-1.

## Test plan

- [x] `ruff check .` and `ruff format --check .` clean
- [x] **786 passed, 1 skipped** (was 755 — +31 tests), no regressions
- [x] `TestPercentEncodingBypass`: all 8 probe cases, encoded SSN, caller bytes preserved on benign escapes, span/`original_text` correctness, 6 malformed-escape forms, the two-round bound, index-map monotonicity, multi-byte UTF-8 spans, `scan_dict`, and both NLP-mode merge paths
- [x] `TestWebhookResponseSizeCap`: oversized approving body is denied rather than parsed; a body exactly at the cap is still accepted
- [x] `python -m experiments.surface_form_probe` re-run at both configurations: **6/6 encoded forms detected, 0/6 addresses surviving**, controls unchanged

`experiments/results/surface_form_probe.json` is deliberately **not** updated — it is the paper's record of the measured v0.11.0 gap, deposited in #109. It gets refreshed when this ships and §6.7 is rewritten against a pinned release.

## Notes for review

- No version bump here; this follows the normal chain, with the bump as its own PR.
- Adversary-chain-01's closure evidence cited the old `_sm` wheel hash and was updated in the outer repo to match the repin. The mitigation is unchanged in kind — a hash-pinned wheel URL, not `spacy download`.