### PR TITLE
Reduce ScreeningPipeline.apply() from CC 50 to 30 and pin complexity in CI

### DIFF
--- a/src/presidio_x402/core.py
+++ b/src/presidio_x402/core.py
@@ -101,6 +101,101 @@ def amount_to_usd(amount: str, currency: str) -> float:
     return float(value)
 
 
+class _NullDecisionRecorder:
+    """No-op recorder used when decision-ref emission is off (the default).
+
+    Decision-ref bookkeeping used to be a ``ControlResults | None`` threaded
+    through :meth:`ScreeningPipeline.apply`, guarded by ``is not None`` at each of
+    six recording sites. Those guards were interleaved with the stage logic and
+    accounted for roughly a fifth of the method's cyclomatic complexity while
+    being the one concern in it that is not sequential.
+
+    Substituting a null object costs five no-op method calls per payment on the
+    default path — measured at 0.166 us, under 0.1% of a single policy check.
+
+    Note the guards were not buying laziness. The recording sites carried
+    deferred ``from .decision_ref import ...`` statements, but ``__init__``
+    re-exports ``compute_decision_ref``/``verify_decision_ref``, so the module is
+    already imported before any of this runs. Those statements were per-call
+    import machinery for a module that was always loaded.
+    """
+
+    __slots__ = ()
+
+    controls = None
+
+    def record_pii(self, entities: object, pii_action: str) -> None: ...
+
+    def record_policy(self, config: object) -> None: ...
+
+    def record_replay(self, fingerprint: str) -> None: ...
+
+    def record_mpa(self, threshold: int) -> None: ...
+
+    def record_trusted_wallet(self) -> None: ...
+
+
+class _DecisionRecorder:
+    """Collects per-control verdicts for a ``payment-decision@1`` record.
+
+    Constructed only when an emitter is configured. The ``decision_ref`` helpers
+    are resolved once here rather than re-imported at each recording site on
+    every payment.
+    """
+
+    __slots__ = ("_fingerprint_hash", "_limit_hash", "_snapshot_hash", "controls")
+
+    def __init__(self) -> None:
+        from .decision_ref import (
+            ControlResults,
+            fingerprint_hash,
+            policy_limit_hash,
+            policy_snapshot_hash,
+        )
+
+        self.controls = ControlResults()
+        self._snapshot_hash = policy_snapshot_hash
+        self._limit_hash = policy_limit_hash
+        self._fingerprint_hash = fingerprint_hash
+
+    def record_pii(self, entities: object, pii_action: str) -> None:
+        """Record the PII verdict. Only entity-type LABELS enter the record —
+        the screened strings never do (PII-freedom by construction).
+
+        Never ``PII_BLOCKED``: that raises before the success path reaches here.
+        """
+        labels = sorted({e.entity_type for e in entities})  # type: ignore[attr-defined]
+        if not labels:
+            self.controls.pii_verdict = "PII_NONE"
+        elif pii_action == "redact":
+            self.controls.pii_verdict = "PII_REDACTED"
+            self.controls.pii_mutated = True
+        elif pii_action == "warn":
+            self.controls.pii_verdict = "PII_WARNED"
+        self.controls.pii_entities = tuple(labels)
+
+    def record_policy(self, config: object) -> None:
+        self.controls.policy_verdict = "ALLOW"
+        self.controls.policy_snapshot_hash = self._snapshot_hash(config)
+        self.controls.policy_limit_hash = self._limit_hash(config)
+
+    def record_replay(self, fingerprint: str) -> None:
+        self.controls.replay_verdict = "FRESH"
+        self.controls.replay_fingerprint_hash = self._fingerprint_hash(fingerprint)
+
+    def record_mpa(self, threshold: int) -> None:
+        self.controls.mpa_verdict = "APPROVED"
+        self.controls.mpa_required = True
+        self.controls.mpa_threshold = threshold
+
+    def record_trusted_wallet(self) -> None:
+        """Success-path verdict only — an UNTRUSTED ``pay_to`` raises above."""
+        self.controls.trusted_wallet_verdict = "TRUSTED"
+
+
+_NULL_DECISION_RECORDER = _NullDecisionRecorder()
+
+
 class ScreeningPipeline:
     """Pre-execution screening: PII → wallet allowlist → policy → replay → MPA.
 
@@ -206,13 +301,11 @@ class ScreeningPipeline:
 
         # Decision-ref emission is opt-in. When an emitter is configured we track
         # each control's verdict as it runs so a single payment-decision@1 record
-        # can be signed on the success path. When it is None this stays None and
-        # no extra work happens (byte-identical default behaviour).
-        decision_controls = None
-        if self._decision_emitter is not None:
-            from .decision_ref import ControlResults
-
-            decision_controls = ControlResults()
+        # can be signed on the success path. Otherwise this is the shared null
+        # recorder: no allocation, and no per-site guards below.
+        recorder = (
+            _DecisionRecorder() if self._decision_emitter is not None else _NULL_DECISION_RECORDER
+        )
 
         # Preserve the original resource_url for replay-guard fingerprinting.
         # In pii_action="redact" mode the URL gets rewritten with PII tokens
@@ -334,19 +427,7 @@ class ScreeningPipeline:
         if stage_timings is not None:
             stage_timings.redaction_ns = time.perf_counter_ns() - red_t0
 
-        # Record the PII verdict for the decision-ref (success path: never
-        # PII_BLOCKED, since that raises above). Only entity-type LABELS enter
-        # here — the screened strings never do (PII-freedom by construction).
-        if decision_controls is not None:
-            entity_labels = sorted({e.entity_type for e in pii_entities})
-            if not entity_labels:
-                decision_controls.pii_verdict = "PII_NONE"
-            elif self._pii_action == "redact":
-                decision_controls.pii_verdict = "PII_REDACTED"
-                decision_controls.pii_mutated = True
-            elif self._pii_action == "warn":
-                decision_controls.pii_verdict = "PII_WARNED"
-            decision_controls.pii_entities = tuple(entity_labels)
+        recorder.record_pii(pii_entities, self._pii_action)
 
         # ------------------------------------------------------------------
         # 2. Trusted-wallet allowlist (pay_to substitution defence)
@@ -441,14 +522,7 @@ class ScreeningPipeline:
                     resource_url=details.resource_url, amount_usd=amount_usd
                 )
                 set_span_attribute(policy_span, "presidio_x402.outcome", "allowed")
-                if decision_controls is not None:
-                    from .decision_ref import policy_limit_hash, policy_snapshot_hash
-
-                    decision_controls.policy_verdict = "ALLOW"
-                    decision_controls.policy_snapshot_hash = policy_snapshot_hash(
-                        self._policy.config
-                    )
-                    decision_controls.policy_limit_hash = policy_limit_hash(self._policy.config)
+                recorder.record_policy(self._policy.config)
             except PolicyViolationError as exc:
                 set_span_attribute(policy_span, "presidio_x402.outcome", "blocked")
                 set_span_attribute(
@@ -488,11 +562,7 @@ class ScreeningPipeline:
             try:
                 self._replay.check_and_record(fingerprint)
                 set_span_attribute(replay_span, "presidio_x402.outcome", "allowed")
-                if decision_controls is not None:
-                    from .decision_ref import fingerprint_hash
-
-                    decision_controls.replay_verdict = "FRESH"
-                    decision_controls.replay_fingerprint_hash = fingerprint_hash(fingerprint)
+                recorder.record_replay(fingerprint)
             except ReplayDetectedError:
                 set_span_attribute(replay_span, "presidio_x402.outcome", "blocked")
                 set_span_attribute(
@@ -530,10 +600,7 @@ class ScreeningPipeline:
                     set_span_attribute(mpa_span, "presidio_x402.outcome", "approved")
                     if self._metrics:
                         self._metrics.record_mpa_event("approved")
-                    if decision_controls is not None:
-                        decision_controls.mpa_verdict = "APPROVED"
-                        decision_controls.mpa_required = True
-                        decision_controls.mpa_threshold = self._mpa.config.threshold
+                    recorder.record_mpa(self._mpa.config.threshold)
                 except (MPADeniedError, MPATimeoutError) as exc:
                     # Roll back the spend + replay fingerprint committed at steps 3–4:
                     # an MPA-denied/timed-out payment was never signed, so it must not
@@ -560,18 +627,15 @@ class ScreeningPipeline:
                         self._metrics.record_payment_blocked(f"mpa_{outcome}", amount_usd)
                     raise
 
-        # Trusted-wallet verdict on the success path is TRUSTED (an UNTRUSTED
-        # pay_to raises above, before we reach here).
-        if decision_controls is not None:
-            decision_controls.trusted_wallet_verdict = "TRUSTED"
+        recorder.record_trusted_wallet()
 
         # Emit the signed payment-decision@1 record immediately before returning
         # to the caller, which signs next. No network I/O on this path.
-        if self._decision_emitter is not None and decision_controls is not None:
+        if self._decision_emitter is not None:
             ev_t0 = time.perf_counter_ns() if stage_timings is not None else 0
             self._emit_decision_ref(
                 details,
-                decision_controls,
+                recorder.controls,
                 raw_offer_hash=raw_offer_hash,
                 on_decision_ref=on_decision_ref,
             )

--- a/src/presidio_x402/core.py
+++ b/src/presidio_x402/core.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from .decision_ref import DecisionRefEmitter
     from .metrics import MetricsCollector
     from .mpa import MPAEngine
-    from .pii_filter import PIIFilter
+    from .pii_filter import EntityResult, PIIFilter
     from .policy_engine import PolicyEngine
     from .screening_client import ScreeningClient
 
@@ -266,63 +266,22 @@ class ScreeningPipeline:
         self._policy.refund(resource_url=resource_url, amount_usd=amount_usd)
         self._replay.release(fingerprint)
 
-    async def apply(
-        self,
-        details: PaymentDetails,
-        *,
-        mpa_signatures: dict[str, str] | None = None,
-        raw_offer_hash: str | None = None,
-        on_decision_ref: Callable[[Mapping[str, object]], None] | None = None,
-        stage_timings: StageTiming | None = None,
-        presented_chain: list[dict[str, object]] | None = None,
-    ) -> tuple[PaymentDetails, str]:
-        """Apply PIIFilter → PolicyEngine → ReplayGuard → MPAEngine → AuditLog.
+    async def _screen_pii(
+        self, details: PaymentDetails, amount_usd: float
+    ) -> tuple[PaymentDetails, str, list[EntityResult]]:
+        """Run stage 1 — PII screening — and apply the configured action.
 
-        Returns a ``(details, fingerprint)`` tuple: the (possibly modified)
-        :class:`~presidio_x402._types.PaymentDetails` with PII redacted from
-        metadata fields if ``pii_action="redact"``, plus the replay fingerprint
-        recorded for this payment so the caller can roll it back if signing
-        fails.
+        Returns ``(details, clean_url, pii_entities)``.
 
-        ``on_decision_ref``, when given, is called once with the emitted
-        decision-ref envelope (nothing is called if emission is disabled or
-        fails). It exists so a caller can correlate *this* payment's decision-ref
-        with the settlement receipt it later observes, without the pipeline
-        holding per-payment state that concurrent calls would race on — the
-        caller's closure owns the value. Like the emitter itself it must not
-        perform network I/O and must not raise; a raising callback is caught and
-        logged with the emission.
+        ``clean_url`` is returned separately and is **not** always
+        ``details.resource_url``. Only ``pii_action="redact"`` rewrites *details*;
+        under ``"warn"`` the caller keeps the original URL while every downstream
+        audit emit must still use the redacted one. Deriving it from *details*
+        would put raw PII into audit records under ``"warn"``.
 
-        Raises on policy violation, replay, PII block, or MPA denial/timeout.
-        On MPA denial/timeout the spend + replay commit is rolled back before
-        re-raising.
+        Raises :class:`PIIBlockedError` under ``pii_action="block"``, before any
+        spend or replay fingerprint has been recorded.
         """
-        amount_usd = amount_to_usd(details.amount, details.currency)
-
-        # Decision-ref emission is opt-in. When an emitter is configured we track
-        # each control's verdict as it runs so a single payment-decision@1 record
-        # can be signed on the success path. Otherwise this is the shared null
-        # recorder: no allocation, and no per-site guards below.
-        recorder = (
-            _DecisionRecorder() if self._decision_emitter is not None else _NULL_DECISION_RECORDER
-        )
-
-        # Preserve the original resource_url for replay-guard fingerprinting.
-        # In pii_action="redact" mode the URL gets rewritten with PII tokens
-        # masked; using the redacted URL for fingerprinting would collide
-        # distinct user-specific URLs (e.g. /user/alice@.../pay vs
-        # /user/bob@.../pay both reduce to /user/<EMAIL_ADDRESS>/pay) and
-        # produce false-positive ReplayDetectedError. Original URL is never
-        # passed downstream to signer / MPA — only used for the local HMAC.
-        original_resource_url = details.resource_url
-
-        # ------------------------------------------------------------------
-        # 1. PII Filter (local regex/NLP or remote screening service)
-        # ------------------------------------------------------------------
-        # Per-stage redaction timing is measured only when a StageTiming sink is
-        # provided (E2 harness); when it is None no perf_counter call is made and
-        # the path is byte-identical to prior releases.
-        red_t0 = time.perf_counter_ns() if stage_timings is not None else 0
         with security_control_span(
             "pii_filter",
             amount_usd=amount_usd,
@@ -423,6 +382,66 @@ class ScreeningPipeline:
                     # pii_action == "warn": log already happened in PIIFilter
                     self._metrics.record_pii_detection(entity_types, "warn")
             set_span_attribute(pii_span, "presidio_x402.outcome", "allowed")
+            return details, clean_url, pii_entities
+
+    async def apply(
+        self,
+        details: PaymentDetails,
+        *,
+        mpa_signatures: dict[str, str] | None = None,
+        raw_offer_hash: str | None = None,
+        on_decision_ref: Callable[[Mapping[str, object]], None] | None = None,
+        stage_timings: StageTiming | None = None,
+        presented_chain: list[dict[str, object]] | None = None,
+    ) -> tuple[PaymentDetails, str]:
+        """Apply PIIFilter → PolicyEngine → ReplayGuard → MPAEngine → AuditLog.
+
+        Returns a ``(details, fingerprint)`` tuple: the (possibly modified)
+        :class:`~presidio_x402._types.PaymentDetails` with PII redacted from
+        metadata fields if ``pii_action="redact"``, plus the replay fingerprint
+        recorded for this payment so the caller can roll it back if signing
+        fails.
+
+        ``on_decision_ref``, when given, is called once with the emitted
+        decision-ref envelope (nothing is called if emission is disabled or
+        fails). It exists so a caller can correlate *this* payment's decision-ref
+        with the settlement receipt it later observes, without the pipeline
+        holding per-payment state that concurrent calls would race on — the
+        caller's closure owns the value. Like the emitter itself it must not
+        perform network I/O and must not raise; a raising callback is caught and
+        logged with the emission.
+
+        Raises on policy violation, replay, PII block, or MPA denial/timeout.
+        On MPA denial/timeout the spend + replay commit is rolled back before
+        re-raising.
+        """
+        amount_usd = amount_to_usd(details.amount, details.currency)
+
+        # Decision-ref emission is opt-in. When an emitter is configured we track
+        # each control's verdict as it runs so a single payment-decision@1 record
+        # can be signed on the success path. Otherwise this is the shared null
+        # recorder: no allocation, and no per-site guards below.
+        recorder = (
+            _DecisionRecorder() if self._decision_emitter is not None else _NULL_DECISION_RECORDER
+        )
+
+        # Preserve the original resource_url for replay-guard fingerprinting.
+        # In pii_action="redact" mode the URL gets rewritten with PII tokens
+        # masked; using the redacted URL for fingerprinting would collide
+        # distinct user-specific URLs (e.g. /user/alice@.../pay vs
+        # /user/bob@.../pay both reduce to /user/<EMAIL_ADDRESS>/pay) and
+        # produce false-positive ReplayDetectedError. Original URL is never
+        # passed downstream to signer / MPA — only used for the local HMAC.
+        original_resource_url = details.resource_url
+
+        # ------------------------------------------------------------------
+        # 1. PII Filter (local regex/NLP or remote screening service)
+        # ------------------------------------------------------------------
+        # Per-stage redaction timing is measured only when a StageTiming sink is
+        # provided (E2 harness); when it is None no perf_counter call is made and
+        # the path is byte-identical to prior releases.
+        red_t0 = time.perf_counter_ns() if stage_timings is not None else 0
+        details, clean_url, pii_entities = await self._screen_pii(details, amount_usd)
 
         if stage_timings is not None:
             stage_timings.redaction_ns = time.perf_counter_ns() - red_t0

--- a/tests/test_complexity_ceiling.py
+++ b/tests/test_complexity_ceiling.py
@@ -33,7 +33,7 @@ CEILING_DEFAULT = 15
 # Functions currently above the default, pinned at their measured value.
 # Lower these as they are refactored; do not add to the list without a reason.
 KNOWN_HIGH = {
-    "core.py::ScreeningPipeline.apply": 50,
+    "core.py::ScreeningPipeline.apply": 41,
     "decision_ref.py::verify_decision_ref": 32,
     "mica.py::applicable_obligations": 20,
     "treasury_binding.py::verify_settlement_ref": 19,

--- a/tests/test_complexity_ceiling.py
+++ b/tests/test_complexity_ceiling.py
@@ -33,7 +33,7 @@ CEILING_DEFAULT = 15
 # Functions currently above the default, pinned at their measured value.
 # Lower these as they are refactored; do not add to the list without a reason.
 KNOWN_HIGH = {
-    "core.py::ScreeningPipeline.apply": 41,
+    "core.py::ScreeningPipeline.apply": 30,
     "decision_ref.py::verify_decision_ref": 32,
     "mica.py::applicable_obligations": 20,
     "treasury_binding.py::verify_settlement_ref": 19,

--- a/tests/test_complexity_ceiling.py
+++ b/tests/test_complexity_ceiling.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 PRESIDIO Group
+"""Cyclomatic-complexity ratchet for ``src/``.
+
+``software-audit/run_audit.py`` tracks max and mean complexity, but only against a
+baseline that is refreshed by hand — so a function can grow for months between
+refreshes without anything failing. This pins the numbers in CI instead.
+
+The measurement deliberately mirrors ``software-audit/bench/bench_quality.py``
+(``CC = 1 + branch-creating nodes``, same node set) so the two never disagree. If
+that file's definition changes, change this one with it.
+
+Two directions, both failures:
+
+* **above** the pin — a regression; reduce the complexity, or raise the pin
+  consciously and say why in the commit message.
+* **below** the pin — the pin is stale; lower it so the recorded numbers stay
+  truthful. This is what makes it a ratchet rather than a high-water mark.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+
+# Anything not listed must stay at or below this.
+CEILING_DEFAULT = 15
+
+# Functions currently above the default, pinned at their measured value.
+# Lower these as they are refactored; do not add to the list without a reason.
+KNOWN_HIGH = {
+    "core.py::ScreeningPipeline.apply": 50,
+    "decision_ref.py::verify_decision_ref": 32,
+    "mica.py::applicable_obligations": 20,
+    "treasury_binding.py::verify_settlement_ref": 19,
+    "treasury_binding.py::verify_bundle": 19,
+    "capability.py::_parse_caveats": 19,
+    "mpa.py::MPAEngine.request_approval": 18,
+    "decision_ref.py::_validated_control_verdicts": 17,
+    "capability.py::verify_chain": 17,
+    "mpa.py::MPAEngine._request_single_approval": 16,
+    "mica.py::verify_ref": 16,
+}
+
+# Must match bench_quality.py's _BRANCH_TYPES exactly.
+_BRANCH_TYPES = (
+    ast.If,
+    ast.For,
+    ast.While,
+    ast.ExceptHandler,
+    ast.With,
+    ast.BoolOp,
+    ast.IfExp,
+)
+
+
+def _complexity(node: ast.AST) -> int:
+    return 1 + sum(1 for child in ast.walk(node) if isinstance(child, _BRANCH_TYPES))
+
+
+def _collect(node: ast.AST, prefix: str, out: dict[str, int]) -> None:
+    """Walk into classes and functions, keying by dotted qualified name.
+
+    Bare ``function.__name__`` collides 22 ways across ``src/`` (``__init__``,
+    ``write``, ``flush`` on sibling classes), and a collision would let one
+    function's growth hide behind another's pin.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.ClassDef):
+            _collect(child, f"{prefix}{child.name}.", out)
+        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            key = f"{prefix}{child.name}"
+            # The langchain/crewai adapters define their tool class twice — once
+            # real, once as a stub in the `except ImportError` arm — so a key can
+            # legitimately appear twice. Keep the higher value.
+            out[key] = max(out.get(key, 0), _complexity(child))
+            _collect(child, f"{key}.", out)
+        else:
+            _collect(child, prefix, out)
+
+
+def _measure() -> dict[str, int]:
+    measured: dict[str, int] = {}
+    for path in sorted(SRC.rglob("*.py")):
+        per_file: dict[str, int] = {}
+        _collect(ast.parse(path.read_text(encoding="utf-8")), "", per_file)
+        for qualname, value in per_file.items():
+            measured[f"{path.name}::{qualname}"] = value
+    return measured
+
+
+@pytest.fixture(scope="module")
+def measured() -> dict[str, int]:
+    return _measure()
+
+
+def test_no_function_exceeds_its_ceiling(measured):
+    over = [
+        (key, value, KNOWN_HIGH.get(key, CEILING_DEFAULT))
+        for key, value in sorted(measured.items())
+        if value > KNOWN_HIGH.get(key, CEILING_DEFAULT)
+    ]
+    assert not over, "cyclomatic complexity grew past its ceiling:\n" + "\n".join(
+        f"  {key}: {value} > {ceiling}" for key, value, ceiling in over
+    )
+
+
+def test_pins_are_not_stale(measured):
+    """A pin below the measured value means someone improved it without retuning."""
+    slack = [
+        (key, measured[key], pinned)
+        for key, pinned in sorted(KNOWN_HIGH.items())
+        if key in measured and measured[key] < pinned
+    ]
+    assert not slack, (
+        "complexity improved — lower these pins so the recorded numbers stay true:\n"
+        + "\n".join(f"  {key}: now {value}, pinned at {pinned}" for key, value, pinned in slack)
+    )
+
+
+def test_pinned_functions_still_exist(measured):
+    """Catches renames and deletions leaving dead entries behind."""
+    missing = sorted(key for key in KNOWN_HIGH if key not in measured)
+    assert not missing, "pinned functions no longer found (renamed or removed?):\n" + "\n".join(
+        f"  {key}" for key in missing
+    )


### PR DESCRIPTION
`ScreeningPipeline.apply()` was **CC 50 across 407 lines** — triple the next-worst function in the library, on the payment path. Three commits, each reviewable on its own.

## 1. Pin complexity in CI (`991751c`)

`run_audit.py` tracks complexity only against a hand-refreshed baseline, so a function can grow for months with nothing failing. That is how `apply()` reached 50 without ever tripping a check.

`tests/test_complexity_ceiling.py` ratchets **both directions**: above a pin is a regression, below it means the pin is stale and must be lowered. Without the second half the list becomes a high-water mark that only ratchets the wrong way — and in fact it fired twice during this PR, which is how the numbers below stayed honest.

Keys are dotted qualified names. Bare `__name__` collides 22 ways across `src/` (`__init__`, `write`, `flush` on sibling classes) and a collision would let one function's growth hide behind another's pin. 347 of 358 functions were already at or below the default of 15.

## 2. Collapse the decision-ref bookkeeping (`d143b04`) — 50 → 41

`decision_controls` was a `ControlResults | None` threaded through `apply()` and guarded by `is not None` at six recording sites: **23 references**, ~20% of the method's complexity, and the only concern in it that was not sequential. The interleaving is what made the stage ordering hard to follow.

A null object removes every guard. The branches are not destroyed — they move into `_DecisionRecorder`, where they are individually testable rather than inline in a 407-line method.

**Incidental finding:** those sites carried deferred `from .decision_ref import ...` statements, which buy nothing — `__init__` re-exports `compute_decision_ref`/`verify_decision_ref`, so the module is already imported before `apply()` runs. They were per-call, per-site import machinery for an always-loaded module. The recorder resolves the helpers once.

Cost on the default path is five no-op calls, **measured at 0.166 µs** — under 0.1% of a single policy check.

## 3. Extract the PII stage (`393c460`) — 41 → 30

100 lines and CC 11, the only stage big enough to move on its own merits. `_screen_pii` lands at **CC 12**, under the default ceiling.

It returns `clean_url` alongside `details` rather than letting the caller read `details.resource_url`. The two differ under `pii_action="warn"`, where `details` keeps the original URL but every downstream audit emit must still use the redacted one — collapsing them would have quietly put raw PII into audit records in warn mode.

## What was deliberately not done

The other five stages stay inline. **The ordering is the security property** — `CLAUDE.md` pins "policy checks run before replay fingerprinting", and today that is still verifiable by reading `apply()` top to bottom. Extracting every stage would move that ordering into a caller of opaque method names and force a context object for the shared mutable state (`details`, `stage_timings`, `fingerprint`, `original_resource_url`, `amount_usd`), relocating complexity into state management. The two changes here were the ones that buy readability without costing the linear audit read.

## Test plan

- [x] `ruff check` clean; 106 files formatted
- [x] **793 passed, 1 skipped** (skip is pre-existing: `langchain-core` not installed)
- [x] Targeted: PII filter, adversary chains, gateway, decision-ref and remote-screening suites all green — these are the conformance proof for unchanged behaviour
- [x] `run_audit.py`: **PASS, 0 regressions, 1 improvement** (max complexity 50 → 32)
- [x] Null-recorder overhead measured, not estimated
- [x] Ratchet verified to catch growth, stale pins and renames before being relied on

**After merge:** `software-audit/baseline.json` will read low on `max_cyclomatic_complexity` (50, now 32). Worth a refresh in the outer repo so the improvement becomes the new floor.
