### PR TITLE
CI: repair Codecov upload (#72) and add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Something in the library behaves differently than documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Not for vulnerabilities.** If this is a security issue, close this form
+        and file a private advisory instead — see
+        [SECURITY.md](https://github.com/presidio-v/presidio-hardened-x402/blob/main/SECURITY.md).
+
+
+        Redact real payment metadata, wallet addresses, and personal data from
+        anything you paste here. This is a public issue tracker.
+  - type: input
+    id: version
+    attributes:
+      label: Library version
+      description: Output of `pip show presidio-hardened-x402`.
+      placeholder: "0.11.3"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12.3"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected, and what happened instead
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: >-
+        The smallest snippet that shows the behaviour. Tracebacks belong here
+        too — paste the whole thing, redacted.
+      render: python
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which stage is involved, if you know
+      options:
+        - "Not sure"
+        - "PII filter / screening"
+        - "Policy engine / budgets"
+        - "Replay guard"
+        - "MPA (multi-party authorisation)"
+        - "Capability enforcement"
+        - "Evidence / MiCA / decision refs"
+        - "Audit log / sinks"
+        - "Adapters (LangChain, gateway, bindings)"
+        - "Packaging / install"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Blank issues are disabled: every inbound issue picks one of the forms below or
+# one of the contact links. The forms exist to route reports, not to gate them —
+# if none fits, "Something else" is deliberately near-empty.
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/presidio-v/presidio-hardened-x402/security/advisories/new
+    about: >-
+      Do not open a public issue for a vulnerability. Use a private GitHub
+      Security Advisory — see SECURITY.md. Acknowledgement within 5 business days.
+  - name: Contribution guidelines
+    url: https://github.com/presidio-v/presidio-hardened-x402/blob/main/CONTRIBUTING.md
+    about: What a change needs to clear before it can be merged.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request or design proposal
+description: A capability the library should have, or a change to how it behaves.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        This is security middleware on a payment path, so proposals are weighed
+        against blast radius as much as usefulness. Saying what an attacker gains
+        or loses is more persuasive here than a feature list.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What can't you do today, or what goes wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: >-
+        What should happen instead. If it touches the payment path, say where in
+        the stage order (PII → wallet → capability → policy → replay → MPA).
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This is client-side (agent/buyer) behaviour, not a change to what a 402-emitting server does.
+        - label: I have searched existing issues, including closed ones.

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,17 @@
+name: Something else
+description: A question, or anything the other forms do not fit.
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Please do not use the tracker to advertise a service.** Posts whose
+        purpose is to promote a product, endpoint, dashboard, or paid API are
+        closed as off-topic, whatever their format. Offers of an external endpoint
+        as a test target are also declined by default: CI here is hermetic and
+        does not make live mainnet calls.
+  - type: textarea
+    id: body
+    attributes:
+      label: What's on your mind?
+    validations:
+      required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+    # Job-level so the upload step's `if:` can read it — the `secrets` context is
+    # not available in a step-level `if`, and a step's own `env:` is not visible
+    # to its own condition.
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -91,12 +96,25 @@ jobs:
           PY
       - name: Partner conformance suite (the OEM embed-kit guarantee, SEMVER.md)
         run: python -m presidio_x402.conformance
+      # Uploads had been failing on every matrix leg with "Token required - not
+      # valid tokenless upload" while the step still reported success, so Codecov
+      # received nothing from any interpreter and nothing said so. `token` fixes
+      # the upload; `fail_ci_if_error` stops it from rotting silently again. The
+      # `if` guard skips the step where no secret is exposed — forks and
+      # Dependabot PRs — so those do not fail on a credential they cannot have.
+      # Coverage *enforcement* does not depend on this step: the floors above run
+      # inline on all four interpreters and fail the job on their own.
       - name: Upload coverage
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
-          file: coverage.xml
+          # `file` (singular) is the v4 input name; v5+ ignores it silently, which
+          # is why the logged CLI invocation carried no --file at all.
+          files: coverage.xml
           flags: py${{ matrix.python-version }}
           name: py${{ matrix.python-version }}
+          token: ${{ env.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   latency-slo:
     name: Latency SLO


### PR DESCRIPTION
Closes #72.

## Coverage upload

#72 reports the upload as gated to the 3.12 matrix leg. **No such gate exists, and none is in the history** — `ci.yml` as of the filing date (`b122fdf`) already ran the step on all four legs with per-version flags. F046 was carried forward from a state this repo has not been in.

What is actually broken is worse, and silent. Every leg logs:

```
-> Token length: 0
info  -- Upload queued for processing complete
error -- Upload queued for processing failed: {"message":"Token required - not valid tokenless upload"}
##[end-action ...;outcome=success;conclusion=success]
```

No token is configured, tokenless upload is refused, and `codecov-action` does not fail the step — so Codecov has been receiving **nothing from any interpreter**, and nothing said so.

| Change | Why |
|---|---|
| `token:` | Passes `CODECOV_TOKEN`, so the upload is accepted at all. |
| `fail_ci_if_error: true` | An upload that errors fails the job instead of reporting success. This is what stops it rotting silently a second time. |
| `if: env.CODECOV_TOKEN != ''` | Skips the step where no secret is exposed — forks and Dependabot PRs — so those don't fail on a credential they can't have. Read through job-level `env` because the `secrets` context isn't available in a step-level `if`, and a step's own `env:` isn't visible to its own condition. |
| `files:` replaces `file:` | `file` is the v4 input name; v5+ ignores it silently. The logged CLI invocation carried no `--file` at all — auto-discovery had been doing the work. |

**Action required:** this needs a `CODECOV_TOKEN` repository secret. Until one is set the step skips cleanly and coverage reporting stays where it is today — nowhere.

Coverage *enforcement* is unaffected either way, which is why the severity stays low: the statement ≥ 90% / branch ≥ 80% floors run inline on all four interpreters (`ci.yml:73-91`) and fail the job on their own. Codecov is reporting, not gating.

## Issue forms

The tracker had no templates, and blank issues let promotional posts in faster than they can be closed (#108, #81, and the comment on #81 are all the same pattern).

- `bug_report.yml` — asks for the two things triage always has to ask for anyway (library + Python version), offers a stage dropdown matching the payment-path order, and repeats the CONTRIBUTING.md redaction warning at the point where someone is about to paste a payment envelope into a public box.
- `feature_request.yml` — includes a client-side scope check, since server-side 402 behaviour is out of scope for this library.
- `other.yml` — states the promotion and live-endpoint-fixture policy up front.
- `config.yml` — disables blank issues and routes vulnerability reports to the private advisory flow per SECURITY.md rather than a public issue.

Both referenced labels (`bug`, `enhancement`) exist in the repo. All five YAML files parse.

---
_Generated by [Claude Code](https://claude.ai/code/session_017uZEEkgk4SH9VUDCP4HCVd)_