### PR TITLE
v0.11.2 — declare tomli so TOML policy files work on Python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.2] — 2026-08-03
+
 ### Fixed
 - **`tomli` was never declared, so TOML policy files did not work on Python 3.10.**
   `requires-python` is `>=3.10`, stdlib `tomllib` is 3.11+, and
@@ -28,6 +30,23 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `load_policy_file` test that forces the pre-3.11 `tomli` branch on any
   interpreter. Both gaps above were invisible to functional tests, which pass
   whenever the package is installed for unrelated reasons.
+- **A per-function cyclomatic-complexity ratchet in CI**
+  (`tests/test_complexity_ceiling.py`). `run_audit.py` measured complexity only
+  against a hand-refreshed baseline, so a function could grow for months without
+  anything failing. It pins each function at its measured value and fails in both
+  directions — above a pin is a regression, below means the pin is stale.
+
+### Changed
+- **`ScreeningPipeline.apply()` reduced from cyclomatic complexity 50 to 30**
+  (407 → 277 lines); no behavioural change. Decision-ref bookkeeping was a
+  `ControlResults | None` threaded through the method behind six `is not None`
+  guards — 23 references, the only non-sequential concern in it, and the reason
+  the stage ordering was hard to follow. It is now a null-object recorder, at a
+  measured cost of 0.166 us per payment on the default path. The 100-line PII
+  stage moved to `_screen_pii`. The remaining stages stay inline deliberately:
+  their ordering is a security property and is meant to stay readable top to
+  bottom. The gateway, adversary-chain and remote-screening suites are the
+  conformance proof.
 
 ## [0.11.1] — 2026-08-02
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-x402"
-version = "0.11.1"
+version = "0.11.2"
 description = "Security middleware for x402 agentic payments — PII redaction, spending policy, and replay detection before blockchain commit"
 readme = "README.md"
 license = "MIT"

--- a/src/presidio_x402/core.py
+++ b/src/presidio_x402/core.py
@@ -124,15 +124,25 @@ class _NullDecisionRecorder:
 
     controls = None
 
-    def record_pii(self, entities: object, pii_action: str) -> None: ...
+    # `pass`, not `...`: these are the real implementation, not stubs. This
+    # codebase reserves `...` for Protocol bodies (see _types.py) and uses `pass`
+    # for runtime no-ops — NullAuditWriter.write() is the same null-object
+    # pattern. Flagged on PR #114 by github-code-quality as ineffectual
+    # statements, which is what a discarded Ellipsis constant literally is.
+    def record_pii(self, entities: object, pii_action: str) -> None:
+        pass
 
-    def record_policy(self, config: object) -> None: ...
+    def record_policy(self, config: object) -> None:
+        pass
 
-    def record_replay(self, fingerprint: str) -> None: ...
+    def record_replay(self, fingerprint: str) -> None:
+        pass
 
-    def record_mpa(self, threshold: int) -> None: ...
+    def record_mpa(self, threshold: int) -> None:
+        pass
 
-    def record_trusted_wallet(self) -> None: ...
+    def record_trusted_wallet(self) -> None:
+        pass
 
 
 class _DecisionRecorder:

--- a/uv.lock
+++ b/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "presidio-hardened-x402"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump for **v0.11.2**, a patch release driven by one real defect in the published artifact.

## Why this release exists

The published `0.11.1` on PyPI does not declare `tomli`. `requires-python` is `>=3.10`, stdlib `tomllib` is 3.11+, so `load_policy_file("policy.toml")` — documented as public API at `README.md:296` — raises `ImportError` on a core install at the lowest supported Python. That is live for anyone who installs the current release and uses TOML policy files on 3.10.

**Patch, not minor.** Net new packages for 3.11+ installs is **zero**: `packaging` already resolved transitively via presidio-analyzer → spaCy, and `tomli` is marker-gated to `< 3.11`. Nothing breaks; installs gain what they already effectively had.

Narrow blast radius, stated plainly: Python 3.10 **and** TOML policy files. The MCP server is unaffected (env-var config, no `load_policy_file`), though it pins `>=0.11.1,<0.12.0` and will pick this up automatically.

## Contents

- `pyproject.toml` 0.11.1 → 0.11.2, `uv.lock` regenerated
- CHANGELOG `[Unreleased]` promoted to `## [0.11.2] — 2026-08-03`, empty `[Unreleased]` retained
- **CHANGELOG entry for #114**, which was missed when that PR merged
- `...` → `pass` on `_NullDecisionRecorder` (see below)

Already on main and shipping in this release: #113 (declare `tomli` + `packaging`) and #114 (`apply()` CC 50 → 30 plus the CI complexity ratchet).

## The `...` → `pass` change

`github-code-quality` flagged the five `...` bodies on #114 as ineffectual statements and was correct. This codebase reserves `...` for Protocol bodies (`_types.py`: `PaymentSigner`, `AuditWriter`, `PaymentProtocolBinding`) and uses `pass` for runtime no-ops — `NullAuditWriter.write()` at `audit_log.py:136` is the same null-object pattern using `pass`. So it was an inconsistency, not a false positive.

It was deferred to here rather than pushed to #114 because `dismiss_stale_reviews` is on and the fix has no behavioural content — pushing it would have discarded an approval already given. The reasoning was left on the #114 thread rather than resolving it silently.

## Docs sync

Deliberately not in this PR, per how `v0.10.1` shipped: a patch gets a CHANGELOG heading and a roadmap row, but the README banner and "latest release" marker stay on the last **feature** release. `SECURITY.md` needs no edit — `0.11.x ✓ (latest release)` already covers `0.11.2`. `PRESIDIO-REQ.md` gets per-version sections for minors only. The roadmap row lives in the private repo and is handled there.

## Test plan

- [x] `ruff check` + `ruff format --check` over `src/ tests/ fuzz/` — clean, 85 files formatted
- [x] SPDX header check, using CI's exact command (`--include='*.py'`) — all covered
- [x] `uv lock --check` — no drift
- [x] **793 passed, 1 skipped** (skip pre-existing: `langchain-core` not installed)
- [x] vstantch-code style lint on `core.py` — no anti-patterns
- [x] Complexity ratchet still green (`pass` and `...` are both non-branching, so `apply()` stays at 30)

After merge: signed tag `v0.11.2` → `publish.yml` → PyPI via OIDC → verify tag signature and PyPI version.
