### PR TITLE
Declare tomli and packaging instead of relying on transitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **`tomli` was never declared, so TOML policy files did not work on Python 3.10.**
+  `requires-python` is `>=3.10`, stdlib `tomllib` is 3.11+, and
+  `load_policy_file()` reaches TOML on 3.10 only through `tomli` — which appeared
+  in no dependency list. The README documents `load_policy_file("policy.toml")` as
+  public API, so that example raised `ImportError` on a core install at the lowest
+  supported Python. The existing TOML tests could not see it: `pytest-cov` pulls
+  `coverage[toml]` → `tomli`, so the 3.10 CI leg tested against an environment
+  richer than the one users get. Declared as `tomli>=2.0.1; python_version < "3.11"`.
+- **`packaging` was a 3-hop transitive under the import-time CVE audit.**
+  `_on_import_audit()` compares installed dependencies against the
+  `_KNOWN_VULNERABLE` floors using `packaging.version`, behind a guarded import
+  whose fallback skips every comparison. Losing `packaging` therefore disabled the
+  dependency-CVE warning *silently* instead of raising, and it resolved only via
+  presidio-analyzer → spaCy → thinc/weasel. Now a declared core dependency.
+
+### Added
+- **Packaging-contract tests** (`tests/test_declared_dependencies.py`) asserting
+  that directly imported modules are declared requirements, plus a
+  `load_policy_file` test that forces the pre-3.11 `tomli` branch on any
+  interpreter. Both gaps above were invisible to functional tests, which pass
+  whenever the package is installed for unrelated reasons.
+
 ## [0.11.1] — 2026-08-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,18 @@ dependencies = [
     # Transitive of presidio-analyzer -> spaCy; pin minimum to evict
     # PYSEC-2026-3447 (setuptools < 83.0.0 vulnerable). Audit 2026-07-14.
     "setuptools>=83.0.0",
+    # Imported directly by _on_import_audit() in __init__.py to compare installed
+    # versions against the _KNOWN_VULNERABLE floors. It resolved only as a 3-hop
+    # transitive (presidio-analyzer -> spaCy -> thinc/weasel), and the import is
+    # guarded, so losing it would silently disable the whole dependency-CVE warning
+    # rather than fail loudly. Declared so that cannot happen. Audit 2026-08-03.
+    "packaging>=23.0",
+    # Imported directly by load_policy_file() for TOML policy files, which is
+    # documented in the README. stdlib tomllib is 3.11+, and requires-python is
+    # >=3.10, so a core install on 3.10 had no TOML reader at all. CI never caught
+    # it: pytest-cov pulls coverage[toml] -> tomli, so the test environment is
+    # richer than the shipped one. Audit 2026-08-03.
+    'tomli>=2.0.1; python_version < "3.11"',
 ]
 
 [project.optional-dependencies]

--- a/src/presidio_x402/__init__.py
+++ b/src/presidio_x402/__init__.py
@@ -242,7 +242,11 @@ def _on_import_audit() -> None:
         try:
             from packaging.version import InvalidVersion as _InvalidVersion
             from packaging.version import Version as _Version
-        except ImportError:  # pragma: no cover - packaging ships with pip
+        except ImportError:  # pragma: no cover - packaging is a declared dependency
+            # This fallback is defense-in-depth against a broken install, not a
+            # supported mode: taking it silently disables every version comparison
+            # below, so the dependency-CVE warning never fires. `packaging` is a
+            # declared dependency precisely so this branch stays unreachable.
             _Version = None  # noqa: N806 - aliasing imported class symbol
             # _InvalidVersion is unreachable on the fallback path: line 124's
             # `if _Version is None: continue` short-circuits before any code

--- a/tests/test_declared_dependencies.py
+++ b/tests/test_declared_dependencies.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
+"""Packaging-contract tests for directly imported third-party modules.
+
+A module that ``import``s a package the distribution does not declare works only
+for as long as some *other* dependency happens to pull that package in. The
+arrangement is invisible to the test suite, because a dev environment installs
+strictly more than a core install does, and invisible to Dependabot, which reads
+declared requirements.
+
+These tests assert the declarations exist. They are deliberately metadata
+assertions rather than functional ones: a functional test passes either way in
+any environment where the package is present for unrelated reasons, which is
+exactly the situation that let both of the gaps below survive.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+
+DIST = "presidio-hardened-x402"
+
+
+def _requirements() -> list[str]:
+    reqs = importlib.metadata.requires(DIST)
+    if reqs is None:  # pragma: no cover - only when running against a broken install
+        pytest.skip(f"{DIST} metadata unavailable; run against an installed distribution")
+    return reqs
+
+
+def _core_requirements() -> list[str]:
+    """Requirements with no ``extra ==`` marker — what a bare install gets."""
+    return [r for r in _requirements() if "extra ==" not in r]
+
+
+def _named(requirements: list[str], name: str) -> list[str]:
+    out = []
+    for req in requirements:
+        head = req.split(";")[0].strip()
+        for sep in ("[", ">", "<", "=", "!", "~", " ", "("):
+            head = head.split(sep)[0]
+        if head.strip().lower().replace("_", "-") == name:
+            out.append(req)
+    return out
+
+
+def test_packaging_is_a_core_dependency():
+    """``packaging`` backs the import-time dependency-CVE audit.
+
+    ``_on_import_audit`` compares installed versions against the
+    ``_KNOWN_VULNERABLE`` floors using ``packaging.version``. Its import is
+    guarded, and the fallback skips every comparison, so an absent ``packaging``
+    disables the warning silently rather than raising. It previously resolved only
+    as a 3-hop transitive of presidio-analyzer -> spaCy -> thinc/weasel.
+    """
+    assert _named(_core_requirements(), "packaging"), (
+        "packaging must be a core dependency — __init__.py imports it directly, and "
+        "without it the dependency-CVE audit fails open instead of loudly"
+    )
+
+
+def test_tomli_is_declared_for_pre_311():
+    """``tomli`` backs TOML policy files on the lowest supported Python.
+
+    stdlib ``tomllib`` is 3.11+ while ``requires-python`` is >=3.10, so
+    ``load_policy_file`` on a ``.toml`` path needs ``tomli`` there. It must carry a
+    ``python_version < "3.11"`` marker so 3.11+ installs do not take a needless
+    dependency.
+    """
+    matches = _named(_core_requirements(), "tomli")
+    assert matches, (
+        "tomli must be declared — load_policy_file() imports it for TOML policy "
+        "files, which the README documents, and stdlib tomllib is 3.11+"
+    )
+    assert any("python_version" in req and "3.11" in req for req in matches), (
+        f"tomli must be marked for Python < 3.11, got: {matches}"
+    )
+
+
+def test_no_extra_only_dependency_backs_a_core_import():
+    """Guard the general shape: core imports must not rest on extras.
+
+    Both gaps above shared a cause — a module-scope import satisfied by something
+    outside the core requirement set. This pins the two names that were fixed so a
+    later edit cannot quietly demote either into an extra.
+    """
+    core = {
+        req.split(";")[0].strip().split("[")[0].split(">")[0].split("<")[0].split("=")[0].strip()
+        for req in _core_requirements()
+    }
+    for name in ("httpx", "packaging", "tomli"):
+        assert name in core, f"{name} is imported directly and must stay a core requirement"

--- a/tests/test_policy_schema.py
+++ b/tests/test_policy_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 from pathlib import Path
 
@@ -218,6 +219,30 @@ class TestLoadPolicyFileTOML:
         policy = load_policy_file(path)
         assert "https://premium-api.io" in policy.per_endpoint
         assert policy.per_endpoint["https://premium-api.io"] == pytest.approx(0.50)
+
+    def test_loads_via_tomli_when_stdlib_tomllib_is_absent(self, monkeypatch):
+        """The Python 3.10 path must work on a core install.
+
+        stdlib ``tomllib`` is 3.11+, so on 3.10 — which ``requires-python`` still
+        supports — ``load_policy_file`` reaches TOML only through ``tomli``. The
+        other tests in this class cannot detect a missing ``tomli`` declaration:
+        they run on 3.11+ where the stdlib branch is taken, and even on the 3.10 CI
+        leg ``pytest-cov`` drags in ``coverage[toml]`` -> ``tomli``, making the test
+        environment richer than a core install. So force the fallback branch here
+        on every interpreter instead of trusting the matrix to cover it.
+        """
+        monkeypatch.setattr(sys, "version_info", (3, 10, 0, "final", 0))
+        # Setting a sys.modules entry to None makes `import tomllib` raise
+        # ImportError, which is what a real 3.10 interpreter does.
+        monkeypatch.setitem(sys.modules, "tomllib", None)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write('max_per_call_usd = 0.25\nagent_id = "py310-agent"\n')
+            path = f.name
+
+        policy = load_policy_file(path)
+        assert policy.max_per_call_usd == pytest.approx(0.25)
+        assert policy.agent_id == "py310-agent"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_policy_schema.py
+++ b/tests/test_policy_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 import tempfile
@@ -220,16 +221,22 @@ class TestLoadPolicyFileTOML:
         assert "https://premium-api.io" in policy.per_endpoint
         assert policy.per_endpoint["https://premium-api.io"] == pytest.approx(0.50)
 
+    @pytest.mark.skipif(
+        importlib.util.find_spec("tomli") is None,
+        reason="tomli is declared only for python_version < 3.11; 3.11+ has no fallback to test",
+    )
     def test_loads_via_tomli_when_stdlib_tomllib_is_absent(self, monkeypatch):
         """The Python 3.10 path must work on a core install.
 
         stdlib ``tomllib`` is 3.11+, so on 3.10 — which ``requires-python`` still
         supports — ``load_policy_file`` reaches TOML only through ``tomli``. The
-        other tests in this class cannot detect a missing ``tomli`` declaration:
-        they run on 3.11+ where the stdlib branch is taken, and even on the 3.10 CI
-        leg ``pytest-cov`` drags in ``coverage[toml]`` -> ``tomli``, making the test
-        environment richer than a core install. So force the fallback branch here
-        on every interpreter instead of trusting the matrix to cover it.
+        other tests in this class never exercise that branch: they take the stdlib
+        path on 3.11+, and on 3.10 they cannot tell a declared ``tomli`` from one
+        that ``pytest-cov`` -> ``coverage[toml]`` happened to drag in. Forcing the
+        branch here covers the code path; the declaration itself is guarded by
+        ``tests/test_declared_dependencies.py``.
+
+        Skipped on 3.11+, where ``tomli`` is deliberately not installed.
         """
         monkeypatch.setattr(sys, "version_info", (3, 10, 0, "final", 0))
         # Setting a sys.modules entry to None makes `import tomllib` raise

--- a/uv.lock
+++ b/uv.lock
@@ -1625,9 +1625,11 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "idna" },
+    { name = "packaging" },
     { name = "presidio-analyzer" },
     { name = "presidio-anonymizer" },
     { name = "setuptools" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "urllib3" },
 ]
 
@@ -1689,6 +1691,7 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.28.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.28.0" },
+    { name = "packaging", specifier = ">=23.0" },
     { name = "pip-audit", marker = "extra == 'audit'", specifier = ">=2.7.0" },
     { name = "presidio-analyzer", specifier = ">=2.2.0" },
     { name = "presidio-anonymizer", specifier = ">=2.2.0" },
@@ -1702,6 +1705,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "setuptools", specifier = ">=83.0.0" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["nlp", "evidence", "redis", "audit-s3", "audit", "langchain", "crewai", "prometheus", "otel", "schema", "fuzz", "dev"]


### PR DESCRIPTION
## Summary

- **`tomli` was undeclared, so TOML policy files did not work on Python 3.10.** `requires-python` is `>=3.10`, stdlib `tomllib` is 3.11+, and `load_policy_file()` reaches TOML on 3.10 only via `tomli` — which appeared in no dependency list. `README.md:296` documents `load_policy_file("policy.toml")` as public API, so that example raised `ImportError` on a core install at the lowest supported Python. Verified on a real 3.10 interpreter.
- **`packaging` was a 3-hop transitive holding up the import-time CVE audit.** `_on_import_audit()` compares installed versions against the `_KNOWN_VULNERABLE` floors using `packaging.version`, behind a guarded import whose fallback `continue`s past every comparison. Losing it disabled the dependency-CVE warning *silently* rather than raising. It resolved only through presidio-analyzer → spaCy → thinc/weasel.
- Both are now declared: `packaging>=23.0` and `tomli>=2.0.1; python_version < "3.11"`.

## Why CI was green

`pytest-cov` pulls `coverage[toml]` → `tomli`, so the 3.10 matrix leg ran against an environment strictly richer than a core install. The existing `TestLoadPolicyFileTOML` tests passed against a dependency the package never declared. Confirmed by resolving both sets on 3.10: the dev resolve contains `tomli==2.4.1`, the core resolve contains none.

That is why the new tests are **metadata assertions** rather than functional ones — a functional test passes either way wherever the package happens to be installed, which is exactly how both gaps survived. The added `load_policy_file` test forces the pre-3.11 `tomli` branch on any interpreter rather than trusting the matrix to cover it.

## Context

Found by sweeping every subproject for module-scope imports absent from `pyproject.toml`, after the same pattern broke `presidio-hardened-x402-mcp` (mcp 2.x moved its HTTP stack to `httpx2`, stranding an undeclared `import httpx`). `screening-api` and `evidence-bridge` are clean. `crewai` remains undeclared deliberately — that extra is intentionally empty with a documented CVE-2026-45829 rationale.

No behaviour change on 3.11+. The only `src/` edit is a comment: the guard was annotated *"packaging ships with pip"*, which is true of the pip environment but not of an installed package's import graph.

## Test plan

- [x] `ruff check` clean; 105 files already formatted
- [x] Full suite passes — 790 passed, 1 skipped (the skip is pre-existing: `langchain-core` not installed)
- [x] **Both new metadata tests verified to fail pre-fix** — neither name is in `git show HEAD:pyproject.toml` core deps
- [x] **TOML fallback verified to raise without `tomli`** — hiding both `tomllib` and `tomli` reproduces the exact `ImportError` a 3.10 user hit
- [x] Python 3.10 gap reproduced on a real 3.10 interpreter before fixing
- [x] `uv.lock` regenerated, not hand-edited
- [x] vstantch-code style run on all changed Python — only `assert`-in-tests findings, identical to the pre-existing `test_import_audit.py` baseline

## Follow-up commit

The first push failed `Test (Python 3.11)`. The fallback test forced the pre-3.11 branch on every interpreter, but the new marker means 3.11+ deliberately has no `tomli` — so it drove `load_policy_file` into a fallback with nothing to fall back to. My local venv passed only because it still carried `tomli` from an older resolve. `c39dea9` gates the test on `tomli` being importable; it runs on 3.10, the only place the branch is reachable. All 14 checks now pass on 3.10 / 3.11 / 3.12 / 3.13.
